### PR TITLE
Add schema resources and validation utilities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+.pytest_cache/
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# AstroEngine Schema Contracts
+
+The repository stores JSON schema definitions that mirror the
+ruleset appendix contracts referenced by the AstroEngine
+runtimes.  Operators can use the helper utilities in
+`astroengine.validation` to run doctor-style validations before
+launching a scenario.
+
+## Schema directory
+
+All schema payloads live under [`./schemas`](./schemas):
+
+- `result_schema_v1.json` — structure for full run result
+  payloads (channels, events, and provenance metadata).
+- `contact_gate_schema_v2.json` — captures the gating decisions
+  for near-threshold contacts and the evidence that justified
+  them.
+- `orbs_policy.json` — JSON resource describing the orb policy
+  profiles that inform gating and scoring.
+
+The JSON files live outside the Python modules to honor the
+append-only ruleset workflow and to keep large data assets out
+of the package namespace.
+
+## Validation helpers
+
+Two utility layers support schema validation:
+
+- `astroengine.data.schemas` exposes a registry that resolves the
+  JSON files to their on-disk locations.
+- `astroengine.validation` provides a self-contained validator that
+  understands the subset of JSON Schema used by the appendix contracts.
+  Doctor scripts can call `validate_payload("result_v1", payload)` (or any
+  other registered schema key) and receive actionable error messages without
+  installing third-party packages.
+
+### Running local validations
+
+1. Validate a payload:
+
+   ```python
+   from astroengine.validation import validate_payload
+   payload = {...}  # assembled from a run
+   validate_payload("result_v1", payload)
+   ```
+
+2. (Optional) Install `pytest` and run the automated tests (these ship with
+   representative sample payloads):
+
+   ```bash
+   pip install pytest
+   pytest
+   ```
+
+The validation helpers are intentionally lightweight so they can
+be embedded into existing “doctor” or pre-flight scripts without
+risking accidental module removals.

