### PR TITLE
Add control plane specs for VCA outline closure

### DIFF
--- a/docs/ASPECT_PATTERNS_SPEC.md
+++ b/docs/ASPECT_PATTERNS_SPEC.md
@@ -1,0 +1,30 @@
+<!-- >>> AUTO-GEN BEGIN: Aspect Patterns v1.0 (instructions) -->
+Scope
+- Define and detect classic multi-leg patterns using existing aspect detections: Grand Trine, Kite, T-Square, Grand Cross, Mystic Rectangle, Yod, Thor's Hammer (Fist of God), Grand Sextile (Star of David), Grand Quintile/Septile/Novile (when harmonics enabled).
+
+General Rules
+- A pattern is present when **all required legs** exist within their **allowed orbs**, and the polygon **closes** within a small angular tolerance (closure_tol ≤ 2° by default).
+- Use the engine's orb policy for each leg; optionally apply a **pattern orb factor** (e.g., 0.9×) for tighter coherence.
+- Participants may be transiting→natal, natal↔natal (for natal pattern reference), or transit-only (rare; context timelines). Start with transiting body to natal points.
+
+Definitions (legs)
+- Grand Trine: 3 nodes linked by 3 × 120°.
+- Kite: Grand Trine + an **opposition** to one node; include the two **sextiles** to the opposing apex.
+- T-Square: 1 **opposition** with 2 **squares** to a third apex.
+- Grand Cross: 2 **oppositions** forming a cross, with 4 **squares** closing the loop.
+- Mystic Rectangle: 2 **oppositions** + 4 **sextiles** forming a rectangle.
+- Yod: 2 **quincunxes** to an apex + base **sextile** between the other two points.
+- Thor's Hammer: apex receives 2 **sesquisquares** (135°) with a **semisquare** (45°) between the base.
+- Grand Sextile: 6 points alternating **sextiles** and **trines** (rare; allow inset variants).
+- Grand *Harmonic* (5/7/9/11): 5/7/9/11 nodes linked by the respective harmonic aspects when H5/H7/H9/H11 are enabled.
+
+Scoring & Gating
+- **Pattern severity** = weighted mean of leg severities × **coherence factor** (1.0 at perfect closure; decays with closure error).
+- Gate when (a) all legs within orb, (b) coherence ≥ 0.8, and (c) at least one **outer planet** participates or a **natal angle** is a node. Partile on any leg auto-passes.
+
+Outputs
+- Emit a composite event carrying: pattern_name, nodes (ordered), legs (list of {body/point A, aspect, body/point B, orb}), apex (if defined), coherence, severity.
+
+Acceptance
+- Synthetic examples for each pattern pass; removing any leg breaks detection; tightening orbs increases coherence.
+<!-- >>> AUTO-GEN END: Aspect Patterns v1.0 (instructions) -->

--- a/docs/EASTPOINT_POLARASC_SPEC.md
+++ b/docs/EASTPOINT_POLARASC_SPEC.md
@@ -1,0 +1,17 @@
+<!-- >>> AUTO-GEN BEGIN: East Point & Polar Ascendant v1.0 (instructions) -->
+Definitions
+- **East Point (Equatorial Ascendant)**: the ecliptic point rising **due East** (azimuth = 90°) for the observer at the moment; compute via intersection of ecliptic with prime vertical at azimuth 90°.
+- **Polar Ascendant**: ecliptic intersection with the **prime vertical** at the meridian (north/south) for high latitudes; used as an alternate ascendant.
+
+Provider Requirements
+- Provide EP and PA longitudes given (t, lat, lon); document the frame conversions and refraction assumptions (none by default).
+
+Aspects & Orbs
+- Treat EP/PA as **angles**: use angle-tight orbs (≤3° majors, ≤1.5° minors).
+
+Gating & Outputs
+- Include contacts to transiting personals/outers; flag `is_angle_variant = true`, `angle_kind = EP|PA`.
+
+Acceptance
+- Cross-check EP vs known software for sample latitudes (±0.5° tolerance); PA available and stable at high latitudes.
+<!-- >>> AUTO-GEN END: East Point & Polar Ascendant v1.0 (instructions) -->

