### PR TITLE
Add CP-SPECS-100 documentation set

### DIFF
--- a/docs/ACCEPTANCE_TEST_MATRIX.md
+++ b/docs/ACCEPTANCE_TEST_MATRIX.md
@@ -1,0 +1,11 @@
+<!-- >>> AUTO-GEN BEGIN: Acceptance Matrix v1.0 (instructions) -->
+Catalog
+- BCE dates (e.g., −0044‑03‑15 Julius Caesar), Julian↔Gregorian boundary (1582‑10), DST ambiguous hour (fall‑back), leap seconds.
+- 359°↔1° continuity near aspect exacts; retro loops around stations.
+- High latitude houses (70°N), house fallback flag present.
+- Node choice effects (mean vs true) on draconic and eclipses.
+- Cross‑backend parity (Skyfield vs SWE) for Sun–Pluto over sampled windows.
+
+Outcomes
+- Each scenario specifies inputs, expected invariants, acceptable tolerances, and pass/fail rules.
+<!-- >>> AUTO-GEN END: Acceptance Matrix v1.0 (instructions) -->

--- a/docs/DATA_PROVENANCE_LICENSES.md
+++ b/docs/DATA_PROVENANCE_LICENSES.md
@@ -1,0 +1,12 @@
+<!-- >>> AUTO-GEN BEGIN: Data Provenance & Licensing v1.0 (instructions) -->
+Sources & Licenses
+- Skyfield + JPL DE data (JPL/NASA; public domain elements; cite versions).
+- Swiss Ephemeris (Astrodienst; proprietary/free for non‑commercial — document license terms clearly if used).
+- tzdb/zoneinfo, tzdata (IANA; public domain), timezonefinder (MIT).
+- OSM/Nominatim (ODbL/CC‑BY‑SA policies apply to data; follow usage policy).
+- Fixed stars: Hipparcos/Tycho/GAIA‑derived tables — confirm license; store source and transformation pipeline.
+
+Artifacts
+- Store checksums for ephemeris sets, star catalogs, rulesets, profiles.
+- Include LICENSE file snippets or links for each dataset; embed provenance block in exported artifacts.
+<!-- >>> AUTO-GEN END: Data Provenance & Licensing v1.0 (instructions) -->

--- a/docs/DRACONIC_SPEC.md
+++ b/docs/DRACONIC_SPEC.md
@@ -1,0 +1,13 @@
+<!-- >>> AUTO-GEN BEGIN: Draconic Zodiac v1.0 (instructions) -->
+Definition
+- Draconic longitude λ_d = (λ_tropical − Ω_NN) mod 360°, where Ω_NN is chosen (Mean Node default; profile can select True Node).
+- Property: North Node is always 0° Aries in draconic.
+
+Outputs
+- Provide alternate longitudes for bodies/points; export field: `coord.draconic.lon_deg`.
+- Profiles: `draconic.enabled` (default false), `draconic.node = mean|true`.
+
+Acceptance
+- Invariant: Node at 0° Aries; consistency check λ_tropical = (λ_d + Ω_NN) mod 360.
+- Example test: if tropical Sun = Ω_NN then draconic Sun = 0° Aries.
+<!-- >>> AUTO-GEN END: Draconic Zodiac v1.0 (instructions) -->

--- a/docs/ECLIPSE_LOCALITY_SPEC.md
+++ b/docs/ECLIPSE_LOCALITY_SPEC.md
@@ -1,0 +1,17 @@
+<!-- >>> AUTO-GEN BEGIN: Eclipse Locality v1.0 (instructions) -->
+Scope
+- Compute ground path (central line, umbra/penumbra) using Besselian elements for solar eclipses; great‑circle proximity for lunar.
+
+Inputs
+- Observer lat/lon (optional); eclipse catalog (provider) returning exacts + Besselian coefficients or precomputed paths.
+
+Rules
+- Distance‑to‑centerline weighting: severity_locality = clamp(1 − d/R, 0, 1) where R is penumbral radius at closest approach.
+- Time window: boost influences ±48h around local maximum; decay outside.
+
+Outputs
+- Add fields: `eclipse.local_distance_km`, `eclipse.path_class` (total/annular/partial), `locality_weight`.
+
+Acceptance
+- Sample eclipse (e.g., 2024‑04‑08) distances reproduce within ±50 km against NASA/USNO data.
+<!-- >>> AUTO-GEN END: Eclipse Locality v1.0 (instructions) -->