--- a/Version Consolidation/README_CONSOLIDATION.md
+++ b/Version Consolidation/README_CONSOLIDATION.md
@@ -76,5 +76,20 @@ Enable the GitHub Actions workflow by committing `.github/workflows/consolidate-
 - It’s OK if some older files are malformed; see the Validation report for exact errors.
 - If a module has two files with the same `version`, the latest by sort order is chosen. You can bump the `version` in the intended latest file to force selection.
 - You can re-run the script as many times as needed; it never overwrites your originals, only writes new timestamped outputs.
+
+## Schema contracts
+
+JSON schema definitions that mirror the appendix references live in the top-level
+[`schemas/`](../schemas) directory.  Use the helpers in `astroengine.validation`
+to validate run payloads or contact-gate decisions prior to publishing a new
+ruleset bundle:
+
+```bash
+pip install pytest
+pytest tests/test_result_schema.py tests/test_contact_gate_schema.py
+```
+
+The same utilities are safe to call from custom doctor scripts because they do
+not modify or relocate any ruleset modules.
  
 

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -1,0 +1,20 @@
+"""AstroEngine package bootstrap.
+
+This lightweight package exposes convenience
+helpers for loading schema definitions used by the
+validation and doctor tooling.  The actual
+rulesets live under :mod:`Version Consolidation` and
+are left untouched to preserve the append-only
+workflow preferred by operators.
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import PackageNotFoundError, version
+
+__all__ = ["__version__"]
+
+try:  # pragma: no cover - package metadata not available during tests
+    __version__ = version("astroengine")
+except PackageNotFoundError:  # pragma: no cover
+    __version__ = "0.0.0"

--- a/astroengine/data/__init__.py
+++ b/astroengine/data/__init__.py
@@ -1,0 +1,38 @@
+"""Data access helpers for AstroEngine.
+
+The project intentionally keeps large CSV and ruleset
+files outside of the Python package so that they may be
+updated independently without risking module loss.  This
+module exposes a couple of convenience accessors that
+resolve those resources relative to the repository root.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+__all__ = [
+    "PACKAGE_ROOT",
+    "ASTROENGINE_ROOT",
+    "REPO_ROOT",
+    "SCHEMA_DIR",
+    "project_root",
+    "schema_dir",
+]
+
+PACKAGE_ROOT = Path(__file__).resolve().parent
+ASTROENGINE_ROOT = PACKAGE_ROOT.parent
+REPO_ROOT = ASTROENGINE_ROOT.parent
+SCHEMA_DIR = REPO_ROOT / "schemas"
+
+
+def project_root() -> Path:
+    """Return the filesystem root of the repository."""
+
+    return REPO_ROOT
+
+
+def schema_dir() -> Path:
+    """Return the directory that stores JSON schema resources."""
+
+    return SCHEMA_DIR

--- a/astroengine/data/schemas.py
+++ b/astroengine/data/schemas.py
@@ -1,0 +1,72 @@
+"""Schema registry and loaders.
+
+The registry keeps track of JSON schema files used by
+validation/doctor tooling.  All files live in the top-level
+``schemas`` directory so operators can inspect them without
+packing everything into the Python module.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Iterable, Mapping, MutableMapping
+
+from . import SCHEMA_DIR
+
+__all__ = [
+    "SCHEMA_REGISTRY",
+    "SchemaNotFoundError",
+    "load_schema_document",
+    "list_schema_keys",
+]
+
+
+class SchemaNotFoundError(KeyError):
+    """Raised when an unknown schema key is requested."""
+
+
+SchemaMetadata = Mapping[str, str]
+
+SCHEMA_REGISTRY: Dict[str, SchemaMetadata] = {
+    "result_v1": {"filename": "result_schema_v1.json", "kind": "jsonschema"},
+    "contact_gate_v2": {
+        "filename": "contact_gate_schema_v2.json",
+        "kind": "jsonschema",
+    },
+    "orbs_policy": {"filename": "orbs_policy.json", "kind": "data"},
+}
+
+
+def _schema_path(metadata: Mapping[str, str]) -> Path:
+    filename = metadata.get("filename")
+    if not filename:
+        raise ValueError("Schema metadata missing filename field")
+    return SCHEMA_DIR / filename
+
+
+@lru_cache(maxsize=None)
+def load_schema_document(key: str) -> MutableMapping[str, object]:
+    """Return the JSON payload for the requested schema key.
+
+    Parameters
+    ----------
+    key:
+        Identifier registered in :data:`SCHEMA_REGISTRY`.
+    """
+
+    if key not in SCHEMA_REGISTRY:
+        raise SchemaNotFoundError(key)
+    metadata = SCHEMA_REGISTRY[key]
+    path = _schema_path(metadata)
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def list_schema_keys(kind: str | None = None) -> Iterable[str]:
+    """Yield the registered schema keys filtered by kind."""
+
+    for name, metadata in SCHEMA_REGISTRY.items():
+        if kind is None or metadata.get("kind") == kind:
+            yield name

--- a/astroengine/validation/__init__.py
+++ b/astroengine/validation/__init__.py
@@ -1,0 +1,17 @@
+"""Validation utilities for AstroEngine schema contracts."""
+
+from __future__ import annotations
+
+from .schema_loader import (
+    SchemaValidationError,
+    available_schema_keys,
+    get_validator,
+    validate_payload,
+)
+
+__all__ = [
+    "SchemaValidationError",
+    "available_schema_keys",
+    "get_validator",
+    "validate_payload",
+]

--- a/astroengine/validation/_simple_validator.py
+++ b/astroengine/validation/_simple_validator.py
@@ -1,0 +1,199 @@
+"""A tiny JSON-schema-like validator for offline doctor checks.
+
+The implementation supports only the keywords used by the schema
+contracts bundled with this repository.  It avoids third-party
+requirements so operators can run validations in constrained
+offline environments.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, Iterator, Tuple
+
+__all__ = ["SimpleValidationError", "SimpleValidator"]
+
+
+@dataclass
+class SimpleValidationError:
+    """Represents a validation failure."""
+
+    path: Tuple[Any, ...]
+    message: str
+
+    @property
+    def json_path(self) -> str:
+        pointer = "$"
+        for part in self.path:
+            if isinstance(part, int):
+                pointer += f"[{part}]"
+            else:
+                pointer += f".{part}"
+        return pointer
+
+
+class SimpleValidator:
+    """Very small subset of JSON Schema validation."""
+
+    def __init__(self, schema: Dict[str, Any]):
+        self._schema = schema
+        self._defs = schema.get("$defs") or schema.get("definitions") or {}
+
+    def iter_errors(self, value: Any) -> Iterator[SimpleValidationError]:
+        yield from self._iter_errors(self._schema, value, ())
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _iter_errors(
+        self, schema: Dict[str, Any], value: Any, path: Tuple[Any, ...]
+    ) -> Iterable[SimpleValidationError]:
+        if "$ref" in schema:
+            target = self._resolve_ref(schema["$ref"], path)
+            if target is None:
+                yield SimpleValidationError(path, f"Unresolvable reference {schema['$ref']}")
+            else:
+                yield from self._iter_errors(target, value, path)
+            return
+
+        schema_type = schema.get("type")
+        if schema_type is not None:
+            if isinstance(schema_type, list):
+                if not any(self._matches_type(t, value) for t in schema_type):
+                    yield SimpleValidationError(
+                        path, f"Expected type {schema_type} but got {type(value).__name__}"
+                    )
+                    return
+            else:
+                if not self._matches_type(schema_type, value):
+                    yield SimpleValidationError(
+                        path, f"Expected type {schema_type} but got {type(value).__name__}"
+                    )
+                    return
+
+        if schema_type == "object":
+            if not isinstance(value, dict):
+                yield SimpleValidationError(path, "Expected object")
+                return
+            required = schema.get("required", [])
+            for key in required:
+                if key not in value:
+                    yield SimpleValidationError(path + (key,), "Missing required property")
+            props = schema.get("properties", {})
+            additional_allowed = schema.get("additionalProperties", True)
+            if additional_allowed is False:
+                extras = [key for key in value.keys() if key not in props]
+                for extra in extras:
+                    yield SimpleValidationError(
+                        path + (extra,), "Additional properties are not allowed"
+                    )
+            for key, subschema in props.items():
+                if key in value:
+                    yield from self._iter_errors(subschema, value[key], path + (key,))
+            return
+
+        if schema_type == "array":
+            if not isinstance(value, list):
+                yield SimpleValidationError(path, "Expected array")
+                return
+            min_items = schema.get("minItems")
+            if min_items is not None and len(value) < min_items:
+                yield SimpleValidationError(
+                    path, f"Expected at least {min_items} items"
+                )
+            item_schema = schema.get("items")
+            if item_schema:
+                for idx, item in enumerate(value):
+                    yield from self._iter_errors(item_schema, item, path + (idx,))
+            return
+
+        if schema_type == "string":
+            if not isinstance(value, str):
+                yield SimpleValidationError(path, "Expected string")
+                return
+            pattern = schema.get("pattern")
+            if pattern and not re.fullmatch(pattern, value):
+                yield SimpleValidationError(path, f"Value does not match pattern {pattern}")
+            if "enum" in schema and value not in schema["enum"]:
+                yield SimpleValidationError(path, f"Value {value!r} is not one of {schema['enum']}")
+            fmt = schema.get("format")
+            if fmt == "date-time" and not _is_datetime(value):
+                yield SimpleValidationError(path, "Invalid date-time format")
+            return
+
+        if schema_type == "boolean":
+            if not isinstance(value, bool):
+                yield SimpleValidationError(path, "Expected boolean")
+            return
+
+        if schema_type == "integer":
+            if not isinstance(value, int) or isinstance(value, bool):
+                yield SimpleValidationError(path, "Expected integer")
+                return
+            minimum = schema.get("minimum")
+            maximum = schema.get("maximum")
+            if minimum is not None and value < minimum:
+                yield SimpleValidationError(path, f"Value {value} is less than minimum {minimum}")
+            if maximum is not None and value > maximum:
+                yield SimpleValidationError(path, f"Value {value} exceeds maximum {maximum}")
+            return
+
+        if schema_type == "number":
+            if not _is_number(value):
+                yield SimpleValidationError(path, "Expected number")
+                return
+            minimum = schema.get("minimum")
+            maximum = schema.get("maximum")
+            if minimum is not None and value < minimum:
+                yield SimpleValidationError(path, f"Value {value} is less than minimum {minimum}")
+            if maximum is not None and value > maximum:
+                yield SimpleValidationError(path, f"Value {value} exceeds maximum {maximum}")
+            return
+
+        if "enum" in schema:
+            if value not in schema["enum"]:
+                yield SimpleValidationError(path, f"Value {value!r} is not one of {schema['enum']}")
+
+    # ------------------------------------------------------------------
+    # Utility helpers
+    # ------------------------------------------------------------------
+    def _resolve_ref(self, ref: str, path: Tuple[Any, ...]) -> Dict[str, Any] | None:
+        if ref.startswith("#/$defs/"):
+            key = ref.split("/")[-1]
+            return self._defs.get(key)
+        if ref.startswith("#/definitions/"):
+            key = ref.split("/")[-1]
+            return self._defs.get(key)
+        return None
+
+    @staticmethod
+    def _matches_type(expected: str, value: Any) -> bool:
+        if expected == "object":
+            return isinstance(value, dict)
+        if expected == "array":
+            return isinstance(value, list)
+        if expected == "string":
+            return isinstance(value, str)
+        if expected == "boolean":
+            return isinstance(value, bool)
+        if expected == "integer":
+            return isinstance(value, int) and not isinstance(value, bool)
+        if expected == "number":
+            return _is_number(value)
+        return True
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _is_datetime(value: str) -> bool:
+    try:
+        if value.endswith("Z"):
+            value = value[:-1] + "+00:00"
+        _dt.datetime.fromisoformat(value)
+        return True
+    except Exception:
+        return False

--- a/astroengine/validation/schema_loader.py
+++ b/astroengine/validation/schema_loader.py
@@ -1,0 +1,70 @@
+"""Schema loading and validation utilities.
+
+The validation helpers keep the I/O responsibilities out of
+the core modules so that the underlying astrology engines can
+be swapped without touching the schema contracts.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Iterable, List
+
+from astroengine.data.schemas import (
+    SCHEMA_REGISTRY,
+    SchemaNotFoundError,
+    list_schema_keys,
+    load_schema_document,
+)
+from ._simple_validator import SimpleValidator
+
+__all__ = [
+    "SchemaValidationError",
+    "available_schema_keys",
+    "get_validator",
+    "validate_payload",
+]
+
+
+class SchemaValidationError(RuntimeError):
+    """Raised when a payload fails schema validation."""
+
+    def __init__(self, errors: Iterable[str]):
+        self.errors: List[str] = list(errors)
+        super().__init__("; ".join(self.errors))
+
+
+@lru_cache(maxsize=None)
+def get_validator(schema_key: str) -> SimpleValidator:
+    """Return a cached validator instance for ``schema_key``."""
+
+    if schema_key not in SCHEMA_REGISTRY:
+        raise SchemaNotFoundError(schema_key)
+    schema = load_schema_document(schema_key)
+    if not isinstance(schema, dict):
+        raise TypeError(f"Schema '{schema_key}' is not a JSON object")
+    return SimpleValidator(schema)
+
+
+def available_schema_keys(kind: str | None = None) -> List[str]:
+    """List schema keys known to the registry."""
+
+    return sorted(list_schema_keys(kind))
+
+
+def validate_payload(schema_key: str, payload: object) -> None:
+    """Validate ``payload`` against ``schema_key``.
+
+    Raises
+    ------
+    SchemaValidationError
+        If validation fails.  The exception message contains a
+        semicolon separated list of human-readable errors.
+    """
+
+    validator = get_validator(schema_key)
+    failures = []
+    for error in validator.iter_errors(payload):
+        failures.append(f"{error.json_path}: {error.message}")
+    if failures:
+        raise SchemaValidationError(failures)

--- a/schemas/contact_gate_schema_v2.json
+++ b/schemas/contact_gate_schema_v2.json
@@ -1,0 +1,242 @@
+{
+  "$id": "https://astro.engine/schemas/contact_gate_schema_v2.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AstroEngine Contact Gate Decisions",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run",
+    "gates"
+  ],
+  "properties": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^astroengine\\.contact_gate$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^v?2\\.0\\.[0-9]+$"
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "generated_at"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "ruleset_version": {
+          "type": "string"
+        }
+      }
+    },
+    "gates": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "channel",
+          "decision",
+          "score",
+          "threshold",
+          "window",
+          "subjects",
+          "evidence",
+          "audit"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^GATE-[A-Z0-9]{4,}$"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "subchannel": {
+            "type": "string"
+          },
+          "decision": {
+            "type": "string",
+            "enum": [
+              "include",
+              "exclude",
+              "defer"
+            ]
+          },
+          "score": {
+            "type": "number",
+            "minimum": -100,
+            "maximum": 100
+          },
+          "threshold": {
+            "type": "number",
+            "minimum": -100,
+            "maximum": 100
+          },
+          "delta": {
+            "type": "number"
+          },
+          "window": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "start",
+              "end",
+              "timezone"
+            ],
+            "properties": {
+              "start": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "end": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "timezone": {
+                "type": "string"
+              },
+              "label": {
+                "type": "string"
+              }
+            }
+          },
+          "subjects": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "token",
+                "role"
+              ],
+              "properties": {
+                "token": {
+                  "type": "string"
+                },
+                "role": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "summary",
+              "events"
+            ],
+            "properties": {
+              "summary": {
+                "type": "string"
+              },
+              "events": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "$ref": "#/$defs/eventReference"
+                }
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "notes": {
+                "type": "string"
+              }
+            }
+          },
+          "audit": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "decided_by",
+              "decided_at",
+              "source"
+            ],
+            "properties": {
+              "decided_by": {
+                "type": "string"
+              },
+              "decided_at": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "source": {
+                "type": "string"
+              },
+              "manual_override": {
+                "type": "boolean"
+              }
+            }
+          },
+          "recommendation": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "$defs": {
+    "eventReference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "event_id",
+        "orb",
+        "valence"
+      ],
+      "properties": {
+        "event_id": {
+          "type": "string"
+        },
+        "orb": {
+          "type": "number"
+        },
+        "valence": {
+          "type": "number",
+          "minimum": -1,
+          "maximum": 1
+        },
+        "strength": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "near_threshold": {
+          "type": "boolean"
+        },
+        "note": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/schemas/orbs_policy.json
+++ b/schemas/orbs_policy.json
@@ -1,0 +1,89 @@
+{
+  "schema": {
+    "id": "astroengine.orbs.policy",
+    "version": "2025-09-03",
+    "notes": "Derived from ruleset appendix major/minor aspect tolerances."
+  },
+  "profiles": {
+    "standard": {
+      "description": "Default profile tuned for AP-SUPER runs.",
+      "multipliers": {
+        "luminaries": 1.2,
+        "outer": 0.8,
+        "asteroids": 0.6
+      }
+    },
+    "tight": {
+      "description": "Stricter gating used for high-precision diagnostics.",
+      "multipliers": {
+        "luminaries": 1.0,
+        "outer": 0.7,
+        "asteroids": 0.5
+      }
+    },
+    "wide": {
+      "description": "Relaxed profile for exploratory scans and storyline assembly.",
+      "multipliers": {
+        "luminaries": 1.35,
+        "outer": 0.9,
+        "asteroids": 0.75
+      }
+    }
+  },
+  "aspects": {
+    "conjunction": {
+      "category": "major",
+      "base_orb": 8.0,
+      "profile_overrides": {
+        "tight": 6.5,
+        "wide": 9.0
+      },
+      "notes": "Luminaries use multipliers; composites clamp at +/- 9\u00b0."
+    },
+    "opposition": {
+      "category": "major",
+      "base_orb": 7.0,
+      "profile_overrides": {
+        "tight": 6.0,
+        "wide": 8.0
+      },
+      "notes": "Outer planets rarely exceed 6\u00b0 after multipliers."
+    },
+    "square": {
+      "category": "major",
+      "base_orb": 6.0,
+      "profile_overrides": {
+        "tight": 5.0,
+        "wide": 7.0
+      },
+      "notes": "Used for tension/pressure motifs in relationship channel."
+    },
+    "trine": {
+      "category": "major",
+      "base_orb": 6.0,
+      "profile_overrides": {
+        "tight": 4.5,
+        "wide": 7.0
+      },
+      "notes": "Friendly flow aspects; minors borrow from this window."
+    },
+    "sextile": {
+      "category": "minor",
+      "base_orb": 4.0,
+      "profile_overrides": {
+        "tight": 3.0,
+        "wide": 5.0
+      },
+      "notes": "Used for activation prompts and guidance."
+    },
+    "quincunx": {
+      "category": "minor",
+      "base_orb": 3.0,
+      "profile_overrides": {
+        "tight": 2.5,
+        "wide": 4.0
+      },
+      "notes": "Health and adjustments channel emphasises these hits."
+    }
+  }
+}

--- a/schemas/result_schema_v1.json
+++ b/schemas/result_schema_v1.json
@@ -1,0 +1,392 @@
+{
+  "$id": "https://astro.engine/schemas/result_schema_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AstroEngine Result Payload",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "run",
+    "window",
+    "subjects",
+    "channels",
+    "events"
+  ],
+  "properties": {
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^astroengine\\.result$"
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^v?1\\.0\\.[0-9]+$"
+        }
+      }
+    },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "profile",
+        "generated_at",
+        "engine_version",
+        "ruleset_version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^RUN-[A-Z0-9]{6,}$"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "generated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "engine_version": {
+          "type": "string"
+        },
+        "ruleset_version": {
+          "type": "string"
+        },
+        "seed": {
+          "type": "integer"
+        },
+        "timezone": {
+          "type": "string"
+        }
+      }
+    },
+    "window": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "start",
+        "end",
+        "timezone"
+      ],
+      "properties": {
+        "start": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "timezone": {
+          "type": "string"
+        },
+        "label": {
+          "type": "string"
+        }
+      }
+    },
+    "subjects": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "token",
+          "name",
+          "role"
+        ],
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "consent": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "channels": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "name",
+          "score",
+          "state"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number",
+            "minimum": -100,
+            "maximum": 100
+          },
+          "strength": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "quiet",
+              "rising",
+              "steady",
+              "surging",
+              "peaking"
+            ]
+          },
+          "subchannels": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "id",
+                "name",
+                "score",
+                "state"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": "number",
+                  "minimum": -100,
+                  "maximum": 100
+                },
+                "state": {
+                  "type": "string",
+                  "enum": [
+                    "quiet",
+                    "rising",
+                    "steady",
+                    "surging",
+                    "peaking"
+                  ]
+                },
+                "peaks": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": [
+                      "window_id",
+                      "score"
+                    ],
+                    "properties": {
+                      "window_id": {
+                        "type": "string"
+                      },
+                      "score": {
+                        "type": "number",
+                        "minimum": -100,
+                        "maximum": 100
+                      },
+                      "timestamp": {
+                        "type": "string",
+                        "format": "date-time"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "peaks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "window_id",
+                "score"
+              ],
+              "properties": {
+                "window_id": {
+                  "type": "string"
+                },
+                "score": {
+                  "type": "number",
+                  "minimum": -100,
+                  "maximum": 100
+                },
+                "timestamp": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "tier": {
+                  "type": "string",
+                  "enum": [
+                    "major",
+                    "notable",
+                    "supporting"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "datetime",
+          "layer",
+          "subject",
+          "body",
+          "aspect",
+          "target",
+          "channel",
+          "orb",
+          "valence",
+          "strength"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^EVT-[A-Z0-9]{4,}$"
+          },
+          "datetime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "window_id": {
+            "type": "string"
+          },
+          "window_label": {
+            "type": "string"
+          },
+          "layer": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "aspect": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "orb": {
+            "type": "number"
+          },
+          "valence": {
+            "type": "number",
+            "minimum": -1,
+            "maximum": 1
+          },
+          "strength": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "confidence": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "time_bin": {
+            "type": "string"
+          },
+          "day_tilt": {
+            "type": "string"
+          },
+          "window_type": {
+            "type": "string"
+          },
+          "strength_bin": {
+            "type": "string"
+          },
+          "impact_axes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "intent_hint": {
+            "type": "string"
+          },
+          "channel_state": {
+            "type": "string"
+          },
+          "is_major_event": {
+            "type": "boolean"
+          },
+          "impact_flags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "is_angular": {
+            "type": "boolean"
+          },
+          "is_sensitive_degree": {
+            "type": "boolean"
+          },
+          "is_declination_hit": {
+            "type": "boolean"
+          },
+          "contributes_to_peak": {
+            "type": "boolean"
+          },
+          "is_near_threshold": {
+            "type": "boolean"
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root is importable so ``astroengine`` can be resolved
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))

--- a/tests/test_contact_gate_schema.py
+++ b/tests/test_contact_gate_schema.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from astroengine.validation import SchemaValidationError, validate_payload
+
+
+def _valid_gate_payload() -> dict:
+    return {
+        "schema": {"id": "astroengine.contact_gate", "version": "v2.0.0"},
+        "run": {
+            "id": "RUN-XY34ZT",
+            "generated_at": "2025-09-03T12:05:00Z",
+            "profile": "AP-SUPER",
+            "ruleset_version": "v2.18.13",
+        },
+        "gates": [
+            {
+                "id": "GATE-001A",
+                "channel": "relationship",
+                "subchannel": "relationship_bonding",
+                "decision": "include",
+                "score": 42.0,
+                "threshold": 35.0,
+                "delta": 7.0,
+                "window": {
+                    "start": "2025-09-03T16:00:00Z",
+                    "end": "2025-09-03T20:00:00Z",
+                    "timezone": "America/New_York",
+                    "label": "Transit Peak",
+                },
+                "subjects": [
+                    {"token": "USER_PRIMARY", "role": "primary"},
+                    {"token": "USER_SECONDARY", "role": "secondary"},
+                ],
+                "evidence": {
+                    "summary": "Venus trine Mars near perfected peak",
+                    "events": [
+                        {
+                            "event_id": "EVT-0001",
+                            "orb": 1.2,
+                            "valence": 0.85,
+                            "strength": 72.5,
+                            "near_threshold": False,
+                        }
+                    ],
+                    "confidence": 0.93,
+                    "notes": "Matches gating heuristics",
+                },
+                "audit": {
+                    "decided_by": "astroengine.auto_gate",
+                    "decided_at": "2025-09-03T12:05:01Z",
+                    "source": "scoring.contact_gate",
+                    "manual_override": False,
+                },
+                "recommendation": "Highlight in daily narrative",
+            }
+        ],
+    }
+
+
+def test_contact_gate_schema_accepts_valid_payload():
+    payload = _valid_gate_payload()
+    validate_payload("contact_gate_v2", payload)
+
+
+def test_contact_gate_schema_rejects_bad_decision():
+    payload = _valid_gate_payload()
+    broken = deepcopy(payload)
+    broken["gates"][0]["decision"] = "maybe"
+    with pytest.raises(SchemaValidationError):
+        validate_payload("contact_gate_v2", broken)

--- a/tests/test_orbs_policy.py
+++ b/tests/test_orbs_policy.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from astroengine.data.schemas import list_schema_keys, load_schema_document
+from astroengine.validation import available_schema_keys
+
+
+def test_orbs_policy_contains_expected_entries():
+    data = load_schema_document("orbs_policy")
+    assert data["schema"]["id"] == "astroengine.orbs.policy"
+    assert data["profiles"]["standard"]["multipliers"]["luminaries"] == 1.2
+    assert data["aspects"]["conjunction"]["base_orb"] == 8.0
+    assert set(data["aspects"].keys()) == {
+        "conjunction",
+        "opposition",
+        "square",
+        "trine",
+        "sextile",
+        "quincunx",
+    }
+
+
+def test_available_schema_keys_filters_jsonschemas():
+    json_schemas = available_schema_keys("jsonschema")
+    assert "result_v1" in json_schemas
+    assert "contact_gate_v2" in json_schemas
+    assert "orbs_policy" not in json_schemas
+
+    all_keys = set(list_schema_keys())
+    assert {"result_v1", "contact_gate_v2", "orbs_policy"}.issubset(all_keys)

--- a/tests/test_result_schema.py
+++ b/tests/test_result_schema.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from astroengine.validation import SchemaValidationError, validate_payload
+
+
+def _valid_result_payload() -> dict:
+    return {
+        "schema": {"id": "astroengine.result", "version": "v1.0.0"},
+        "run": {
+            "id": "RUN-AB12CD",
+            "profile": "AP-SUPER",
+            "generated_at": "2025-09-03T12:00:00Z",
+            "engine_version": "2025.9",
+            "ruleset_version": "v2.18.13",
+            "seed": 42,
+            "timezone": "America/New_York",
+        },
+        "window": {
+            "start": "2025-09-03T00:00:00Z",
+            "end": "2025-09-04T00:00:00Z",
+            "timezone": "America/New_York",
+            "label": "Primary Window",
+        },
+        "subjects": [
+            {
+                "token": "USER_PRIMARY",
+                "name": "Chris",
+                "role": "primary",
+                "id": "IND-001",
+                "consent": True,
+            }
+        ],
+        "channels": [
+            {
+                "id": "relationship",
+                "name": "Relationship",
+                "score": 42.5,
+                "strength": 78.2,
+                "state": "surging",
+                "subchannels": [
+                    {
+                        "id": "relationship_bonding",
+                        "name": "Bonding",
+                        "score": 44.8,
+                        "state": "peaking",
+                        "peaks": [
+                            {
+                                "window_id": "2025-09-03",
+                                "score": 45.5,
+                                "timestamp": "2025-09-03T18:00:00Z",
+                            }
+                        ],
+                    }
+                ],
+                "peaks": [
+                    {
+                        "window_id": "2025-09-03",
+                        "score": 43.0,
+                        "timestamp": "2025-09-03T18:00:00Z",
+                        "tier": "major",
+                    }
+                ],
+            }
+        ],
+        "events": [
+            {
+                "id": "EVT-0001",
+                "datetime": "2025-09-03T17:45:00Z",
+                "window_id": "2025-09-03",
+                "window_label": "2025-09-03",
+                "layer": "transits",
+                "subject": "USER_PRIMARY",
+                "body": "Venus",
+                "aspect": "trine",
+                "target": "Mars",
+                "channel": "relationship",
+                "orb": 1.2,
+                "valence": 0.85,
+                "strength": 72.5,
+                "confidence": 0.92,
+                "time_bin": "afternoon",
+                "day_tilt": "rising",
+                "window_type": "peak",
+                "strength_bin": "high",
+                "impact_axes": ["relationship", "creativity"],
+                "intent_hint": "connect",
+                "channel_state": "surging",
+                "is_major_event": True,
+                "impact_flags": ["primary"],
+                "is_angular": False,
+                "is_sensitive_degree": True,
+                "is_declination_hit": False,
+                "contributes_to_peak": True,
+                "is_near_threshold": False,
+                "tags": ["Venus", "Mars", "trine"],
+                "notes": "Favorable connection",
+            }
+        ],
+    }
+
+
+def test_result_schema_accepts_valid_payload():
+    payload = _valid_result_payload()
+    validate_payload("result_v1", payload)
+
+
+def test_result_schema_rejects_invalid_event_payload():
+    payload = _valid_result_payload()
+    broken = deepcopy(payload)
+    broken["events"][0].pop("channel")
+    with pytest.raises(SchemaValidationError):
+        validate_payload("result_v1", broken)


### PR DESCRIPTION
## Summary
- add JSON schema resources for result payloads, contact gate decisions, and orb policy data that follow the appendix contracts
- add registry and validation helpers under `astroengine` so tooling can locate schemas and run lightweight checks
- add unit tests and documentation describing how to load schemas and run the validator

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2ffc2fd48324bc9e63b37343f621