### PR TITLE
Add VCA domain taxonomy and scoring utilities

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -12,9 +12,33 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
+__all__ = [
+    "__version__",
+    "TransitEvent",
+    "DomainResolver",
+    "DomainResolution",
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "natal_domain_factor",
+    "DomainScoringProfile",
+    "VCA_DOMAIN_PROFILES",
+    "compute_domain_factor",
+]
 
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
+
+from .api import TransitEvent  # ENSURE-LINE
+from .domains import (
+    DOMAINS,
+    ELEMENTS,
+    ZODIAC_ELEMENT_MAP,
+    DomainResolution,
+    DomainResolver,
+    natal_domain_factor,
+)
+from .profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES  # ENSURE-LINE
+from .scoring import compute_domain_factor  # ENSURE-LINE

--- a/astroengine/api.py
+++ b/astroengine/api.py
@@ -1,0 +1,26 @@
+"""Public API dataclasses used by the AstroEngine runtime."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+# >>> AUTO-GEN BEGIN: API Domain Fields v1.0
+
+
+@dataclass
+class TransitEvent:
+    """Lightweight event structure enriched with optional domain metadata."""
+
+    severity: Optional[float] = None
+    elements: List[str] = field(default_factory=list)
+    domains: Dict[str, float] = field(default_factory=dict)
+    domain_profile: Optional[str] = None
+
+
+# >>> AUTO-GEN END: API Domain Fields v1.0
+
+
+__all__ = ["TransitEvent"]
+

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1,0 +1,79 @@
+"""Command line helpers for AstroEngine."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, Mapping, Sequence
+
+from .engine import assemble_transit_event, event_to_mapping
+
+
+# >>> AUTO-GEN BEGIN: CLI Domain Scorer Flags v1.1
+
+
+def _add_domain_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--emit-domains",
+        action="store_true",
+        help="Include elements/domains on each TransitEvent.",
+    )
+    parser.add_argument(
+        "--domain-profile",
+        default="vca_neutral",
+        help="Domain profile key (see VCA_DOMAIN_PROFILES).",
+    )
+    parser.add_argument(
+        "--domain-scorer",
+        default="weighted",
+        choices=["weighted", "top", "softmax"],
+        help="Method to transform domains into a severity multiplier.",
+    )
+    parser.add_argument(
+        "--domain-temperature",
+        type=float,
+        default=8.0,
+        help="Softmax temperature (only used when --domain-scorer=softmax).",
+    )
+
+
+# >>> AUTO-GEN END: CLI Domain Scorer Flags v1.1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Assemble AstroEngine transit events")
+    parser.add_argument("--sign-index", type=int, help="Zodiac index (0=Aries)")
+    parser.add_argument("--planet-key", help="Canonical planet identifier")
+    parser.add_argument("--house-index", type=int, help="House index (1-12)")
+    parser.add_argument("--severity", type=float, default=None, help="Base severity value")
+    _add_domain_args(parser)
+    return parser
+
+
+def _ctx_from_args(namespace: argparse.Namespace) -> Mapping[str, Any]:
+    ctx: dict[str, Any] = {
+        "sign_index": namespace.sign_index,
+        "planet_key": namespace.planet_key,
+        "house_index": namespace.house_index,
+        "severity": namespace.severity,
+        "emit_domains": namespace.emit_domains,
+    }
+    if namespace.emit_domains:
+        ctx["domain_profile"] = namespace.domain_profile
+        ctx["domain_scorer"] = namespace.domain_scorer
+        ctx["domain_temperature"] = namespace.domain_temperature
+    return ctx
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    ctx = _ctx_from_args(args)
+    event = assemble_transit_event(ctx)
+    payload = event_to_mapping(event)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = ["build_parser", "main", "_add_domain_args"]
+

