### PR TITLE
Add VCA domain-aware taxonomy and profile support

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -1,18 +1,64 @@
-"""AstroEngine package bootstrap.
-
-This lightweight package exposes convenience
-helpers for loading schema definitions used by the
-validation and doctor tooling.  The actual
-rulesets live under :mod:`Version Consolidation` and
-are left untouched to preserve the append-only
-workflow preferred by operators.
-"""
+"""AstroEngine package bootstrap and public surface exports."""
 
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
+from .api import TransitEvent, TransitScanConfig
+from .catalogs import (
+    VCA_CENTAURS,
+    VCA_CORE_BODIES,
+    VCA_EXT_ASTEROIDS,
+    VCA_SENSITIVE_POINTS,
+    VCA_TNOS,
+)
+from .config import load_profile_json, profile_into_ctx
+from .domains import (
+    DOMAINS,
+    ELEMENTS,
+    ZODIAC_ELEMENT_MAP,
+    DomainResolution,
+    DomainResolver,
+    natal_domain_factor,
+)
+from .engine import (
+    apply_profile_if_any,
+    get_active_aspect_angles,
+    get_feature_flag,
+    maybe_attach_domain_fields,
+)
+from .profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES
+from .rulesets import VCA_RULESET, get_vca_aspect, vca_orb_for
+from .scoring import compute_domain_factor
+
+__all__ = [
+    "__version__",
+    "TransitEvent",
+    "TransitScanConfig",
+    "DomainResolver",
+    "DomainResolution",
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "natal_domain_factor",
+    "DomainScoringProfile",
+    "VCA_DOMAIN_PROFILES",
+    "compute_domain_factor",
+    "load_profile_json",
+    "profile_into_ctx",
+    "apply_profile_if_any",
+    "get_active_aspect_angles",
+    "get_feature_flag",
+    "maybe_attach_domain_fields",
+    "VCA_RULESET",
+    "get_vca_aspect",
+    "vca_orb_for",
+    "VCA_CORE_BODIES",
+    "VCA_EXT_ASTEROIDS",
+    "VCA_CENTAURS",
+    "VCA_TNOS",
+    "VCA_SENSITIVE_POINTS",
+]
 
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")

--- a/astroengine/api.py
+++ b/astroengine/api.py
@@ -1,0 +1,29 @@
+"""Public API dataclasses used by AstroEngine helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class TransitEvent:
+    """Container for a resolved transit event."""
+
+    elements: List[str] = field(default_factory=list)
+    domains: Dict[str, float] = field(default_factory=dict)
+    domain_profile: Optional[str] = None
+    severity: Optional[float] = None
+
+
+@dataclass
+class TransitScanConfig:
+    """Configuration options for a transit scan."""
+
+    ruleset_id: str = "vca_core"
+    enable_declination: bool = True
+    enable_mirrors: bool = True
+    enable_harmonics: bool = True
+
+
+__all__ = ["TransitEvent", "TransitScanConfig"]

--- a/astroengine/catalogs.py
+++ b/astroengine/catalogs.py
@@ -1,0 +1,85 @@
+"""Catalog definitions for VCA Outline bodies and points."""
+
+from __future__ import annotations
+
+VCA_CORE_BODIES = [
+    "sun",
+    "moon",
+    "mercury",
+    "venus",
+    "mars",
+    "jupiter",
+    "saturn",
+    "uranus",
+    "neptune",
+    "pluto",
+    "north_node",
+    "south_node",
+    "chiron",
+]
+
+VCA_EXT_ASTEROIDS = [
+    "ceres",
+    "pallas",
+    "juno",
+    "vesta",
+    "hygiea",
+    "eros",
+    "psyche",
+    "isis",
+    "lilith1181",
+    "sappho",
+    "panacea",
+    "astraea",
+    "hekate",
+    "fortuna",
+    "nemesis",
+]
+
+VCA_CENTAURS = [
+    "pholus",
+    "nessus",
+    "chariklo",
+    "okyrhoe",
+    "asbolus",
+    "thereus",
+    "hylonome",
+    "cyllarus",
+]
+
+VCA_TNOS = [
+    "eris",
+    "haumea",
+    "makemake",
+    "sedna",
+    "orcus",
+    "quaoar",
+    "varuna",
+    "ixion",
+    "gonggong",
+]
+
+VCA_SENSITIVE_POINTS = [
+    "asc",
+    "dsc",
+    "mc",
+    "ic",
+    "vertex",
+    "antivertex",
+    "east_point",
+    "polar_asc",
+    "lot_fortune",
+    "lot_spirit",
+    "black_moon_lilith",
+    "priapus",
+    "prenatal_eclipse",
+]
+
+
+__all__ = [
+    "VCA_CORE_BODIES",
+    "VCA_EXT_ASTEROIDS",
+    "VCA_CENTAURS",
+    "VCA_TNOS",
+    "VCA_SENSITIVE_POINTS",
+]

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1,0 +1,83 @@
+"""Command line interface helpers for AstroEngine."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+from .api import TransitEvent, TransitScanConfig
+from .config import load_profile_json
+from .engine import apply_profile_if_any, maybe_attach_domain_fields
+
+
+def _add_domain_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--emit-domains", action="store_true", help="Include elements/domains on each TransitEvent.")
+    p.add_argument("--domain-profile", default="vca_neutral", help="Domain profile key (see VCA_DOMAIN_PROFILES).")
+    p.add_argument(
+        "--domain-scorer",
+        default="weighted",
+        choices=["weighted", "top", "softmax"],
+        help="Method to transform domains into a severity multiplier.",
+    )
+    p.add_argument(
+        "--domain-temperature",
+        type=float,
+        default=8.0,
+        help="Softmax temperature (only used when --domain-scorer=softmax).",
+    )
+
+
+def _add_profile_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--profile-file", help="Path to profile JSON (e.g., profiles/vca_outline.json)")
+
+
+def _add_ruleset_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--ruleset", default="vca_core", help="Aspect ruleset id (default: vca_core)")
+    p.add_argument("--no-declination", action="store_true", help="Disable declination aspects (parallel/contra-parallel)")
+    p.add_argument("--no-mirrors", action="store_true", help="Disable antiscia/contra-antiscia")
+    p.add_argument("--no-harmonics", action="store_true", help="Disable harmonic-derived aspects")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="astroengine", description="AstroEngine command line interface")
+    _add_profile_args(parser)
+    _add_domain_args(parser)
+    _add_ruleset_args(parser)
+    return parser
+
+
+def _initial_context_from_args(args: argparse.Namespace) -> Dict[str, Any]:
+    ctx: Dict[str, Any] = {
+        "emit_domains": args.emit_domains,
+    }
+    if args.emit_domains:
+        ctx["domain_profile"] = args.domain_profile
+        ctx["domain_scorer"] = args.domain_scorer
+        ctx["domain_temperature"] = args.domain_temperature
+    return ctx
+
+
+def main(argv: Optional[Sequence[str]] = None) -> Tuple[TransitScanConfig, Dict[str, Any]]:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    scan_config = TransitScanConfig(
+        ruleset_id=args.ruleset,
+        enable_declination=not args.no_declination,
+        enable_mirrors=not args.no_mirrors,
+        enable_harmonics=not args.no_harmonics,
+    )
+
+    ctx = _initial_context_from_args(args)
+
+    profile = load_profile_json(args.profile_file) if args.profile_file else None
+    ctx = apply_profile_if_any(ctx, profile)
+
+    sample_event = maybe_attach_domain_fields(TransitEvent(), ctx)
+    _ = sample_event  # placeholder to show integration; real engine would persist or stream events
+
+    return scan_config, ctx
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    main()

