### PR TITLE
Add domain taxonomy and profile-aware transit tagging

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -12,9 +12,34 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
-
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
+
+from .api import TransitEvent  # ENSURE-LINE
+from .domains import (  # ENSURE-LINE
+    DOMAINS,
+    ELEMENTS,
+    ZODIAC_ELEMENT_MAP,
+    DomainResolution,
+    DomainResolver,
+)
+from .engine import attach_domain_fields, build_transit_event
+from .exporters import event_to_row
+from .profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES  # ENSURE-LINE
+
+__all__ = [
+    "__version__",
+    "TransitEvent",
+    "DomainResolver",
+    "DomainResolution",
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "DomainScoringProfile",
+    "VCA_DOMAIN_PROFILES",
+    "build_transit_event",
+    "attach_domain_fields",
+    "event_to_row",
+]

--- a/astroengine/api.py
+++ b/astroengine/api.py
@@ -1,0 +1,19 @@
+"""Public API dataclasses for AstroEngine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+__all__ = ["TransitEvent"]
+
+
+# >>> AUTO-GEN BEGIN: API Domain Fields v1.0
+@dataclass
+class TransitEvent:
+    # NOTE: existing fields remain; these are additive and optional
+    severity: Optional[float] = None
+    elements: List[str] = field(default_factory=list)        # e.g., ["FIRE"]
+    domains: Dict[str, float] = field(default_factory=dict)  # normalized weights
+    domain_profile: Optional[str] = None                     # e.g., "vca_neutral"
+# >>> AUTO-GEN END: API Domain Fields v1.0

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1,0 +1,50 @@
+"""Command line interface for AstroEngine."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Sequence
+
+__all__ = ["_add_domain_args", "build_runtime_context", "parse_args", "main"]
+
+
+# >>> AUTO-GEN BEGIN: CLI Domain Flags v1.0
+import argparse
+
+
+def _add_domain_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument("--emit-domains", action="store_true", help="Include elements/domains on each TransitEvent.")
+    p.add_argument(
+        "--domain-profile", default="vca_neutral", help="Domain profile key (see VCA_DOMAIN_PROFILES)."
+    )
+
+
+# In main():
+# parser = argparse.ArgumentParser(...)
+# _add_domain_args(parser)
+# args = parser.parse_args()
+# pass args to engine context as ctx["domain_profile"] = args.domain_profile when args.emit_domains is True
+# >>> AUTO-GEN END: CLI Domain Flags v1.0
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the AstroEngine CLI."""
+
+    parser = argparse.ArgumentParser(description="AstroEngine runtime controller")
+    _add_domain_args(parser)
+    return parser.parse_args(argv)
+
+
+def build_runtime_context(args: argparse.Namespace) -> Dict[str, Any]:
+    """Convert parsed arguments into an engine runtime context."""
+
+    context: Dict[str, Any] = {"emit_domains": bool(args.emit_domains)}
+    if args.emit_domains:
+        context["domain_profile"] = args.domain_profile
+    return context
+
+
+def main(argv: Sequence[str] | None = None) -> Dict[str, Any]:
+    """Entry point for ``python -m astroengine.cli``."""
+
+    args = parse_args(argv)
+    return build_runtime_context(args)

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -1,0 +1,137 @@
+"""Domain and element taxonomy utilities for AstroEngine.
+
+This module centralises the mapping between planets, houses, and
+Mind/Body/Spirit (M/B/S) domain weights.  The resolver exposes a
+deterministic API that callers can use to decorate transit events with
+consistent annotations.  The defaults are intentionally lightweight so
+that downstream profiles can override them without editing this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Optional, Tuple
+
+__all__ = [
+    "ELEMENTS",
+    "DOMAINS",
+    "ZODIAC_ELEMENT_MAP",
+    "DEFAULT_PLANET_DOMAIN_WEIGHTS",
+    "DEFAULT_HOUSE_DOMAIN_WEIGHTS",
+    "DomainResolution",
+    "DomainResolver",
+]
+
+# >>> AUTO-GEN BEGIN: Domains & Elements v1.0
+# Canonical element labels (uppercase; stable public API)
+ELEMENTS: Tuple[str, str, str, str] = ("FIRE", "EARTH", "AIR", "WATER")
+DOMAINS: Tuple[str, str, str] = ("MIND", "BODY", "SPIRIT")
+
+# Zodiac (0=Aries ... 11=Pisces) → Element
+ZODIAC_ELEMENT_MAP: Tuple[str, ...] = (
+    "FIRE",   # 0 Aries
+    "EARTH",  # 1 Taurus
+    "AIR",    # 2 Gemini
+    "WATER",  # 3 Cancer
+    "FIRE",   # 4 Leo
+    "EARTH",  # 5 Virgo
+    "AIR",    # 6 Libra
+    "WATER",  # 7 Scorpio
+    "FIRE",   # 8 Sagittarius
+    "EARTH",  # 9 Capricorn
+    "AIR",    # 10 Aquarius
+    "WATER",  # 11 Pisces
+)
+
+# Planet → default Domain weights (VCA-ish sensible defaults; overridable by profiles)
+# Keys use engine’s canonical planet ids: sun, moon, mercury, venus, mars, jupiter, saturn, uranus, neptune, pluto, north_node, south_node, chiron
+DEFAULT_PLANET_DOMAIN_WEIGHTS: Mapping[str, Mapping[str, float]] = {
+    "sun":     {"SPIRIT": 1.0, "MIND": 0.25, "BODY": 0.25},
+    "moon":    {"BODY": 1.0,   "MIND": 0.25},
+    "mercury": {"MIND": 1.0},
+    "venus":   {"BODY": 0.6,   "SPIRIT": 0.4},
+    "mars":    {"BODY": 1.0,   "SPIRIT": 0.3},
+    "jupiter": {"SPIRIT": 1.0, "MIND": 0.4},
+    "saturn":  {"BODY": 0.7,   "MIND": 0.5},
+    "uranus":  {"MIND": 0.9,   "SPIRIT": 0.4},
+    "neptune": {"SPIRIT": 1.0},
+    "pluto":   {"SPIRIT": 0.7, "BODY": 0.7},
+    "north_node": {"SPIRIT": 0.8, "MIND": 0.4},
+    "south_node": {"SPIRIT": 0.8, "BODY": 0.4},
+    "chiron":  {"BODY": 0.8,   "SPIRIT": 0.5},
+}
+
+# House index (1..12) → Domain weights (kept light; debated houses marked TODO for profiles)
+DEFAULT_HOUSE_DOMAIN_WEIGHTS: Mapping[int, Mapping[str, float]] = {
+    1: {"BODY": 1.0},             # Vitality, soma
+    2: {"BODY": 0.7, "MIND": 0.3},
+    3: {"MIND": 1.0},             # Communication
+    4: {"BODY": 0.6, "SPIRIT": 0.4},
+    5: {"SPIRIT": 0.9, "BODY": 0.3},
+    6: {"BODY": 1.0},             # Health/routines
+    7: {"MIND": 0.6, "SPIRIT": 0.4},
+    8: {"SPIRIT": 0.9, "BODY": 0.4},
+    9: {"SPIRIT": 0.9, "MIND": 0.6},
+    10: {"BODY": 0.6, "SPIRIT": 0.4},
+    11: {"MIND": 0.7, "SPIRIT": 0.5},
+    12: {"SPIRIT": 1.0},
+}
+
+
+@dataclass(frozen=True)
+class DomainResolution:
+    elements: List[str]            # e.g., ["FIRE"] (sign-derived)
+    domains: Dict[str, float]      # merged weights {"MIND": w, ...}
+
+
+class DomainResolver:
+    """Resolve Elements (by sign) and Mind/Body/Spirit domain weights for a transit contact.
+
+    Inputs expected:
+      - sign_index: int in [0..11]
+      - planet_key: str canonical (see DEFAULT_PLANET_DOMAIN_WEIGHTS)
+      - house_index: Optional[int] 1..12 (if available)
+      - profile_overrides: optional dict with keys "planet_weights", "house_weights"
+    """
+
+    def __init__(
+        self,
+        planet_weights: Optional[Mapping[str, Mapping[str, float]]] = None,
+        house_weights: Optional[Mapping[int, Mapping[str, float]]] = None,
+    ):
+        self._planet = planet_weights or DEFAULT_PLANET_DOMAIN_WEIGHTS
+        self._house = house_weights or DEFAULT_HOUSE_DOMAIN_WEIGHTS
+
+    def resolve(
+        self,
+        sign_index: int,
+        planet_key: str,
+        house_index: Optional[int] = None,
+        overrides: Optional[Mapping[str, Mapping]] = None,
+    ) -> DomainResolution:
+        if not (0 <= sign_index <= 11):
+            raise ValueError("sign_index must be 0..11")
+        elements = [ZODIAC_ELEMENT_MAP[sign_index]]
+
+        # Merge weights with shallow override logic
+        p = dict(self._planet.get(planet_key, {}))
+        h = dict(self._house.get(house_index, {})) if house_index else {}
+        if overrides:
+            planet_overrides = overrides.get("planet_weights") if isinstance(overrides, Mapping) else None
+            house_overrides = overrides.get("house_weights") if isinstance(overrides, Mapping) else None
+            if planet_overrides and planet_key in planet_overrides:
+                p = dict(planet_overrides[planet_key])
+            if house_overrides and house_index in house_overrides:
+                h = dict(house_overrides[house_index])
+
+        # Sum and normalize to max=1.0 (keeping zeros if both empty)
+        merged: Dict[str, float] = {}
+        for src in (p, h):
+            for k, v in src.items():
+                merged[k] = merged.get(k, 0.0) + float(v)
+        if merged:
+            m = max(merged.values()) or 1.0
+            merged = {k: round(v / m, 6) for k, v in merged.items()}
+        return DomainResolution(elements=elements, domains=merged)
+
+# >>> AUTO-GEN END: Domains & Elements v1.0

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -1,0 +1,100 @@
+"""Core assembly helpers for AstroEngine transit events."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Optional
+
+from .api import TransitEvent
+from .domains import DomainResolver
+from .profiles import VCA_DOMAIN_PROFILES
+
+__all__ = [
+    "DomainResolver",
+    "VCA_DOMAIN_PROFILES",
+    "build_transit_event",
+    "attach_domain_fields",
+]
+
+# >>> AUTO-GEN BEGIN: Engine Domain Injection v1.0
+# Instantiate once; can be swapped by callers if needed.
+_domain_resolver = DomainResolver()
+
+
+# Hook this inside the event construction path after sign/house/planet are known
+# Pseudo-API expected context keys: sign_index, planet_key, house_index, severity, profile_key
+
+def _attach_domain_fields(event_obj: TransitEvent, ctx: Mapping[str, Any], *, resolver: Optional[DomainResolver] = None,
+                          overrides: Optional[Mapping[str, Mapping]] = None) -> None:
+    resolver = resolver or _domain_resolver
+    if resolver is None:
+        return
+    sign_index = ctx.get("sign_index")
+    planet_key = ctx.get("planet_key")
+    if sign_index is None or planet_key is None:
+        return
+    house_index = ctx.get("house_index")
+    profile_key = ctx.get("domain_profile", "vca_neutral")
+
+    res = resolver.resolve(sign_index=sign_index, planet_key=planet_key, house_index=house_index, overrides=overrides)
+    event_obj.elements = res.elements
+    event_obj.domains = res.domains
+    event_obj.domain_profile = profile_key
+
+    # Optional: apply domain severity multiplier to existing numeric severity if present
+    prof = VCA_DOMAIN_PROFILES.get(profile_key)
+    if prof and hasattr(event_obj, "severity") and event_obj.domains and event_obj.severity is not None:
+        # Weight by the highest contributing domain (arg-max), then multiply
+        top_domain = max(event_obj.domains.items(), key=lambda kv: kv[1])[0]
+        mult = prof.domain_multipliers.get(top_domain, 1.0)
+        event_obj.severity = float(event_obj.severity) * float(mult)
+
+
+# >>> AUTO-GEN END: Engine Domain Injection v1.0
+
+
+def attach_domain_fields(event_obj: TransitEvent, ctx: Mapping[str, Any], *, resolver: Optional[DomainResolver] = None,
+                         overrides: Optional[Mapping[str, Mapping]] = None) -> None:
+    """Public helper that mirrors :func:`_attach_domain_fields` but exposes dependency injection."""
+
+    _attach_domain_fields(event_obj, ctx, resolver=resolver, overrides=overrides)
+
+
+def build_transit_event(
+    ctx: Mapping[str, Any] | MutableMapping[str, Any],
+    *,
+    emit_domains: bool = False,
+    resolver: Optional[DomainResolver] = None,
+    overrides: Optional[Mapping[str, Mapping]] = None,
+    base_event: Optional[TransitEvent] = None,
+) -> TransitEvent:
+    """Construct a :class:`TransitEvent` from a context mapping.
+
+    Parameters
+    ----------
+    ctx:
+        Mapping containing event metadata such as sign index, planet key, and
+        severity.  Callers are responsible for populating these values from
+        trusted runtime data sources.
+    emit_domains:
+        When ``True`` the function resolves the element/domain annotations and
+        applies the domain severity multiplier defined by the chosen profile.
+    resolver:
+        Optional resolver instance to use in place of the module singleton.
+    overrides:
+        Optional weights override payload forwarded to :class:`DomainResolver`.
+    base_event:
+        Optional pre-constructed :class:`TransitEvent` instance to decorate.
+    """
+
+    event = base_event or TransitEvent()
+    if "severity" in ctx:
+        try:
+            event.severity = float(ctx["severity"]) if ctx["severity"] is not None else None
+        except (TypeError, ValueError):
+            event.severity = None
+    if emit_domains:
+        ctx_with_profile = dict(ctx)
+        if "domain_profile" not in ctx_with_profile:
+            ctx_with_profile["domain_profile"] = "vca_neutral"
+        _attach_domain_fields(event, ctx_with_profile, resolver=resolver, overrides=overrides or ctx.get("domain_overrides"))
+    return event

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -1,0 +1,28 @@
+"""Exporter helpers for AstroEngine outputs."""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+__all__ = ["event_to_row", "_event_to_row"]
+
+
+# >>> AUTO-GEN BEGIN: Exporters Domain Fields v1.0
+# When writing SQLite or Parquet, include `elements`, `domains`, `domain_profile` if present on event.
+# Example for row dict assembly:
+
+def _event_to_row(event_obj: Any) -> Dict[str, Any]:
+    row = getattr(event_obj, "__dict__", {}).copy()
+    # Ensure optional fields exist; downstream schemas tolerate absence
+    row.setdefault("elements", [])
+    row.setdefault("domains", {})
+    row.setdefault("domain_profile", None)
+    return row
+
+
+def event_to_row(event_obj: Any) -> Dict[str, Any]:
+    """Public wrapper around :func:`_event_to_row` for external exporters."""
+
+    return _event_to_row(event_obj)
+
+# >>> AUTO-GEN END: Exporters Domain Fields v1.0

--- a/astroengine/profiles.py
+++ b/astroengine/profiles.py
@@ -1,0 +1,41 @@
+"""Profile definitions for domain scoring in AstroEngine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+__all__ = ["DomainScoringProfile", "VCA_DOMAIN_PROFILES"]
+
+# >>> AUTO-GEN BEGIN: VCA Domain Scoring Profile v1.0
+@dataclass(frozen=True)
+class DomainScoringProfile:
+    """Severity multipliers applied per domain after geometric severity is computed.
+    Values are ≥0.0. 1.0 = neutral.
+    """
+
+    name: str
+    domain_multipliers: Mapping[str, float]  # keys in DOMAINS
+
+
+# Sensible defaults; teams can add more via profile registry later.
+VCA_DOMAIN_PROFILES = {
+    "vca_neutral": DomainScoringProfile(
+        name="vca_neutral",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_mind_plus": DomainScoringProfile(
+        name="vca_mind_plus",
+        domain_multipliers={"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0},
+    ),
+    "vca_body_plus": DomainScoringProfile(
+        name="vca_body_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.25, "SPIRIT": 1.0},
+    ),
+    "vca_spirit_plus": DomainScoringProfile(
+        name="vca_spirit_plus",
+        domain_multipliers={"MIND": 1.0, "BODY": 1.0, "SPIRIT": 1.25},
+    ),
+}
+
+# >>> AUTO-GEN END: VCA Domain Scoring Profile v1.0

--- a/schemas/result_schema_v1.json
+++ b/schemas/result_schema_v1.json
@@ -384,9 +384,65 @@
           },
           "notes": {
             "type": "string"
+          },
+          "elements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "domains": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          },
+          "domain_profile": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         }
       }