--- a/docs/GALACTIC_POINTS_SPEC.md
+++ b/docs/GALACTIC_POINTS_SPEC.md
@@ -1,0 +1,16 @@
+<!-- >>> AUTO-GEN BEGIN: Galactic Points v1.0 (instructions) -->
+Scope
+- Include **Galactic Center (GC)** and **Anti-Center**, and **Supergalactic Center (SGC)** and Anti-SGC as fixed reference points.
+
+Computation
+- Store RA/Dec (J2000) for GC and SGC (with provenance). Convert to ecliptic longitude for **date** using precession model; expose longitudes via provider utility.
+
+Orbs & Gating
+- Default orbs: GC/SGC conjunctions ≤ 1° (≤ 2° to angles). Include only when contacted by transiting outer planets or when the natal point is an angle/luminary.
+
+Outputs
+- `fixed_point: GC|Anti-GC|SGC|Anti-SGC`, method metadata, aspect info.
+
+Acceptance
+- Longitudes match reputable references within a small tolerance (≤ 0.1°) after precession.
+<!-- >>> AUTO-GEN END: Galactic Points v1.0 (instructions) -->

--- a/docs/HARMONIC_CHARTS_SPEC.md
+++ b/docs/HARMONIC_CHARTS_SPEC.md
@@ -1,0 +1,16 @@
+<!-- >>> AUTO-GEN BEGIN: Harmonic Charts v1.0 (instructions) -->
+Definition
+- The **N-th harmonic chart** transforms longitudes as λ_N = (N × λ_base) mod 360°, applied to all bodies/points in a source chart (natal or progressed). Aspects in base become **conjunctions** in the N-th harmonic.
+
+Profiles
+- Default OFF; enable per N for H5/H7/H9/H11. Provide orbit/visibility toggles and restrict to conjunctions/oppositions within the harmonic chart (optional extra aspects).
+
+Ruleset Hooks
+- Allow scanning transits **to** harmonic chart points (e.g., transiting outer to natal 5th harmonic Venus), or analyze harmonic chart patterns internally.
+
+Outputs
+- Attach `chart_kind: harmonic:N` to derived outputs; record base chart metadata and N used.
+
+Acceptance
+- Verify λ_N formula on sample points; quintile in base chart manifests as conjunction in H5, etc.
+<!-- >>> AUTO-GEN END: Harmonic Charts v1.0 (instructions) -->

--- a/docs/LILITH_PRIAPUS_SPEC.md
+++ b/docs/LILITH_PRIAPUS_SPEC.md
@@ -1,0 +1,19 @@
+<!-- >>> AUTO-GEN BEGIN: Lilith & Priapus v1.0 (instructions) -->
+Scope
+- Distinguish **Black Moon Lilith (BML)** from asteroid 1181 Lilith. Support **Mean** and **True (osculating)** BML; **Priapus** is the point opposite BML (180°).
+
+Provider Requirements
+- Expose mean/true BML longitudes for a given time; document source and method. Priapus = BML + 180° (normalized).
+
+Aspects & Orbs
+- Default: treat as personal-class for orbs (6° majors, 2° minors) with **conjunctions** prioritized (≤3° recommended). To angles/luminaries, tighten orbs by 0.5–1°.
+
+Gating
+- Include when BML/Priapus aspects natal luminaries, ASC/MC/IC/DSC, or Nodes. Partile conjunctions always pass.
+
+Outputs
+- `point_kind: BML_mean|BML_true|Priapus`, method metadata, aspect details, and notes distinguishing from asteroid 1181.
+
+Acceptance
+- Mean/True delta documented; Priapus computed exactly 180° apart; sample events generated for test windows.
+<!-- >>> AUTO-GEN END: Lilith & Priapus v1.0 (instructions) -->