--- a/astroengine/config.py
+++ b/astroengine/config.py
@@ -1,0 +1,40 @@
+"""Profile loading helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+
+def load_profile_json(path: str | Path) -> Dict[str, Any]:
+    """Load a profile JSON document and return a dictionary."""
+
+    profile_path = Path(path)
+    data = json.loads(profile_path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict) or "id" not in data:
+        raise ValueError("Invalid profile json: must be an object with 'id'")
+    return data
+
+
+def profile_into_ctx(ctx: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
+    """Merge profile keys into an engine context dictionary."""
+
+    ctx = dict(ctx or {})
+    ctx.setdefault("profile_id", profile.get("id"))
+
+    aspects = profile.get("aspects", {})
+    orbs = profile.get("orbs", {})
+    flags = profile.get("flags", {})
+    domain = profile.get("domain", {})
+
+    ctx["aspects"] = aspects
+    ctx["orbs"] = orbs
+    ctx["flags"] = flags
+    ctx["domain_profile"] = domain.get("profile_key", ctx.get("domain_profile", "vca_neutral"))
+    ctx["domain_scorer"] = domain.get("scorer", ctx.get("domain_scorer", "weighted"))
+    ctx["domain_temperature"] = domain.get("temperature", ctx.get("domain_temperature", 8.0))
+    return ctx
+
+
+__all__ = ["load_profile_json", "profile_into_ctx"]

--- a/astroengine/data/schemas.py
+++ b/astroengine/data/schemas.py
@@ -31,11 +31,19 @@ SchemaMetadata = Mapping[str, str]
 
 SCHEMA_REGISTRY: Dict[str, SchemaMetadata] = {
     "result_v1": {"filename": "result_schema_v1.json", "kind": "jsonschema"},
+    "result_v1_with_domains": {
+        "filename": "result_schema_v1_with_domains.json",
+        "kind": "jsonschema",
+    },
     "contact_gate_v2": {
         "filename": "contact_gate_schema_v2.json",
         "kind": "jsonschema",
     },
     "orbs_policy": {"filename": "orbs_policy.json", "kind": "data"},
+    "natal_input_v1_ext": {
+        "filename": "natal_input_v1_ext.json",
+        "kind": "jsonschema",
+    },
 }
 
 

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -1,0 +1,157 @@
+"""Domain and element taxonomy utilities for AstroEngine.
+
+This module centralises the mapping logic for Mind/Body/Spirit
+weighting along with the classical element association for zodiac
+signs.  The implementation intentionally keeps the defaults easily
+inspectable so that downstream profile files can override them without
+risking silent regressions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Tuple
+
+# Canonical element labels (uppercase; stable public API)
+ELEMENTS: Tuple[str, str, str, str] = ("FIRE", "EARTH", "AIR", "WATER")
+DOMAINS: Tuple[str, str, str] = ("MIND", "BODY", "SPIRIT")
+
+# Zodiac (0=Aries ... 11=Pisces) → Element
+ZODIAC_ELEMENT_MAP: Tuple[str, ...] = (
+    "FIRE",   # 0 Aries
+    "EARTH",  # 1 Taurus
+    "AIR",    # 2 Gemini
+    "WATER",  # 3 Cancer
+    "FIRE",   # 4 Leo
+    "EARTH",  # 5 Virgo
+    "AIR",    # 6 Libra
+    "WATER",  # 7 Scorpio
+    "FIRE",   # 8 Sagittarius
+    "EARTH",  # 9 Capricorn
+    "AIR",    # 10 Aquarius
+    "WATER",  # 11 Pisces
+)
+
+# Planet → default Domain weights (VCA-ish sensible defaults; overridable by profiles)
+# Keys use engine’s canonical planet ids: sun, moon, mercury, venus, mars, jupiter, saturn, uranus, neptune, pluto, north_node, south_node, chiron
+DEFAULT_PLANET_DOMAIN_WEIGHTS: Mapping[str, Mapping[str, float]] = {
+    "sun":     {"SPIRIT": 1.0, "MIND": 0.25, "BODY": 0.25},
+    "moon":    {"BODY": 1.0,   "MIND": 0.25},
+    "mercury": {"MIND": 1.0},
+    "venus":   {"BODY": 0.6,   "SPIRIT": 0.4},
+    "mars":    {"BODY": 1.0,   "SPIRIT": 0.3},
+    "jupiter": {"SPIRIT": 1.0, "MIND": 0.4},
+    "saturn":  {"BODY": 0.7,   "MIND": 0.5},
+    "uranus":  {"MIND": 0.9,   "SPIRIT": 0.4},
+    "neptune": {"SPIRIT": 1.0},
+    "pluto":   {"SPIRIT": 0.7, "BODY": 0.7},
+    "north_node": {"SPIRIT": 0.8, "MIND": 0.4},
+    "south_node": {"SPIRIT": 0.8, "BODY": 0.4},
+    "chiron":  {"BODY": 0.8,   "SPIRIT": 0.5},
+}
+
+# House index (1..12) → Domain weights (kept light; debated houses marked TODO for profiles)
+DEFAULT_HOUSE_DOMAIN_WEIGHTS: Mapping[int, Mapping[str, float]] = {
+    1: {"BODY": 1.0},             # Vitality, soma
+    2: {"BODY": 0.7, "MIND": 0.3},
+    3: {"MIND": 1.0},             # Communication
+    4: {"BODY": 0.6, "SPIRIT": 0.4},
+    5: {"SPIRIT": 0.9, "BODY": 0.3},
+    6: {"BODY": 1.0},             # Health/routines
+    7: {"MIND": 0.6, "SPIRIT": 0.4},
+    8: {"SPIRIT": 0.9, "BODY": 0.4},
+    9: {"SPIRIT": 0.9, "MIND": 0.6},
+    10: {"BODY": 0.6, "SPIRIT": 0.4},
+    11: {"MIND": 0.7, "SPIRIT": 0.5},
+    12: {"SPIRIT": 1.0},
+}
+
+
+@dataclass(frozen=True)
+class DomainResolution:
+    elements: List[str]            # e.g., ["FIRE"] (sign-derived)
+    domains: Dict[str, float]      # merged weights {"MIND": w, ...}
+
+
+class DomainResolver:
+    """Resolve elements and Mind/Body/Spirit domain weights for a transit contact."""
+
+    def __init__(
+        self,
+        planet_weights: Optional[Mapping[str, Mapping[str, float]]] = None,
+        house_weights: Optional[Mapping[int, Mapping[str, float]]] = None,
+    ) -> None:
+        self._planet = planet_weights or DEFAULT_PLANET_DOMAIN_WEIGHTS
+        self._house = house_weights or DEFAULT_HOUSE_DOMAIN_WEIGHTS
+
+    def resolve(
+        self,
+        sign_index: int,
+        planet_key: str,
+        house_index: Optional[int] = None,
+        overrides: Optional[Mapping[str, Mapping]] = None,
+    ) -> DomainResolution:
+        if not (0 <= sign_index <= 11):
+            raise ValueError("sign_index must be 0..11")
+        elements = [ZODIAC_ELEMENT_MAP[sign_index]]
+
+        # Merge weights with shallow override logic
+        p = dict(self._planet.get(planet_key, {}))
+        h = dict(self._house.get(house_index, {})) if house_index else {}
+        if overrides:
+            planet_over = overrides.get("planet_weights") if "planet_weights" in overrides else None
+            if planet_over and planet_key in planet_over:
+                p = dict(planet_over[planet_key])
+            house_over = overrides.get("house_weights") if "house_weights" in overrides else None
+            if house_over and house_index in house_over:
+                h = dict(house_over[house_index])
+
+        merged: Dict[str, float] = {}
+        for src in (p, h):
+            for key, value in src.items():
+                merged[key] = merged.get(key, 0.0) + float(value)
+        if merged:
+            max_value = max(merged.values()) or 1.0
+            merged = {key: round(value / max_value, 6) for key, value in merged.items()}
+        return DomainResolution(elements=elements, domains=merged)
+
+
+def natal_domain_factor(
+    sign_index: int,
+    planet_key: str,
+    house_index: Optional[int],
+    multipliers: Mapping[str, float],
+    method: str = "weighted",
+    temperature: float = 8.0,
+) -> float:
+    """Compute a domain multiplier for a natal placement using the DomainResolver.
+
+    Returns ``1.0`` if inputs are invalid or if the resolver fails to
+    produce domain weights.
+    """
+
+    try:
+        resolver = DomainResolver()
+        resolution = resolver.resolve(sign_index=sign_index, planet_key=planet_key, house_index=house_index)
+    except Exception:
+        return 1.0
+    from .scoring import compute_domain_factor
+
+    return compute_domain_factor(
+        resolution.domains,
+        multipliers,
+        method=method,
+        temperature=temperature,
+    )
+
+
+__all__ = [
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "DEFAULT_PLANET_DOMAIN_WEIGHTS",
+    "DEFAULT_HOUSE_DOMAIN_WEIGHTS",
+    "DomainResolver",
+    "DomainResolution",
+    "natal_domain_factor",
+]

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -1,0 +1,89 @@
+"""Core engine helpers for assembling transit events."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Optional
+
+from .config import profile_into_ctx
+from .scoring import compute_domain_factor
+
+
+def _attach_domain_fields(event_obj, ctx):
+    """Populate domain-related fields on ``event_obj`` using ``ctx`` metadata."""
+
+    from .domains import DomainResolver
+    from .profiles import VCA_DOMAIN_PROFILES
+
+    resolver = DomainResolver()
+
+    sign_index = ctx.get("sign_index") if ctx else None
+    planet_key = ctx.get("planet_key") if ctx else None
+    house_index = ctx.get("house_index") if ctx else None
+
+    if sign_index is None or planet_key is None:
+        return
+
+    profile_key = ctx.get("domain_profile", "vca_neutral") if ctx else "vca_neutral"
+    scorer = ctx.get("domain_scorer", "weighted") if ctx else "weighted"
+    temperature = float(ctx.get("domain_temperature", 8.0)) if ctx else 8.0
+
+    resolution = resolver.resolve(sign_index=sign_index, planet_key=planet_key, house_index=house_index)
+    event_obj.elements = resolution.elements
+    event_obj.domains = resolution.domains
+    event_obj.domain_profile = profile_key
+
+    profile = VCA_DOMAIN_PROFILES.get(profile_key)
+    if profile and hasattr(event_obj, "severity") and resolution.domains:
+        factor = compute_domain_factor(
+            resolution.domains,
+            profile.domain_multipliers,
+            method=scorer,
+            temperature=temperature,
+        )
+        if event_obj.severity is not None:
+            event_obj.severity = float(event_obj.severity) * float(factor)
+        else:
+            event_obj.severity = float(factor)
+
+
+def maybe_attach_domain_fields(event_obj, ctx):
+    """Attach domain metadata when the execution context requests it."""
+
+    if ctx and ctx.get("emit_domains"):
+        _attach_domain_fields(event_obj, ctx)
+    return event_obj
+
+
+def apply_profile_if_any(ctx: Dict[str, Any], profile_dict: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Merge an optional profile into ``ctx`` and return a new dictionary."""
+
+    if profile_dict:
+        ctx = profile_into_ctx(ctx, profile_dict)
+    return ctx
+
+
+def get_active_aspect_angles(ctx: Optional[Dict[str, Any]]) -> Iterable[float]:
+    """Return the sorted aspect angles configured in ``ctx``."""
+
+    aspects = (ctx or {}).get("aspects", {})
+    angles = []
+    for key in ("major", "minor", "harmonics"):
+        entries = aspects.get(key, [])
+        angles.extend(entries)
+    return sorted({float(angle) for angle in angles})
+
+
+def get_feature_flag(ctx: Optional[Dict[str, Any]], key: str, default: bool = False) -> bool:
+    """Return the boolean feature flag stored under ``key`` in ``ctx``."""
+
+    flags = (ctx or {}).get("flags", {})
+    return bool(flags.get(key, default))
+
+
+__all__ = [
+    "_attach_domain_fields",
+    "maybe_attach_domain_fields",
+    "apply_profile_if_any",
+    "get_active_aspect_angles",
+    "get_feature_flag",
+]

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -1,0 +1,16 @@
+"""Exporter helpers for AstroEngine."""
+
+from __future__ import annotations
+
+
+def _event_to_row(event_obj):
+    """Return a dictionary representation of ``event_obj`` suitable for persistence."""
+
+    row = getattr(event_obj, "__dict__", {}).copy()
+    row.setdefault("elements", [])
+    row.setdefault("domains", {})
+    row.setdefault("domain_profile", None)
+    return row
+
+
+__all__ = ["_event_to_row"]