--- a/astroengine/data/schemas.py
+++ b/astroengine/data/schemas.py
@@ -31,6 +31,10 @@ SchemaMetadata = Mapping[str, str]
 
 SCHEMA_REGISTRY: Dict[str, SchemaMetadata] = {
     "result_v1": {"filename": "result_schema_v1.json", "kind": "jsonschema"},
+    "result_v1_domains": {
+        "filename": "result_schema_v1.json",
+        "kind": "jsonschema",
+    },
     "contact_gate_v2": {
         "filename": "contact_gate_schema_v2.json",
         "kind": "jsonschema",

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -1,0 +1,173 @@
+"""Domain and element taxonomy utilities for AstroEngine.
+
+This module provides deterministic mappings between zodiac signs,
+planets, houses, and their corresponding VCA Mind/Body/Spirit domain
+weights.  The goal is to make the tagging logic fully data-driven so it
+can be reused by the engine, exporters, and any diagnostic tooling
+without risking accidental module loss.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Tuple
+
+# >>> AUTO-GEN BEGIN: Domains & Elements v1.0
+
+# Canonical element labels (uppercase; stable public API)
+ELEMENTS: Tuple[str, str, str, str] = ("FIRE", "EARTH", "AIR", "WATER")
+DOMAINS: Tuple[str, str, str] = ("MIND", "BODY", "SPIRIT")
+
+# Zodiac (0=Aries ... 11=Pisces) → Element
+ZODIAC_ELEMENT_MAP: Tuple[str, ...] = (
+    "FIRE",  # 0 Aries
+    "EARTH",  # 1 Taurus
+    "AIR",  # 2 Gemini
+    "WATER",  # 3 Cancer
+    "FIRE",  # 4 Leo
+    "EARTH",  # 5 Virgo
+    "AIR",  # 6 Libra
+    "WATER",  # 7 Scorpio
+    "FIRE",  # 8 Sagittarius
+    "EARTH",  # 9 Capricorn
+    "AIR",  # 10 Aquarius
+    "WATER",  # 11 Pisces
+)
+
+# Planet → default Domain weights (VCA-ish sensible defaults; overridable by profiles)
+# Keys use engine’s canonical planet ids: sun, moon, mercury, venus, mars, jupiter, saturn,
+# uranus, neptune, pluto, north_node, south_node, chiron
+DEFAULT_PLANET_DOMAIN_WEIGHTS: Mapping[str, Mapping[str, float]] = {
+    "sun": {"SPIRIT": 1.0, "MIND": 0.25, "BODY": 0.25},
+    "moon": {"BODY": 1.0, "MIND": 0.25},
+    "mercury": {"MIND": 1.0},
+    "venus": {"BODY": 0.6, "SPIRIT": 0.4},
+    "mars": {"BODY": 1.0, "SPIRIT": 0.3},
+    "jupiter": {"SPIRIT": 1.0, "MIND": 0.4},
+    "saturn": {"BODY": 0.7, "MIND": 0.5},
+    "uranus": {"MIND": 0.9, "SPIRIT": 0.4},
+    "neptune": {"SPIRIT": 1.0},
+    "pluto": {"SPIRIT": 0.7, "BODY": 0.7},
+    "north_node": {"SPIRIT": 0.8, "MIND": 0.4},
+    "south_node": {"SPIRIT": 0.8, "BODY": 0.4},
+    "chiron": {"BODY": 0.8, "SPIRIT": 0.5},
+}
+
+# House index (1..12) → Domain weights (kept light; debated houses marked TODO for profiles)
+DEFAULT_HOUSE_DOMAIN_WEIGHTS: Mapping[int, Mapping[str, float]] = {
+    1: {"BODY": 1.0},  # Vitality, soma
+    2: {"BODY": 0.7, "MIND": 0.3},
+    3: {"MIND": 1.0},  # Communication
+    4: {"BODY": 0.6, "SPIRIT": 0.4},
+    5: {"SPIRIT": 0.9, "BODY": 0.3},
+    6: {"BODY": 1.0},  # Health/routines
+    7: {"MIND": 0.6, "SPIRIT": 0.4},
+    8: {"SPIRIT": 0.9, "BODY": 0.4},
+    9: {"SPIRIT": 0.9, "MIND": 0.6},
+    10: {"BODY": 0.6, "SPIRIT": 0.4},
+    11: {"MIND": 0.7, "SPIRIT": 0.5},
+    12: {"SPIRIT": 1.0},
+}
+
+
+@dataclass(frozen=True)
+class DomainResolution:
+    elements: List[str]  # e.g., ["FIRE"] (sign-derived)
+    domains: Dict[str, float]  # merged weights {"MIND": w, ...}
+
+
+class DomainResolver:
+    """Resolve Elements (by sign) and Mind/Body/Spirit domain weights for a transit contact."""
+
+    def __init__(
+        self,
+        planet_weights: Optional[Mapping[str, Mapping[str, float]]] = None,
+        house_weights: Optional[Mapping[int, Mapping[str, float]]] = None,
+    ) -> None:
+        self._planet = planet_weights or DEFAULT_PLANET_DOMAIN_WEIGHTS
+        self._house = house_weights or DEFAULT_HOUSE_DOMAIN_WEIGHTS
+
+    def resolve(
+        self,
+        sign_index: int,
+        planet_key: str,
+        house_index: Optional[int] = None,
+        overrides: Optional[Mapping[str, Mapping]] = None,
+    ) -> DomainResolution:
+        if not (0 <= sign_index <= 11):
+            raise ValueError("sign_index must be 0..11")
+        elements = [ZODIAC_ELEMENT_MAP[sign_index]]
+
+        # Merge weights with shallow override logic
+        planet_weights = dict(self._planet.get(planet_key, {}))
+        house_weights = dict(self._house.get(house_index, {})) if house_index else {}
+        if overrides:
+            planet_override = overrides.get("planet_weights") if hasattr(overrides, "get") else None
+            if planet_override and planet_key in planet_override:
+                planet_weights = dict(planet_override[planet_key])
+            house_override = overrides.get("house_weights") if hasattr(overrides, "get") else None
+            if house_override and house_index in house_override:
+                house_weights = dict(house_override[house_index])
+
+        merged: Dict[str, float] = {}
+        for src in (planet_weights, house_weights):
+            for key, value in src.items():
+                merged[key] = merged.get(key, 0.0) + float(value)
+        if merged:
+            maximum = max(merged.values()) or 1.0
+            merged = {key: round(value / maximum, 6) for key, value in merged.items()}
+        return DomainResolution(elements=elements, domains=merged)
+
+
+# >>> AUTO-GEN END: Domains & Elements v1.0
+
+
+# >>> AUTO-GEN BEGIN: Natal Domain Factor Helper v1.1
+def natal_domain_factor(
+    sign_index: int,
+    planet_key: str,
+    house_index: Optional[int],
+    multipliers: Mapping[str, float],
+    method: str = "weighted",
+    temperature: float = 8.0,
+) -> float:
+    """Compute a domain multiplier for a natal placement.
+
+    Returns 1.0 if resolution fails or no domain weights are produced.
+    """
+
+    try:
+        resolver = DomainResolver()
+        result = resolver.resolve(
+            sign_index=sign_index,
+            planet_key=planet_key,
+            house_index=house_index,
+        )
+    except Exception:
+        return 1.0
+    if not result.domains:
+        return 1.0
+    from .scoring import compute_domain_factor
+
+    return compute_domain_factor(
+        result.domains,
+        multipliers,
+        method=method,
+        temperature=temperature,
+    )
+
+
+# >>> AUTO-GEN END: Natal Domain Factor Helper v1.1
+
+
+__all__ = [
+    "DomainResolver",
+    "DomainResolution",
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "DEFAULT_PLANET_DOMAIN_WEIGHTS",
+    "DEFAULT_HOUSE_DOMAIN_WEIGHTS",
+    "natal_domain_factor",
+]
+

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -1,0 +1,75 @@
+"""Core runtime helpers for assembling transit events."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping
+
+from .api import TransitEvent
+from .scoring import compute_domain_factor  # ENSURE-LINE
+
+
+# >>> AUTO-GEN BEGIN: Engine Domain Scoring Hook v1.1
+
+
+def _attach_domain_fields(event_obj: TransitEvent, ctx: Mapping[str, Any]) -> None:
+    from .domains import DomainResolver
+    from .profiles import VCA_DOMAIN_PROFILES
+
+    resolver = DomainResolver()
+
+    sign_index = ctx.get("sign_index")
+    planet_key = ctx.get("planet_key")
+    house_index = ctx.get("house_index")
+
+    if sign_index is None or planet_key is None:
+        return
+
+    profile_key = ctx.get("domain_profile", "vca_neutral")
+    scorer = ctx.get("domain_scorer", "weighted")
+    temperature = float(ctx.get("domain_temperature", 8.0))
+
+    result = resolver.resolve(
+        sign_index=int(sign_index),
+        planet_key=str(planet_key),
+        house_index=int(house_index) if house_index is not None else None,
+    )
+    event_obj.elements = result.elements
+    event_obj.domains = result.domains
+    event_obj.domain_profile = profile_key
+
+    profile = VCA_DOMAIN_PROFILES.get(profile_key)
+    if profile and event_obj.domains:
+        factor = compute_domain_factor(
+            event_obj.domains,
+            profile.domain_multipliers,
+            method=scorer,
+            temperature=temperature,
+        )
+        if event_obj.severity is not None:
+            event_obj.severity = float(event_obj.severity) * float(factor)
+
+
+# >>> AUTO-GEN END: Engine Domain Scoring Hook v1.1
+
+
+def assemble_transit_event(ctx: Mapping[str, Any]) -> TransitEvent:
+    """Create a :class:`TransitEvent` from the provided context mapping."""
+
+    event = TransitEvent()
+    severity = ctx.get("severity")
+    if severity is not None:
+        event.severity = float(severity)
+
+    if ctx.get("emit_domains"):
+        _attach_domain_fields(event, ctx)
+    return event
+
+
+def event_to_mapping(event: TransitEvent) -> MutableMapping[str, Any]:
+    """Return a shallow mapping view of the event for serialization."""
+
+    return dict(event.__dict__)
+
+
+__all__ = ["assemble_transit_event", "event_to_mapping", "_attach_domain_fields"]
+

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -1,0 +1,23 @@
+"""Exporter helpers for AstroEngine runtimes."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+# >>> AUTO-GEN BEGIN: Exporters Domain Fields v1.0
+
+
+def _event_to_row(event_obj: Any) -> Dict[str, Any]:
+    row = getattr(event_obj, "__dict__", {}).copy()
+    row.setdefault("elements", [])
+    row.setdefault("domains", {})
+    row.setdefault("domain_profile", None)
+    return row
+
+
+# >>> AUTO-GEN END: Exporters Domain Fields v1.0
+
+
+__all__ = ["_event_to_row"]
+

--- a/astroengine/profiles.py
+++ b/astroengine/profiles.py
@@ -1,0 +1,44 @@
+"""Domain scoring profiles for AstroEngine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+# >>> AUTO-GEN BEGIN: VCA Domain Scoring Profile v1.0
+
+
+@dataclass(frozen=True)
+class DomainScoringProfile:
+    """Severity multipliers applied per domain after geometric severity is computed."""
+
+    name: str
+    domain_multipliers: Mapping[str, float]
+
+
+# Sensible defaults; teams can add more via profile registry later.
+VCA_DOMAIN_PROFILES = {
+    "vca_neutral": DomainScoringProfile(
+        name="vca_neutral",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_mind_plus": DomainScoringProfile(
+        name="vca_mind_plus",
+        domain_multipliers={"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_body_plus": DomainScoringProfile(
+        name="vca_body_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.25, "SPIRIT": 1.0},
+    ),
+    "vca_spirit_plus": DomainScoringProfile(
+        name="vca_spirit_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.25},
+    ),
+}
+
+
+# >>> AUTO-GEN END: VCA Domain Scoring Profile v1.0
+
+
+__all__ = ["DomainScoringProfile", "VCA_DOMAIN_PROFILES"]
+

--- a/astroengine/scoring.py
+++ b/astroengine/scoring.py
@@ -1,0 +1,51 @@
+"""Domain-based scoring helpers."""
+
+from __future__ import annotations
+
+import math
+from typing import Mapping
+
+
+# >>> AUTO-GEN BEGIN: Domain Scoring Utils v1.1
+
+
+def compute_domain_factor(
+    domains: Mapping[str, float] | None,
+    multipliers: Mapping[str, float] | None,
+    method: str = "weighted",
+    temperature: float = 8.0,
+) -> float:
+    """Return a multiplicative factor ≥0 based on domain weights and profile multipliers."""
+
+    if not domains:
+        return 1.0
+    multipliers = multipliers or {}
+    total = sum(max(0.0, float(value)) for value in domains.values())
+    if total <= 0.0:
+        return 1.0
+    normalized = {key: float(value) / total for key, value in domains.items()}
+
+    active = {key: float(multipliers.get(key, 1.0)) for key in normalized}
+    method = (method or "weighted").lower()
+
+    if method == "top":
+        dominant = max(normalized.items(), key=lambda kv: kv[1])[0]
+        return active.get(dominant, 1.0)
+
+    if method == "softmax":
+        logits = {key: math.log(max(1e-9, active[key])) for key in normalized}
+        temperature = max(1e-6, float(temperature))
+        anchor = max(logits.values())
+        exps = {key: math.exp((logits[key] - anchor) / temperature) for key in normalized}
+        partition = sum(exps.values()) or 1.0
+        weights = {key: exps[key] / partition for key in normalized}
+        return sum(weights[key] * active[key] for key in normalized)
+
+    return sum(normalized[key] * active[key] for key in normalized)
+
+
+# >>> AUTO-GEN END: Domain Scoring Utils v1.1
+
+
+__all__ = ["compute_domain_factor"]
+

--- a/schemas/result_schema_v1.json
+++ b/schemas/result_schema_v1.json
@@ -384,6 +384,24 @@
           },
           "notes": {
             "type": "string"
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "domains": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "domain_profile": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       }

--- a/tests/test_domain_scoring.py
+++ b/tests/test_domain_scoring.py
@@ -1,0 +1,23 @@
+from astroengine.scoring import compute_domain_factor
+
+
+MULTIPLIERS = {"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0}
+
+
+def test_weighted_scoring_dot_product() -> None:
+    domains = {"MIND": 0.8, "BODY": 0.2}
+    factor = compute_domain_factor(domains, MULTIPLIERS, method="weighted")
+    assert abs(factor - 1.2) < 1e-9
+
+
+def test_top_scoring_uses_argmax() -> None:
+    domains = {"BODY": 0.6, "MIND": 0.4}
+    factor = compute_domain_factor(domains, MULTIPLIERS, method="top")
+    assert factor == 1.0
+
+
+def test_softmax_returns_expected_value() -> None:
+    domains = {"MIND": 0.5, "BODY": 0.5}
+    factor = compute_domain_factor(domains, MULTIPLIERS, method="softmax", temperature=8.0)
+    assert 1.0 <= factor <= 1.25
+

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,0 +1,20 @@
+from astroengine.domains import DomainResolver, ZODIAC_ELEMENT_MAP
+
+
+def test_elements_triplicity_mapping() -> None:
+    assert ZODIAC_ELEMENT_MAP[0] == "FIRE"
+    assert ZODIAC_ELEMENT_MAP[1] == "EARTH"
+    assert ZODIAC_ELEMENT_MAP[2] == "AIR"
+    assert ZODIAC_ELEMENT_MAP[3] == "WATER"
+    assert ZODIAC_ELEMENT_MAP[10] == "AIR"
+    assert ZODIAC_ELEMENT_MAP[11] == "WATER"
+
+
+def test_domain_resolver_merges_and_normalizes() -> None:
+    resolver = DomainResolver()
+    result = resolver.resolve(sign_index=2, planet_key="mercury", house_index=3)
+    assert result.elements == ["AIR"]
+    assert result.domains
+    top = max(result.domains, key=result.domains.get)
+    assert top == "MIND"
+


### PR DESCRIPTION
## Summary
- introduce domain and element taxonomy with resolver, scoring profiles, and natal helper utilities
- extend TransitEvent, engine assembly, CLI, and exporters to emit domain metadata and apply profile-based severity adjustments
- expand result schema/registry and add unit tests covering resolver mappings and scoring math

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc9224e74c8324bf54dce81b652f1c