--- a/docs/HIGH_LAT_HOUSE_NUMERIC.md
+++ b/docs/HIGH_LAT_HOUSE_NUMERIC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: High-Latitude Fallbacks v1.0 (instructions) -->
+Rules
+- If Placidus/Topocentric fail (non‑real cusps) above |φ| ≥ 66°: fallback → Whole Sign; log `house_fallback = true` with `fallback_system = Whole Sign`.
+- Warning threshold: |φ| ≥ 61° emit advisory even if computation succeeds.
+
+Acceptance
+- Tests at 70°N and 75°S verify fallback triggers; outputs include warning flag; no crashes.
+<!-- >>> AUTO-GEN END: High-Latitude Fallbacks v1.0 (instructions) -->

--- a/docs/HOUSE_RULERS_DIGNITY_TABLES.md
+++ b/docs/HOUSE_RULERS_DIGNITY_TABLES.md
@@ -1,0 +1,21 @@
+<!-- >>> AUTO-GEN BEGIN: House Rulers & Dignities v1.0 (instructions) -->
+Rulerships
+- Traditional: Aries–Mars, Taurus–Venus, Gemini–Mercury, Cancer–Moon, Leo–Sun, Virgo–Mercury, Libra–Venus, Scorpio–Mars, Sagittarius–Jupiter, Capricorn–Saturn, Aquarius–Saturn, Pisces–Jupiter.
+- Modern adjuncts (profile toggle): Scorpio–Pluto, Aquarius–Uranus, Pisces–Neptune.
+
+Exaltations (classical)
+- Aries–Sun, Taurus–Moon, Cancer–Jupiter, Virgo–Mercury, Libra–Saturn, Capricorn–Mars, Pisces–Venus (document alternatives/contested placements).
+
+Triplicities by sect
+- Fire: Sun(day)/Jupiter(night)/Saturn(participating); Earth: Venus/Moon/Mars; Air: Saturn/Mercury/Jupiter; Water: Venus/Mars/Moon.
+
+Terms/Bounds
+- Default: Egyptian terms (primary). Alternative: Ptolemy (profile switch). Provide CSV with degree ranges per sign.
+
+Faces/Decans
+- Chaldean order; 10° sectors per sign; CSV with rulers.
+
+Deliverables
+- Machine‑readable tables (CSV/JSON) with provenance; profile toggles selecting variant sets.
+- Acceptance: Sum of term/face ranges equals 30° per sign; lookups deterministic.
+<!-- >>> AUTO-GEN END: House Rulers & Dignities v1.0 (instructions) -->

--- a/docs/LOCAL_SPACE_MATH.md
+++ b/docs/LOCAL_SPACE_MATH.md
@@ -1,0 +1,13 @@
+<!-- >>> AUTO-GEN BEGIN: Local-Space Math v1.0 (instructions) -->
+Local Space (Az/Alt)
+- Convert RA/Dec → horizontal coordinates using observer lat/lon and sidereal time; great‑circle azimuth paths from natal location.
+
+Astrocartography (A*C*G)
+- Lines for where a body is on ASC/DSC/MC/IC at given times; compute sub‑stellar points and great‑circle loci.
+
+Projections
+- Use WGS84; specify map projection (Web Mercator for web, equal‑area for analysis) and precision goals.
+
+Acceptance
+- Visual parity within line thickness compared to established references for one sample chart.
+<!-- >>> AUTO-GEN END: Local-Space Math v1.0 (instructions) -->

--- a/docs/PRECISION_TIMESCALE_POLICY.md
+++ b/docs/PRECISION_TIMESCALE_POLICY.md
@@ -1,0 +1,15 @@
+<!-- >>> AUTO-GEN BEGIN: Precision & Timescale v1.0 (instructions) -->
+Timescales
+- Internal eval: TT (Terrestrial Time). External I/O: UTC (ISO‑8601 Z). Provider may use TDB internally but returns TT‑consistent results.
+- ΔT source: Espenak‑Meeus fit for historical dates; JPL DE metadata for modern epoch; document version.
+
+Error Budgets (target max absolute longitudinal error at exacts)
+- Sun/Moon: ≤ 0.1″; inner planets: ≤ 0.5″; outer planets: ≤ 1.0″; Nodes: ≤ 6″.
+
+Refinement
+- Secant → bisection fallback; stop when |f| < 1e−6 deg or time step < 0.5 s.
+- Retro/station guards: avoid oscillation by bracketing across sign changes of speed.
+
+Acceptance
+- Cross‑backend parity within budgets on sampled windows; reproducible timestamps within ±1 s for exacts (non‑lunar), ±5 s (lunar).
+<!-- >>> AUTO-GEN END: Precision & Timescale v1.0 (instructions) -->