--- a/astroengine/profiles.py
+++ b/astroengine/profiles.py
@@ -1,0 +1,37 @@
+"""Domain scoring profiles for AstroEngine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class DomainScoringProfile:
+    """Severity multipliers applied per domain after geometric severity is computed."""
+
+    name: str
+    domain_multipliers: Mapping[str, float]
+
+
+VCA_DOMAIN_PROFILES = {
+    "vca_neutral": DomainScoringProfile(
+        name="vca_neutral",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_mind_plus": DomainScoringProfile(
+        name="vca_mind_plus",
+        domain_multipliers={"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_body_plus": DomainScoringProfile(
+        name="vca_body_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.25, "SPIRIT": 1.0},
+    ),
+    "vca_spirit_plus": DomainScoringProfile(
+        name="vca_spirit_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.25},
+    ),
+}
+
+
+__all__ = ["DomainScoringProfile", "VCA_DOMAIN_PROFILES"]

--- a/astroengine/rulesets.py
+++ b/astroengine/rulesets.py
@@ -1,0 +1,85 @@
+"""Ruleset metadata for aspect detection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping, Optional
+
+
+@dataclass(frozen=True)
+class AspectDef:
+    name: str
+    angle: float
+    klass: str
+    default_orb_deg: float
+
+
+_VCA_ASPECTS: Dict[str, AspectDef] = {
+    "conjunction": AspectDef("conjunction", 0.0, "major", 10.0),
+    "opposition": AspectDef("opposition", 180.0, "major", 10.0),
+    "square": AspectDef("square", 90.0, "major", 8.0),
+    "trine": AspectDef("trine", 120.0, "major", 8.0),
+    "sextile": AspectDef("sextile", 60.0, "major", 6.0),
+    "semisextile": AspectDef("semisextile", 30.0, "minor", 3.0),
+    "quincunx": AspectDef("quincunx", 150.0, "minor", 3.0),
+    "semisquare": AspectDef("semisquare", 45.0, "minor", 3.0),
+    "sesquiquadrate": AspectDef("sesquiquadrate", 135.0, "minor", 3.0),
+    "quintile": AspectDef("quintile", 72.0, "minor", 2.0),
+    "biquintile": AspectDef("biquintile", 144.0, "minor", 2.0),
+    "semiquintile": AspectDef("semiquintile", 36.0, "minor", 2.0),
+    "semioctile": AspectDef("semioctile", 22.5, "minor", 1.0),
+    "septile": AspectDef("septile", 51.428, "harmonic", 1.0),
+    "biseptile": AspectDef("biseptile", 102.857, "harmonic", 1.0),
+    "triseptile": AspectDef("triseptile", 154.286, "harmonic", 1.0),
+    "novile": AspectDef("novile", 40.0, "harmonic", 1.0),
+    "binovile": AspectDef("binovile", 80.0, "harmonic", 1.0),
+    "undecile": AspectDef("undecile", 32.717, "harmonic", 1.0),
+    "tredecile": AspectDef("tredecile", 108.0, "harmonic", 2.0),
+    "quindecile": AspectDef("quindecile", 165.0, "harmonic", 2.0),
+    "fifteenth": AspectDef("fifteenth", 24.0, "harmonic", 1.0),
+    "quattuordecile": AspectDef("quattuordecile", 25.717, "harmonic", 1.0),
+    "vigintile": AspectDef("vigintile", 18.0, "harmonic", 1.0),
+    "antiscia": AspectDef("antiscia", 0.0, "mirror", 1.0),
+    "contraantiscia": AspectDef("contraantiscia", 180.0, "mirror", 1.0),
+    "parallel": AspectDef("parallel", 0.0, "declination", 1.0),
+    "contraparallel": AspectDef("contraparallel", 180.0, "declination", 1.0),
+}
+
+_VCA_ORB_CLASS_DEFAULTS: Mapping[str, float] = {
+    "major": 8.0,
+    "minor": 2.0,
+    "harmonic": 1.0,
+    "declination": 1.0,
+    "mirror": 1.0,
+}
+
+
+@dataclass(frozen=True)
+class Ruleset:
+    id: str
+    aspects: Mapping[str, AspectDef]
+    orb_class_defaults: Mapping[str, float]
+    expand_luminaries: bool = True
+
+
+VCA_RULESET = Ruleset(
+    id="vca_core",
+    aspects=_VCA_ASPECTS,
+    orb_class_defaults=_VCA_ORB_CLASS_DEFAULTS,
+)
+
+
+def get_vca_aspect(name: str) -> Optional[AspectDef]:
+    return _VCA_ASPECTS.get(name.lower())
+
+
+def vca_orb_for(name: str, *, override: Optional[float] = None) -> float:
+    if override is not None:
+        return float(override)
+    aspect = get_vca_aspect(name)
+    if not aspect:
+        return 0.0
+    return float(_VCA_ORB_CLASS_DEFAULTS.get(aspect.klass, aspect.default_orb_deg))
+
+
+__all__ = ["AspectDef", "Ruleset", "VCA_RULESET", "get_vca_aspect", "vca_orb_for"]