+    }
+  },
+  "$defs": {
+    "result_v1_with_domains": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://astroengine/schemas/result_v1_with_domains.json",
+      "title": "AstroEngine Run Result (with Domains)",
+      "type": "object",
+      "properties": {
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "elements": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "domains": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "number"
+                }
+              },
+              "domain_profile": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "additionalProperties": true
+          }
+        }
+      },
+      "additionalProperties": true
     }
   }
 }

--- a/tests/acceptance/test_domain_acceptance_stub.py
+++ b/tests/acceptance/test_domain_acceptance_stub.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.skip("Acceptance test stub for domain tagging pipeline integration.")
+def test_domain_tagging_acceptance_stub():
+    """Placeholder acceptance test ensuring the suite tracks domain tagging flows."""
+
+    assert True

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+# >>> AUTO-GEN BEGIN: Tests Domains v1.0
+from astroengine.domains import ZODIAC_ELEMENT_MAP, DomainResolver
+
+
+def test_elements_triplicity_mapping():
+    # Aries..Pisces
+    assert ZODIAC_ELEMENT_MAP[0] == "FIRE"
+    assert ZODIAC_ELEMENT_MAP[1] == "EARTH"
+    assert ZODIAC_ELEMENT_MAP[2] == "AIR"
+    assert ZODIAC_ELEMENT_MAP[3] == "WATER"
+    assert ZODIAC_ELEMENT_MAP[10] == "AIR"   # Aquarius
+    assert ZODIAC_ELEMENT_MAP[11] == "WATER" # Pisces
+
+
+def test_domain_resolver_merges_and_normalizes():
+    r = DomainResolver()
+    # Mercury in Gemini 3rd house → MIND should dominate; elements FIRE/EARTH/AIR/WATER: AIR
+    res = r.resolve(sign_index=2, planet_key="mercury", house_index=3)
+    assert res.elements == ["AIR"]
+    assert res.domains
+    # top domain is MIND
+    top = max(res.domains, key=res.domains.get)
+    assert top == "MIND"
+# >>> AUTO-GEN END: Tests Domains v1.0
+
+
+def test_domain_resolver_respects_overrides():
+    resolver = DomainResolver()
+    overrides = {"planet_weights": {"mercury": {"SPIRIT": 5.0}}}
+    res = resolver.resolve(sign_index=2, planet_key="mercury", house_index=3, overrides=overrides)
+    assert res.domains.get("SPIRIT") == 1.0
+
+
+def test_domain_resolver_invalid_sign_raises():
+    resolver = DomainResolver()
+    with pytest.raises(ValueError):
+        resolver.resolve(sign_index=12, planet_key="sun")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import pytest
+
+from astroengine.api import TransitEvent
+from astroengine.engine import attach_domain_fields, build_transit_event
+
+
+def test_build_transit_event_applies_domain_multiplier():
+    ctx = {
+        "sign_index": 11,  # Pisces
+        "planet_key": "neptune",
+        "house_index": 12,
+        "severity": 2.0,
+        "domain_profile": "vca_spirit_plus",
+    }
+    event = build_transit_event(ctx, emit_domains=True)
+    assert event.elements == ["WATER"]
+    assert event.domain_profile == "vca_spirit_plus"
+    # Neptune (SPIRIT) in 12th (SPIRIT) should favour SPIRIT multiplier 1.25
+    assert event.severity == pytest.approx(2.5)
+
+
+def test_attach_domain_fields_noop_when_missing_keys():
+    event = TransitEvent(severity=1.0)
+    attach_domain_fields(event, {})
+    assert event.elements == []
+    assert event.domains == {}
+    assert event.domain_profile is None
+
+
+def test_build_transit_event_handles_invalid_severity():
+    ctx = {
+        "sign_index": 0,
+        "planet_key": "sun",
+        "severity": "not-a-number",
+    }
+    event = build_transit_event(ctx, emit_domains=False)
+    assert event.severity is None

--- a/tests/test_result_schema.py
+++ b/tests/test_result_schema.py
@@ -108,6 +108,14 @@ def test_result_schema_accepts_valid_payload():
     validate_payload("result_v1", payload)
 
 
+def test_result_schema_accepts_domain_annotations():
+    payload = _valid_result_payload()
+    payload["events"][0]["elements"] = ["FIRE"]
+    payload["events"][0]["domains"] = {"MIND": 1.0}
+    payload["events"][0]["domain_profile"] = "vca_neutral"
+    validate_payload("result_v1", payload)
+
+
 def test_result_schema_rejects_invalid_event_payload():
     payload = _valid_result_payload()
     broken = deepcopy(payload)


### PR DESCRIPTION
## Summary
- add a deterministic domain and element taxonomy with a resolver and VCA profiles
- extend the public API, engine pipeline, CLI, exporters, and result schema to surface domain metadata
- cover the new resolver and engine hooks with unit tests and add an acceptance test stub

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc8ff5486c8324a61c6a9d328b63c0