--- a/docs/PRIVACY_RETENTION_POLICY.md
+++ b/docs/PRIVACY_RETENTION_POLICY.md
@@ -1,0 +1,14 @@
+<!-- >>> AUTO-GEN BEGIN: Privacy & Retention v1.0 (instructions) -->
+PII
+- Prefer pseudonymous IDs; names optional; redact PII in exports by default; consent flags for shared datasets.
+
+Retention
+- Default retention 90 days for raw inputs; derived exports kept indefinitely with PII stripped.
+- Right to deletion: implement purge by `natal_id` and snapshot hash.
+
+Security
+- No secrets in repo; OIDC for releases; audit third‑party licenses.
+
+Acceptance
+- Dry‑run purge logs what would be removed; actual purge removes snapshots and exports by ID.
+<!-- >>> AUTO-GEN END: Privacy & Retention v1.0 (instructions) -->

--- a/docs/README_CP_INDEX.md
+++ b/docs/README_CP_INDEX.md
@@ -1,0 +1,15 @@
+# CP Specifications Index
+
+## CP-SPECS-100
+- [Vedic Layer v1.0](VEDIC_SPEC.md)
+- [Time-Lords v1.0](TIME_LORDS_SPEC.md)
+- [Draconic Zodiac v1.0](DRACONIC_SPEC.md)
+- [Eclipse Locality v1.0](ECLIPSE_LOCALITY_SPEC.md)
+- [House Rulers & Dignities v1.0](HOUSE_RULERS_DIGNITY_TABLES.md)
+- [Precision & Timescale v1.0](PRECISION_TIMESCALE_POLICY.md)
+- [Local-Space Math v1.0](LOCAL_SPACE_MATH.md)
+- [High-Latitude Fallbacks v1.0](HIGH_LAT_HOUSE_NUMERIC.md)
+- [Ruleset DSL Grammar v1.0](RULESET_DSL_GRAMMAR.md)
+- [Data Provenance & Licensing v1.0](DATA_PROVENANCE_LICENSES.md)
+- [Privacy & Retention v1.0](PRIVACY_RETENTION_POLICY.md)
+- [Acceptance Matrix v1.0](ACCEPTANCE_TEST_MATRIX.md)

--- a/docs/RULESET_DSL_GRAMMAR.md
+++ b/docs/RULESET_DSL_GRAMMAR.md
@@ -1,0 +1,31 @@
+<!-- >>> AUTO-GEN BEGIN: Ruleset DSL Grammar v1.0 (instructions) -->
+Grammar (sketch)
+- expr := or_expr
+- or_expr := and_expr { 'or' and_expr }
+- and_expr := unary_expr { 'and' unary_expr }
+- unary_expr := ['not'] primary
+- primary := literal | ident | call | '(' expr ')'
+- call := ident '(' [args] ')'
+- args := expr { ',' expr }
+- literal := number | string | list
+- list := '[' [expr { ',' expr }] ']'
+- comparators: == != < <= > >=
+- identifiers: [A-Za-z_][A-Za-z0-9_]*
+
+Types
+- number (float), string, bool, list, datetime (ISO string), enum (aspect names, bodies).
+
+Predicates (minimum set)
+- is_station, in_shadow, is_ingress, is_lunation, is_eclipse, is_cazimi/combust/under_beams,
+  is_oob/oob_transition, is_parallel/contraparallel, is_antiscia/contra_antiscia,
+  hit_midpoint, hit_fixed_star, near, within_orb, is_angle, has_dignity, is_day_chart, phase,
+  family_cap_per_day, family_cap_per_week.
+
+Errors & Lint
+- Unknown predicate, wrong arity, type mismatch, unreachable due to always‑true/false sub‑exprs, missing caps.
+
+Examples
+- family_cap_per_day(3) and ((aspect in [conjunction, opposition, square] and severity >= 0.65) or (aspect in [trine, sextile] and transiting_body in [Jupiter, Venus]))
+- is_station(Mercury, retro) or (is_ingress(Mars) and is_angle(natal_point))
+- is_lunation(full) and near(ASC, 3)
+<!-- >>> AUTO-GEN END: Ruleset DSL Grammar v1.0 (instructions) -->