--- a/astroengine/scoring.py
+++ b/astroengine/scoring.py
@@ -1,0 +1,43 @@
+"""Domain scoring utilities."""
+
+from __future__ import annotations
+
+import math
+from typing import Mapping
+
+
+def compute_domain_factor(
+    domains: Mapping[str, float] | None,
+    multipliers: Mapping[str, float] | None,
+    method: str = "weighted",
+    temperature: float = 8.0,
+) -> float:
+    """Return a multiplicative factor ≥0 based on domain weights and profile multipliers."""
+
+    if not domains:
+        return 1.0
+    multipliers = multipliers or {}
+    total = sum(max(0.0, float(value)) for value in domains.values())
+    if total <= 0.0:
+        return 1.0
+    probabilities = {key: float(value) / total for key, value in domains.items()}
+    multipliers = {key: float(multipliers.get(key, 1.0)) for key in probabilities}
+    method_normalized = (method or "weighted").lower()
+
+    if method_normalized == "top":
+        top_domain = max(probabilities.items(), key=lambda kv: kv[1])[0]
+        return multipliers.get(top_domain, 1.0)
+
+    if method_normalized == "softmax":
+        logits = {key: math.log(max(1e-9, multipliers[key])) for key in probabilities}
+        temp = max(1e-6, float(temperature))
+        max_logit = max(logits.values())
+        exps = {key: math.exp((logits[key] - max_logit) / temp) for key in probabilities}
+        normalizer = sum(exps.values()) or 1.0
+        distribution = {key: exps[key] / normalizer for key in probabilities}
+        return sum(distribution[key] * multipliers[key] for key in probabilities)
+
+    return sum(probabilities[key] * multipliers[key] for key in probabilities)
+
+
+__all__ = ["compute_domain_factor"]