--- a/docs/PLANETARY_PHASES_SPEC.md
+++ b/docs/PLANETARY_PHASES_SPEC.md
@@ -1,0 +1,20 @@
+<!-- >>> AUTO-GEN BEGIN: Planetary Phases v1.0 (instructions) -->
+Scope
+- Define **Morning/Evening star** states and **heliacal rising/setting** for Mercury and Venus (extend to others later). Use simplified elongation and altitude criteria with profile-tunable thresholds.
+
+Definitions
+- Morning Star: planet **west** of the Sun (rises before Sun). Evening Star: **east** of the Sun. Determine via ecliptic or apparent elongation sign.
+- Heliacal Rising: first visible rising after conjunction with the Sun; Heliacal Setting: last visible setting before conjunction.
+
+Thresholds (defaults, profile-tunable)
+- Minimum elongation for visibility: Mercury 12°, Venus 10°. Minimum altitude at civil twilight: ≥ 5°. Ignore atmospheric extinction by default.
+
+Gating
+- Add **phase flags** to events; allow severity multipliers (+5–10%) when a transit occurs while a planet is in Morning/Evening or around heliacal events (±3 days).
+
+Outputs
+- `phase: morning|evening`, `heliacal_event: rise|set|none`, timestamps if applicable, thresholds used.
+
+Acceptance
+- Sample windows match known phase transitions within 1–2 days using the simplified model.
+<!-- >>> AUTO-GEN END: Planetary Phases v1.0 (instructions) -->

--- a/docs/PRENATAL_ECLIPSE_SPEC.md
+++ b/docs/PRENATAL_ECLIPSE_SPEC.md
@@ -1,0 +1,16 @@
+<!-- >>> AUTO-GEN BEGIN: Prenatal Eclipses v1.0 (instructions) -->
+Scope
+- For each natal record, compute the nearest **preceding** (and optionally nearest following) solar and lunar eclipses (the "prenatal eclipse"). Store the exact time, degree, and Saros info if available.
+
+Triggers
+- Transit-to-natal checks against the **prenatal eclipse degree** (and its opposite) with tight orbs (≤1°; ≤2° to angles).
+
+Gating
+- Enable when `eclipses.prenatal.enabled = true` (default true). Always include transits to prenatal eclipse degree by outer planets; boost if to luminaries/angles.
+
+Outputs
+- `prenatal_eclipse`: {kind, exact_iso, degree, saros?}; event fields note `trigger = prenatal_eclipse`.
+
+Acceptance
+- Example natal dates reproduce published prenatal eclipses within minutes; transits at exact degree are detected.
+<!-- >>> AUTO-GEN END: Prenatal Eclipses v1.0 (instructions) -->

--- a/docs/README_CP_INDEX.md
+++ b/docs/README_CP_INDEX.md
@@ -1,0 +1,10 @@
+# Control Plane Specifications Index
+
+## VCA Outline Closure
+- [CP-SPEC-001 — Aspect Pattern Detectors](ASPECT_PATTERNS_SPEC.md)
+- [CP-SPEC-002 — Black Moon Lilith & Priapus](LILITH_PRIAPUS_SPEC.md)
+- [CP-SPEC-003 — East Point & Polar Ascendant](EASTPOINT_POLARASC_SPEC.md)
+- [CP-SPEC-004 — Prenatal Eclipse Triggers](PRENATAL_ECLIPSE_SPEC.md)
+- [CP-SPEC-005 — Planetary Phases (Heliacal & Morning/Evening)](PLANETARY_PHASES_SPEC.md)
+- [CP-SPEC-006 — Galactic & Supergalactic Points](GALACTIC_POINTS_SPEC.md)
+- [CP-SPEC-007 — Harmonic Charts (Derived)](HARMONIC_CHARTS_SPEC.md)


### PR DESCRIPTION
## Summary
- add seven new control plane spec documents that flesh out the remaining VCA outline items
- update the CP index to link to the new specs under a VCA Outline Closure section

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cc8eca8eb0832482352047c1e3cc60