--- a/docs/TIME_LORDS_SPEC.md
+++ b/docs/TIME_LORDS_SPEC.md
@@ -1,0 +1,20 @@
+<!-- >>> AUTO-GEN BEGIN: Time-Lords v1.0 (instructions) -->
+Scope
+- Zodiacal Releasing (ZR), Firdaria (day/night variants), Vimshottari (ref: VEDIC_SPEC) — as optional context timelines.
+
+Zodiacal Releasing (Lot of Spirit default)
+- Period lengths (years): Aries 15, Taurus 8, Gemini 20, Cancer 25, Leo 19, Virgo 20, Libra 8, Scorpio 15, Sagittarius 12, Capricorn 27, Aquarius 30, Pisces 12.
+- Levels L1–L4: recursive subdivision by the same sign sequence; distribute proportionally by sign length.
+- Inputs: lot_degree (Fortune/Spirit), zodiac = Tropical or Sidereal per profile; house system for sign lord optional.
+- Outputs: spans with level, sign, lord, start/end ISO; angle hits flagged when releasing into sign containing ASC/MC/IC/DSC.
+
+Firdaria
+- Day charts start with Sun; night charts with Moon. Sequence and sub‑periods per tradition.
+- Deliverable: table of spans w/ lords; profile toggles for variant tables.
+
+Gate Usage
+- Provide context flags used in scoring (e.g., +10% when transit hits current L1 lord; +5% for L2).
+
+Acceptance
+- L1 spans sum to lifetime window; nesting continuity (no gaps); published examples reproduced within 1 day.
+<!-- >>> AUTO-GEN END: Time-Lords v1.0 (instructions) -->

--- a/docs/VEDIC_SPEC.md
+++ b/docs/VEDIC_SPEC.md
@@ -1,0 +1,29 @@
+<!-- >>> AUTO-GEN BEGIN: Vedic Layer v1.0 (instructions) -->
+Scope
+- Nakshatras (27), padas (108), Vimshottari dasha timeline, Panchānga (tithi/yoga/karana/vāra) as optional context flags.
+- Ayanamsha choice required (default: Lahiri); all sidereal calculations use chosen ayanamsha.
+
+Nakshatras
+- Segment: 13°20′ each; padas: 3°20′ each.
+- Calculation: sidereal_long = tropical_long − ayanamsha; idx = floor(sidereal_long / 13°20′).
+- Output: nakshatra_name, pada (1–4), lord (per Vimshottari), exact bounds (deg), distance_to_center (deg).
+- Acceptance: Spot-check 0° Aries (sidereal) = Ashwini 1; 26°40′ Pisces (sidereal) = Revati 4.
+
+Vimshottari Dasha (120 years)
+- Sequence & years: Ketu 7, Venus 20, Sun 6, Moon 10, Mars 7, Rahu 18, Jupiter 16, Saturn 19, Mercury 17 (cycle repeats).
+- Start: dasha_lord of natal Moon’s nakshatra; proportion remaining by Moon’s pada remainder.
+- Levels: Maha (D1) → Antar (D2) → Pratyantar (D3) → Sukshma (D4) → Prana (D5) (optional deeper levels).
+- Output: list of spans with start/end ISO, level, lord.
+- Acceptance: Timeline total spans add to 120y; continuity across level boundaries.
+
+Panchānga flags (optional)
+- Tithi: floor((Moon−Sun) / 12°) + 1 (1–30). Yoga: floor((Moon+Sun) / 13°20′) + 1 (1–27). Karana: half‑tithis.
+- Vāra (weekday): from timezone‑aware local time.
+- Gate usage: allow boosters for transits aligning with active dasha lord or nakshatra lord.
+
+Profiles & Toggles
+- `vedic.enabled` (default false), `ayanamsha` (Lahiri default), `dasha.levels` (1–5), `panchanga.flags:true|false`.
+
+Interoperability
+- Export additional fields under `context.vedic`: nakshatra, pada, dasha_level/lord, panchanga.
+<!-- >>> AUTO-GEN END: Vedic Layer v1.0 (instructions) -->


### PR DESCRIPTION
## Summary
- add CP-SPECS-100 specifications for Vedic calculations, time-lord frameworks, draconic coordinates, eclipse locality, dignity tables, precision policy, local-space math, house fallbacks, ruleset grammar, data provenance, privacy, and acceptance testing
- create a CP specifications index linking the new documents

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68cc8d47bcd08324843a1f11dccee519