--- a/docs/vca_profile_mapping.md
+++ b/docs/vca_profile_mapping.md
@@ -1,0 +1,18 @@
+# VCA Outline → AstroEngine Mapping (ops guide)
+
+- **Bodies** → `profiles/vca_outline.json.bodies` (`include`, `optional_groups`, `fixed_stars`).
+- **Aspects** (Major/Minor/Harmonics, Declination, Antiscia) → `aspects`.
+- **Orbs** → `orbs` with degrees per angle; engine reads via `ctx['orbs']`.
+- **Domains (Mind/Body/Spirit)** → `domain` (weights, scorer, temperature, profile key).
+- **Feature Flags** (declination/antiscia/harmonics/fixed stars) → `flags`.
+- **Modules** (EARTH/AIR/FIRE/WATER)** → recorded for tagging; no runtime effect yet.
+
+## How it flows
+1. `--profile-file profiles/vca_outline.json` (CLI) → load.
+2. `apply_profile_if_any(ctx, profile)` merges keys into engine context.
+3. Detectors & orb logic read `ctx['aspects']`, `ctx['orbs']`, `ctx['flags']`.
+4. Domain severity uses `ctx['domain_*']` (see CP10/CP11 v1.1).
+
+## Notes
+- Fixed stars and large TNO/asteroid sets are **disabled by default**; enable only when ephemerides are available.
+- Orbs reflect VCA ranges (midpoint values). Adjust per user profile as needed.

--- a/profiles/vca_outline.json
+++ b/profiles/vca_outline.json
@@ -1,0 +1,72 @@
+{
+  "id": "vca_outline",
+  "version": "2025-09-18",
+  "label": "Vox Crucis Athanor — Program Structural Outline (Canonical)",
+  "modules": {"EARTH": true, "AIR": true, "FIRE": true, "WATER": true},
+  "bodies": {
+    "include": [
+      "sun", "moon", "mercury", "venus", "mars", "jupiter", "saturn", "uranus", "neptune", "pluto",
+      "north_node", "south_node", "chiron"
+    ],
+    "optional_groups": {
+      "asteroids_main": ["ceres", "pallas", "juno", "vesta", "hygiea", "eros", "psyche", "isis", "lilith1181", "sappho", "panacea", "astraea", "hekate", "fortuna", "nemesis"],
+      "centaurs": ["chiron", "pholus", "nessus", "chariklo", "okyrhoe", "asbolus", "thereus", "hylonome", "cyllarus"],
+      "tno": ["pluto", "eris", "haumea", "makemake", "sedna", "orcus", "quaoar", "varuna", "ixion", "gonggong"]
+    },
+    "fixed_stars": {"enabled": false, "list": ["regulus", "spica", "algol", "aldebaran", "antares", "fomalhaut", "sirius", "arcturus", "vega", "altair"]}
+  },
+  "aspects": {
+    "major": [0, 60, 90, 120, 180],
+    "minor": [30, 45, 135, 150],
+    "harmonics": [22.5, 36, 40, 51.4286, 72, 80, 108, 144, 165, 18, 24, 25.7167, 32.7167],
+    "declination": {"parallel": true, "contraparallel": true, "orb_deg": 1.0},
+    "antiscia": {"enabled": true, "orb_deg": 1.0}
+  },
+  "orbs": {
+    "major": {"0": 9.0, "180": 9.0, "90": 7.0, "120": 7.0, "60": 5.0},
+    "minor": {"30": 2.5, "45": 2.5, "135": 2.5, "150": 2.5},
+    "harmonics": {"72": 1.5, "144": 1.5, "36": 1.0, "22.5": 1.0, "40": 1.0, "51.4286": 1.0, "80": 1.0, "108": 1.5, "165": 1.5, "24": 1.0, "18": 0.75, "25.7167": 1.0, "32.7167": 1.0}
+  },
+  "domain": {
+    "profile_key": "vca_neutral",
+    "scorer": "weighted",
+    "temperature": 8.0,
+    "planet_weights": {
+      "sun": {"SPIRIT": 1.0, "MIND": 0.25, "BODY": 0.25},
+      "moon": {"BODY": 1.0, "MIND": 0.25},
+      "mercury": {"MIND": 1.0},
+      "venus": {"BODY": 0.6, "SPIRIT": 0.4},
+      "mars": {"BODY": 1.0, "SPIRIT": 0.3},
+      "jupiter": {"SPIRIT": 1.0, "MIND": 0.4},
+      "saturn": {"BODY": 0.7, "MIND": 0.5},
+      "uranus": {"MIND": 0.9, "SPIRIT": 0.4},
+      "neptune": {"SPIRIT": 1.0},
+      "pluto": {"SPIRIT": 0.7, "BODY": 0.7},
+      "north_node": {"SPIRIT": 0.8, "MIND": 0.4},
+      "south_node": {"SPIRIT": 0.8, "BODY": 0.4},
+      "chiron": {"BODY": 0.8, "SPIRIT": 0.5}
+    },
+    "house_weights": {
+      "1": {"BODY": 1.0},
+      "2": {"BODY": 0.7, "MIND": 0.3},
+      "3": {"MIND": 1.0},
+      "4": {"BODY": 0.6, "SPIRIT": 0.4},
+      "5": {"SPIRIT": 0.9, "BODY": 0.3},
+      "6": {"BODY": 1.0},
+      "7": {"MIND": 0.6, "SPIRIT": 0.4},
+      "8": {"SPIRIT": 0.9, "BODY": 0.4},
+      "9": {"SPIRIT": 0.9, "MIND": 0.6},
+      "10": {"BODY": 0.6, "SPIRIT": 0.4},
+      "11": {"MIND": 0.7, "SPIRIT": 0.5},
+      "12": {"SPIRIT": 1.0}
+    }
+  },
+  "flags": {
+    "enable_declination": true,
+    "enable_antiscia": true,
+    "enable_harmonics": true,
+    "enable_fixed_stars": false,
+    "use_tropical": true,
+    "house_system": "whole_sign"
+  }
+}

--- a/schemas/natal_input_v1_ext.json
+++ b/schemas/natal_input_v1_ext.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://astroengine/schemas/natal_input_v1_ext.json",
+  "title": "Natal Input (VCA Extensions)",
+  "type": "object",
+  "properties": {
+    "source_rating": {
+      "type": "string",
+      "enum": ["AA", "A", "B", "C", "DD", "X", "XX"]
+    },
+    "zodiac": {
+      "type": "string",
+      "enum": [
+        "tropical",
+        "sidereal_fagan_allen",
+        "sidereal_lahiri",
+        "sidereal_deluce",
+        "sidereal_raman",
+        "sidereal_usha_shashi",
+        "sidereal_krishnamurti",
+        "sidereal_djwal_khul",
+        "draconic",
+        "sidereal_svp",
+        "sidereal_sri_yukteswar",
+        "sidereal_jn_bhasin",
+        "sidereal_larry_eli",
+        "sidereal_takra_i",
+        "sidereal_takra_ii",
+        "sidereal_sundra_rajan",
+        "sidereal_shill_pond"
+      ]
+    },
+    "house_system": {
+      "type": "string",
+      "enum": [
+        "placidus",
+        "porphyry",
+        "regiomontanus",
+        "topocentric",
+        "equal",
+        "equal_aries0",
+        "solar_sign",
+        "whole_sign",
+        "whole_sign_fortune",
+        "hindu_bhava",
+        "alcabitius"
+      ]
+    },
+    "coordinate_system": {
+      "type": "string",
+      "enum": ["geocentric", "heliocentric"]
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/result_schema_v1.json
+++ b/schemas/result_schema_v1.json
@@ -346,6 +346,24 @@
               "type": "string"
             }
           },
+          "elements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "domains": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "domain_profile": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "intent_hint": {
             "type": "string"
           },

--- a/schemas/result_schema_v1_with_domains.json
+++ b/schemas/result_schema_v1_with_domains.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://astroengine/schemas/result_v1_with_domains.json",
+  "title": "AstroEngine Run Result (with Domains)",
+  "type": "object",
+  "properties": {
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "elements": {"type": "array", "items": {"type": "string"}},
+          "domains": {"type": "object", "additionalProperties": {"type": "number"}},
+          "domain_profile": {"type": ["string", "null"]}
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/tests/test_domain_scoring.py
+++ b/tests/test_domain_scoring.py
@@ -1,0 +1,19 @@
+from astroengine.scoring import compute_domain_factor
+
+
+MULTIPLIERS = {"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0}
+
+
+def test_weighted_scoring_dot_product():
+    factor = compute_domain_factor({"MIND": 0.8, "BODY": 0.2}, MULTIPLIERS, method="weighted")
+    assert abs(factor - 1.2) < 1e-9
+
+
+def test_top_scoring_uses_argmax():
+    factor = compute_domain_factor({"BODY": 0.6, "MIND": 0.4}, MULTIPLIERS, method="top")
+    assert factor == 1.0
+
+
+def test_softmax_returns_expected_value():
+    factor = compute_domain_factor({"MIND": 0.5, "BODY": 0.5}, MULTIPLIERS, method="softmax", temperature=8.0)
+    assert 1.0 <= factor <= 1.25

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,0 +1,19 @@
+from astroengine.domains import DomainResolver, ZODIAC_ELEMENT_MAP
+
+
+def test_elements_triplicity_mapping():
+    assert ZODIAC_ELEMENT_MAP[0] == "FIRE"
+    assert ZODIAC_ELEMENT_MAP[1] == "EARTH"
+    assert ZODIAC_ELEMENT_MAP[2] == "AIR"
+    assert ZODIAC_ELEMENT_MAP[3] == "WATER"
+    assert ZODIAC_ELEMENT_MAP[10] == "AIR"
+    assert ZODIAC_ELEMENT_MAP[11] == "WATER"
+
+
+def test_domain_resolver_merges_and_normalizes():
+    resolver = DomainResolver()
+    resolution = resolver.resolve(sign_index=2, planet_key="mercury", house_index=3)
+    assert resolution.elements == ["AIR"]
+    assert resolution.domains
+    top = max(resolution.domains, key=resolution.domains.get)
+    assert top == "MIND"

--- a/tests/test_vca_profile.py
+++ b/tests/test_vca_profile.py
@@ -1,0 +1,25 @@
+import json
+
+from astroengine.config import load_profile_json, profile_into_ctx
+from astroengine.engine import get_active_aspect_angles
+
+
+def test_profile_load_and_angles(tmp_path):
+    path = tmp_path / "mini.json"
+    path.write_text(
+        json.dumps(
+            {
+                "id": "mini",
+                "aspects": {"major": [0, 60, 90, 120, 180], "minor": [30]},
+                "orbs": {"major": {"0": 8}},
+                "flags": {"enable_antiscia": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    profile = load_profile_json(path)
+    ctx = profile_into_ctx({}, profile)
+    angles = get_active_aspect_angles(ctx)
+    assert 0.0 in angles
+    assert 180.0 in angles
+    assert 30.0 in angles

--- a/tests/test_vca_ruleset.py
+++ b/tests/test_vca_ruleset.py
@@ -1,0 +1,22 @@
+from astroengine.rulesets import get_vca_aspect, vca_orb_for
+
+
+def test_major_angles_exist():
+    assert get_vca_aspect("conjunction").angle == 0.0
+    assert get_vca_aspect("opposition").angle == 180.0
+    assert get_vca_aspect("square").angle == 90.0
+    assert get_vca_aspect("trine").angle == 120.0
+    assert get_vca_aspect("sextile").angle == 60.0
+
+
+def test_minor_and_harmonics_present():
+    assert get_vca_aspect("quincunx").angle == 150.0
+    assert get_vca_aspect("quintile").angle == 72.0
+    assert get_vca_aspect("septile").angle == 51.428
+    assert get_vca_aspect("novile").angle == 40.0
+
+
+def test_orb_policy_defaults():
+    assert vca_orb_for("square") == 8.0
+    assert vca_orb_for("quincunx") in (2.0, 3.0)
+    assert vca_orb_for("vigintile") == 1.0


### PR DESCRIPTION
## Summary
- add domain and element taxonomy utilities plus scoring profiles and public API exports
- wire CLI, engine helpers, and ruleset/catalog metadata to load VCA outline profiles and scoring options
- extend schemas/docs and add tests covering domain resolution, scoring, profile loading, and ruleset defaults

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc937c68f083248bfb4570261161ee