### PR TITLE
Add AstroEngine runtime modules and regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+src/astroengine.egg-info/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# AstroEngine
+
+AstroEngine provides a modular astrology computation framework organised by module → submodule → channel → subchannel. The
+engine is driven by YAML rulesets, allowing analysts to swap or extend behaviours without modifying the runtime code. The
+current implementation includes contact gating, timelord sequencing, directions/progressions, and synastry composite
+pipelines, all designed to work with deterministic, real-world datasets exported from SolarFire and other charting suites.
+
+Key goals:
+
+- **Data integrity** – every computed output is traceable to the source data and configuration that produced it.
+- **Extensibility** – new modules and datasets can be registered via the ruleset without replacing existing code.
+- **Deterministic testing** – regression fixtures validate each computation path to guard against regressions.
+
+Refer to `docs/astroengine.md` for detailed usage instructions.

--- a/docs/astroengine.md
+++ b/docs/astroengine.md
@@ -1,0 +1,86 @@
+# AstroEngine Runtime Guide
+
+AstroEngine organises computational features into a four-level hierarchy:
+
+1. **Module** – top-level capability family (e.g., `gating`, `timelords`, `directions_progressions`, `synastry_composite`).
+2. **Submodule** – specific implementation of a capability (e.g., `contact_gating_v2`).
+3. **Channel** – data wiring context (e.g., `natal_to_transit`).
+4. **Subchannel** – fine-grained variation or dataset slice (e.g., `default`).
+
+A YAML ruleset declares which submodules are available and how they should be wired. The engine resolves the correct
+implementation at runtime, injects the channel/subchannel configuration, and produces deterministic outputs backed by the
+supplied datasets.
+
+## Ruleset structure
+
+```yaml
+version: 0.1.0
+modules:
+  gating:
+    submodules:
+      contact_gating_v2:
+        channels:
+          natal_to_transit:
+            subchannels:
+              default:
+                hard_vetoes:
+                  - id: combustion
+                    conditions:
+                      - column: angular_distance
+                        op: lt
+                        value: 8
+                dampeners:
+                  - id: retrograde_mercury
+                    factor: 0.5
+                    conditions:
+                      - column: retrograde
+                        op: eq
+                        value: true
+                boosters:
+                  - id: reception
+                    factor: 1.25
+                    conditions:
+                      - column: reception
+                        op: eq
+                        value: true
+        outputs:
+          state_table: tables/contact_gate_states.parquet
+```
+
+Each submodule can define `outputs`, which the engine resolves relative to the working directory.
+
+## Engine usage
+
+```python
+from astroengine.core.engine import AstroEngine
+from pathlib import Path
+
+engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"))
+
+payload = {
+    "module": "gating",
+    "submodule": "contact_gating_v2",
+    "channel": "natal_to_transit",
+    "subchannel": "default",
+    "data": {
+        "contacts": contacts_dataframe,
+    },
+}
+
+result = engine.run(payload)
+print(result.state_summary)
+```
+
+## Connectors
+
+Dataset connectors translate filesystem assets (CSV, Parquet, or SQLite) into pandas data frames. Custom connectors can be
+registered by passing a mapping of names to callables when constructing the engine. Built-in connectors are defined in
+`astroengine.connectors` and are safe to extend without modifying existing implementations.
+
+## Outputs
+
+- `tables/contact_gate_states.parquet` – gating state transitions written by `ContactGatingV2`.
+- Timelord calculations and directions/progressions return structured pandas data frames for downstream analytics.
+- Synastry composite pipelines emit a `CompositeTransitResult` dataclass describing hits and supporting metadata.
+
+All outputs are derived directly from inputs; the engine never fabricates data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "astroengine"
+version = "0.1.0"
+description = "Modular astrology computation engine with gating, timelords, directions, and synastry pipelines."
+authors = [{name = "AstroEngine Team"}]
+dependencies = [
+    "pandas>=2.0",
+    "numpy>=1.24",
+    "pyarrow>=10.0",
+    "pyyaml>=6.0",
+]
+readme = "README.md"
+requires-python = ">=3.9"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/rulesets/vca_astroengine_master.yaml
+++ b/rulesets/vca_astroengine_master.yaml
@@ -1,0 +1,115 @@
+version: 0.1.0
+modules:
+  gating:
+    submodules:
+      contact_gating_v2:
+        description: Contact gating with hard vetoes, dampeners, and boosters.
+        channels:
+          natal_to_transit:
+            subchannels:
+              default:
+                hard_vetoes:
+                  - id: combustion
+                    description: "Veto conjunctions where angular distance is under 8 degrees"
+                    conditions:
+                      - column: angular_distance
+                        op: lt
+                        value: 8
+                  - id: under_orb
+                    description: "Reject contacts below minimum orb requirement"
+                    conditions:
+                      - column: orb
+                        op: lt
+                        value: 0.1
+                dampeners:
+                  - id: malefic_square
+                    factor: 0.5
+                    conditions:
+                      - column: aspect
+                        op: eq
+                        value: square
+                      - column: malefic_involved
+                        op: eq
+                        value: true
+                boosters:
+                  - id: benefic_trine
+                    factor: 1.25
+                    conditions:
+                      - column: aspect
+                        op: eq
+                        value: trine
+                      - column: benefic_involved
+                        op: eq
+                        value: true
+        outputs:
+          state_table: tables/contact_gate_states.parquet
+  timelords:
+    submodules:
+      timelords:
+        description: Time-lord scheduling including zodiacal releasing and annual profections.
+        channels:
+          releasing:
+            subchannels:
+              lot_of_spirit:
+                base_periods:
+                  Aries: 15
+                  Taurus: 8
+                  Gemini: 20
+                  Cancer: 25
+                  Leo: 19
+                  Virgo: 20
+                  Libra: 8
+                  Scorpio: 15
+                  Sagittarius: 12
+                  Capricorn: 27
+                  Aquarius: 30
+                  Pisces: 12
+          profections:
+            subchannels:
+              annual:
+                zodiac_sequence:
+                  - Aries
+                  - Taurus
+                  - Gemini
+                  - Cancer
+                  - Leo
+                  - Virgo
+                  - Libra
+                  - Scorpio
+                  - Sagittarius
+                  - Capricorn
+                  - Aquarius
+                  - Pisces
+  directions_progressions:
+    submodules:
+      directions_progressions:
+        description: Implements Ptolemaic primary directions and secondary progressions.
+        channels:
+          primary_directions:
+            subchannels:
+              default:
+                aspects:
+                  conjunction: 0
+                  sextile: 60
+                  square: 90
+                  trine: 120
+                  opposition: 180
+                orb: 3
+                rate_degrees_per_year: 1
+          secondary_progressions:
+            subchannels:
+              solar_arc:
+                motion_rate_degrees_per_year: 1
+  synastry_composite:
+    submodules:
+      synastry_composite:
+        description: Composite chart generator and transit matcher.
+        channels:
+          composite_transits:
+            subchannels:
+              default:
+                orb: 2
+                tracked_points:
+                  - Sun
+                  - Moon
+                  - Ascendant

--- a/src/astroengine/__init__.py
+++ b/src/astroengine/__init__.py
@@ -1,0 +1,23 @@
+"""AstroEngine public API exports."""
+
+from .core.engine import AstroEngine, EngineRequest
+from .directions_progressions import (
+    PrimaryDirectionCalculator,
+    SecondaryProgressionCalculator,
+)
+from .gating.contact_gating_v2 import ContactGateResult, ContactGatingV2
+from .synastry_composite import CompositeTransitPipeline, CompositeTransitResult
+from .timelords import ProfectionCalculator, ZodiacalReleasingCalculator
+
+__all__ = [
+    "AstroEngine",
+    "EngineRequest",
+    "ContactGatingV2",
+    "ContactGateResult",
+    "ZodiacalReleasingCalculator",
+    "ProfectionCalculator",
+    "PrimaryDirectionCalculator",
+    "SecondaryProgressionCalculator",
+    "CompositeTransitPipeline",
+    "CompositeTransitResult",
+]

--- a/src/astroengine/connectors/__init__.py
+++ b/src/astroengine/connectors/__init__.py
@@ -1,0 +1,19 @@
+"""Dataset connectors for AstroEngine."""
+
+from .base import (
+    ConnectorRegistry,
+    DatasetConnector,
+    DEFAULT_CONNECTORS,
+    csv_connector,
+    parquet_connector,
+    sqlite_connector,
+)
+
+__all__ = [
+    "ConnectorRegistry",
+    "DatasetConnector",
+    "DEFAULT_CONNECTORS",
+    "csv_connector",
+    "parquet_connector",
+    "sqlite_connector",
+]

--- a/src/astroengine/connectors/base.py
+++ b/src/astroengine/connectors/base.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Mapping, Protocol
+
+import pandas as pd
+
+
+class DatasetConnector(Protocol):
+    """Protocol for connectors that load tabular data into pandas."""
+
+    def __call__(self, location: Path) -> pd.DataFrame:  # pragma: no cover - protocol definition
+        ...
+
+
+@dataclass
+class ConnectorRegistry:
+    """Registry mapping connector names to callables.
+
+    The registry ships with connectors for CSV, Parquet, and SQLite (via pandas). Additional
+    connectors can be supplied at engine construction time.
+    """
+
+    connectors: Mapping[str, DatasetConnector]
+
+    def resolve(self, name: str) -> DatasetConnector:
+        try:
+            return self.connectors[name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Connector '{name}' is not registered") from exc
+
+    def with_overrides(self, overrides: Mapping[str, DatasetConnector]) -> "ConnectorRegistry":
+        merged: Dict[str, DatasetConnector] = dict(self.connectors)
+        merged.update(overrides)
+        return ConnectorRegistry(merged)
+
+
+def csv_connector(path: Path) -> pd.DataFrame:
+    return pd.read_csv(path)
+
+
+def parquet_connector(path: Path) -> pd.DataFrame:
+    return pd.read_parquet(path)
+
+
+def sqlite_connector(path: Path) -> pd.DataFrame:
+    import sqlite3
+
+    with sqlite3.connect(path) as conn:
+        # Expecting a table named "data"; callers can copy views as needed.
+        return pd.read_sql("SELECT * FROM data", conn)
+
+
+DEFAULT_CONNECTORS = ConnectorRegistry(
+    {
+        "csv": csv_connector,
+        "parquet": parquet_connector,
+        "sqlite": sqlite_connector,
+    }
+)

--- a/src/astroengine/core/__init__.py
+++ b/src/astroengine/core/__init__.py
@@ -1,0 +1,5 @@
+"""Core runtime package."""
+
+from .engine import AstroEngine, EngineRequest
+
+__all__ = ["AstroEngine", "EngineRequest"]

--- a/src/astroengine/core/engine.py
+++ b/src/astroengine/core/engine.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping, Tuple
+
+import pandas as pd
+import yaml
+
+from ..connectors import ConnectorRegistry, DEFAULT_CONNECTORS
+from ..directions_progressions import (
+    PrimaryDirectionCalculator,
+    SecondaryProgressionCalculator,
+)
+from ..gating.contact_gating_v2 import ContactGatingV2, ContactGateResult
+from ..synastry_composite import CompositeTransitPipeline, CompositeTransitResult
+from ..timelords import ProfectionCalculator, ZodiacalReleasingCalculator
+
+
+@dataclass
+class EngineRequest:
+    module: str
+    submodule: str
+    channel: str
+    subchannel: str
+    data: Mapping[str, Any] | None = None
+    datasets: Tuple[Mapping[str, Any], ...] | None = None
+
+
+class AstroEngine:
+    """Runtime orchestrator that loads modules based on the ruleset configuration."""
+
+    def __init__(
+        self,
+        ruleset_path: Path,
+        *,
+        output_root: Path | None = None,
+        connectors: ConnectorRegistry | None = None,
+    ) -> None:
+        self.ruleset_path = Path(ruleset_path)
+        self.ruleset = self._load_ruleset(self.ruleset_path)
+        self.output_root = Path(output_root) if output_root else Path('.')
+        self.connectors = connectors or DEFAULT_CONNECTORS
+        self._registry = self._index_submodules(self.ruleset.get("modules", {}))
+
+    @staticmethod
+    def _load_ruleset(path: Path) -> Mapping[str, Any]:
+        with path.open("r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+
+    def _index_submodules(self, modules: Mapping[str, Any]) -> Dict[Tuple[str, str], Mapping[str, Any]]:
+        registry: Dict[Tuple[str, str], Mapping[str, Any]] = {}
+        for module_name, module_cfg in modules.items():
+            for submodule_name, submodule_cfg in module_cfg.get("submodules", {}).items():
+                registry[(module_name, submodule_name)] = submodule_cfg
+        return registry
+
+    def run(self, request: EngineRequest | Mapping[str, Any]) -> Any:
+        payload = EngineRequest(**request) if isinstance(request, Mapping) else request
+        submodule_cfg = self._registry[(payload.module, payload.submodule)]
+        channel_cfg = self._resolve_channel(submodule_cfg, payload.channel, payload.subchannel)
+        resolved_data = self._prepare_data(payload)
+
+        if payload.module == "gating" and payload.submodule == "contact_gating_v2":
+            return self._run_contact_gating(submodule_cfg, channel_cfg, resolved_data)
+        if payload.module == "timelords":
+            return self._run_timelords(channel_cfg, resolved_data)
+        if payload.module == "directions_progressions":
+            return self._run_directions(submodule_cfg, channel_cfg, resolved_data)
+        if payload.module == "synastry_composite":
+            return self._run_synastry(channel_cfg, resolved_data)
+        raise KeyError(f"Unsupported module '{payload.module}'")
+
+    def _prepare_data(self, request: EngineRequest) -> MutableMapping[str, Any]:
+        resolved: MutableMapping[str, Any] = {}
+        if request.datasets:
+            for entry in request.datasets:
+                connector_name = entry["connector"]
+                alias = entry["alias"]
+                location = Path(entry["path"])
+                loader = self.connectors.resolve(connector_name)
+                resolved[alias] = loader(location)
+        if request.data:
+            resolved.update(request.data)
+        return resolved
+
+    @staticmethod
+    def _resolve_channel(submodule_cfg: Mapping[str, Any], channel: str, subchannel: str) -> Mapping[str, Any]:
+        channels = submodule_cfg.get("channels", {})
+        channel_cfg = channels[channel]
+        subchannel_cfg = channel_cfg.get("subchannels", {})[subchannel]
+        return subchannel_cfg
+
+    def _run_contact_gating(
+        self,
+        submodule_cfg: Mapping[str, Any],
+        channel_cfg: Mapping[str, Any],
+        data: Mapping[str, Any],
+    ) -> ContactGateResult:
+        output_rel = submodule_cfg.get("outputs", {}).get("state_table", "tables/contact_gate_states.parquet")
+        output_path = (self.output_root / output_rel).resolve()
+        contacts = self._ensure_dataframe(data.get("contacts"), "contacts")
+        gating = ContactGatingV2(channel_cfg, output_path)
+        return gating.process(contacts)
+
+    def _run_timelords(self, channel_cfg: Mapping[str, Any], data: Mapping[str, Any]) -> Dict[str, pd.DataFrame]:
+        results: Dict[str, pd.DataFrame] = {}
+        if "base_periods" in channel_cfg:
+            calculator = ZodiacalReleasingCalculator(channel_cfg["base_periods"])
+            start_sign = data["start_sign"]
+            start_date = data["start_date"]
+            spans = data.get("spans", 4)
+            results["zodiacal_releasing"] = calculator.compute(start_sign, start_date, spans)
+        if "zodiac_sequence" in channel_cfg:
+            calculator = ProfectionCalculator(channel_cfg["zodiac_sequence"])
+            ascendant_sign = data["ascendant_sign"]
+            years = data.get("years", 12)
+            results["profections"] = calculator.tabulate(ascendant_sign, years)
+        return results
+
+    def _run_directions(
+        self,
+        submodule_cfg: Mapping[str, Any],
+        channel_cfg: Mapping[str, Any],
+        data: Mapping[str, Any],
+    ) -> Dict[str, Any]:
+        results: Dict[str, Any] = {}
+        if "aspects" in channel_cfg:
+            calculator = PrimaryDirectionCalculator(
+                channel_cfg["aspects"],
+                channel_cfg.get("orb", 1.0),
+                channel_cfg.get("rate_degrees_per_year", 1.0),
+            )
+            positions = data["positions"]
+            pairs = data.get("pairs", [])
+            results["primary_directions"] = calculator.compute(positions, pairs)
+        if "motion_rate_degrees_per_year" in channel_cfg:
+            calculator = SecondaryProgressionCalculator(channel_cfg["motion_rate_degrees_per_year"])
+            positions = data["positions"]
+            years = data.get("years", range(0, 3))
+            results["secondary_progressions"] = calculator.tabulate(positions, years)
+        return results
+
+    def _run_synastry(self, channel_cfg: Mapping[str, Any], data: Mapping[str, Any]) -> CompositeTransitResult:
+        pipeline = CompositeTransitPipeline(channel_cfg["orb"], channel_cfg.get("tracked_points", []))
+        natal_a = data["natal_a"]
+        natal_b = data["natal_b"]
+        transits = data["transits"]
+        return pipeline.run(natal_a, natal_b, transits)
+
+    @staticmethod
+    def _ensure_dataframe(value: Any, name: str) -> pd.DataFrame:
+        if isinstance(value, pd.DataFrame):
+            return value
+        raise TypeError(f"Expected pandas.DataFrame for '{name}', received {type(value)!r}")
+
+
+__all__ = ["AstroEngine", "EngineRequest"]

--- a/src/astroengine/directions_progressions.py
+++ b/src/astroengine/directions_progressions.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+
+@dataclass
+class DirectionEvent:
+    aspect: str
+    significator: str
+    promissor: str
+    orb: float
+    exact_degrees: float
+    event_age: float
+
+
+class PrimaryDirectionCalculator:
+    """Compute simplified Ptolemaic primary directions."""
+
+    def __init__(self, aspects: Dict[str, float], orb: float, rate_degrees_per_year: float):
+        self.aspects = aspects
+        self.orb = orb
+        self.rate = rate_degrees_per_year
+
+    def compute(self, positions: Dict[str, float], pairs: Iterable[Dict[str, str]]) -> pd.DataFrame:
+        events: List[DirectionEvent] = []
+        for pair in pairs:
+            significator = pair["significator"]
+            promissor = pair["promissor"]
+            sig_pos = positions[significator]
+            prom_pos = positions[promissor]
+            separation = (prom_pos - sig_pos) % 360
+            for aspect_name, aspect_degrees in self.aspects.items():
+                delta = self._angular_delta(separation, aspect_degrees)
+                if abs(delta) <= self.orb:
+                    age = (aspect_degrees - separation) / self.rate
+                    age = age % (360 / self.rate)
+                    events.append(
+                        DirectionEvent(
+                            aspect=aspect_name,
+                            significator=significator,
+                            promissor=promissor,
+                            orb=abs(delta),
+                            exact_degrees=aspect_degrees,
+                            event_age=age,
+                        )
+                    )
+        return pd.DataFrame([e.__dict__ for e in events])
+
+    @staticmethod
+    def _angular_delta(actual: float, target: float) -> float:
+        delta = (actual - target + 180) % 360 - 180
+        return delta
+
+
+class SecondaryProgressionCalculator:
+    """Linear secondary progression model (one degree per year by default)."""
+
+    def __init__(self, motion_rate_degrees_per_year: float):
+        self.motion_rate = motion_rate_degrees_per_year
+
+    def progress(self, positions: Dict[str, float], years: float) -> Dict[str, float]:
+        progressed = {}
+        for body, degree in positions.items():
+            progressed[body] = (degree + years * self.motion_rate) % 360
+        return progressed
+
+    def tabulate(self, positions: Dict[str, float], years: Iterable[int]) -> pd.DataFrame:
+        records = []
+        for year in years:
+            progressed = self.progress(positions, year)
+            for body, degree in progressed.items():
+                records.append({"year": year, "body": body, "degree": degree})
+        return pd.DataFrame.from_records(records)
+
+
+__all__ = [
+    "PrimaryDirectionCalculator",
+    "SecondaryProgressionCalculator",
+]

--- a/src/astroengine/gating/__init__.py
+++ b/src/astroengine/gating/__init__.py
@@ -1,0 +1,5 @@
+"""Gating submodule exports."""
+
+from .contact_gating_v2 import ContactGateResult, ContactGatingV2
+
+__all__ = ["ContactGatingV2", "ContactGateResult"]

--- a/src/astroengine/gating/contact_gating_v2.py
+++ b/src/astroengine/gating/contact_gating_v2.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+import pandas as pd
+
+
+@dataclass
+class Condition:
+    """Column comparison used in gating rules."""
+
+    column: str
+    op: str
+    value: object
+
+    def matches(self, frame: pd.DataFrame) -> pd.Series:
+        if self.column not in frame.columns:
+            raise KeyError(f"Column '{self.column}' required by gating condition is missing from contacts table")
+
+        series = frame[self.column]
+        if self.op == "eq":
+            return series == self._cast(series)
+        if self.op == "neq":
+            return series != self._cast(series)
+        if self.op == "lt":
+            return series < self._cast(series)
+        if self.op == "lte":
+            return series <= self._cast(series)
+        if self.op == "gt":
+            return series > self._cast(series)
+        if self.op == "gte":
+            return series >= self._cast(series)
+        raise ValueError(f"Unsupported condition operator '{self.op}'")
+
+    def _cast(self, series: pd.Series):
+        if pd.api.types.is_bool_dtype(series):
+            if isinstance(self.value, str):
+                return self.value.lower() == "true"
+            return bool(self.value)
+        if pd.api.types.is_numeric_dtype(series):
+            return float(self.value)
+        return self.value
+
+
+@dataclass
+class Rule:
+    rule_id: str
+    rule_type: str
+    factor: float = 1.0
+    conditions: Sequence[Condition] = field(default_factory=list)
+    description: str | None = None
+
+    def applies(self, frame: pd.DataFrame) -> pd.Series:
+        mask = pd.Series(True, index=frame.index, dtype="bool")
+        for condition in self.conditions:
+            mask &= condition.matches(frame)
+        return mask
+
+
+@dataclass
+class ContactGateResult:
+    state_table: pd.DataFrame
+    summary: Dict[str, int]
+
+
+class ContactGatingV2:
+    """Evaluate contact gating rules and persist state transitions."""
+
+    def __init__(self, rules: Dict[str, Iterable[Dict[str, object]]], output_path: Path):
+        self.hard_vetoes = self._build_rules(rules.get("hard_vetoes", []), "hard_veto")
+        self.dampeners = self._build_rules(rules.get("dampeners", []), "dampener")
+        self.boosters = self._build_rules(rules.get("boosters", []), "booster")
+        self.output_path = output_path
+
+    @staticmethod
+    def _build_rules(raw_rules: Iterable[Dict[str, object]], rule_type: str) -> List[Rule]:
+        rules: List[Rule] = []
+        for raw in raw_rules:
+            conditions = [
+                Condition(
+                    column=str(item["column"]),
+                    op=str(item["op"]),
+                    value=item.get("value"),
+                )
+                for item in raw.get("conditions", [])
+            ]
+            rules.append(
+                Rule(
+                    rule_id=str(raw.get("id")),
+                    rule_type=rule_type,
+                    factor=float(raw.get("factor", 0.0 if rule_type == "hard_veto" else 1.0)),
+                    description=raw.get("description"),
+                    conditions=conditions,
+                )
+            )
+        return rules
+
+    def process(self, contacts: pd.DataFrame) -> ContactGateResult:
+        working = contacts.copy()
+        if "base_score" not in working.columns:
+            working["base_score"] = 1.0
+        working["multiplier"] = 1.0
+        working["state"] = "open"
+        working["rules_applied"] = [[] for _ in range(len(working))]
+
+        for rule in self.hard_vetoes:
+            mask = rule.applies(working)
+            if mask.any():
+                working.loc[mask, "state"] = "vetoed"
+                working.loc[mask, "multiplier"] = 0.0
+                self._append_reason(working, mask, f"veto:{rule.rule_id}")
+
+        active_mask = working["state"] != "vetoed"
+        for rule in self.dampeners:
+            mask = rule.applies(working) & active_mask
+            if mask.any():
+                working.loc[mask, "state"] = "dampened"
+                working.loc[mask, "multiplier"] *= rule.factor
+                self._append_reason(working, mask, f"dampener:{rule.rule_id}")
+
+        for rule in self.boosters:
+            mask = rule.applies(working) & active_mask
+            if mask.any():
+                states = working.loc[mask, "state"].where(lambda s: s != "open", other="boosted")
+                working.loc[mask, "state"] = states
+                working.loc[mask, "multiplier"] *= rule.factor
+                self._append_reason(working, mask, f"booster:{rule.rule_id}")
+
+        working["final_score"] = working["base_score"] * working["multiplier"]
+
+        summary = working["state"].value_counts().to_dict()
+        self._write_output(working)
+        return ContactGateResult(working, summary)
+
+    def _write_output(self, frame: pd.DataFrame) -> None:
+        self.output_path.parent.mkdir(parents=True, exist_ok=True)
+        frame.to_parquet(self.output_path, index=False)
+
+    @staticmethod
+    def _append_reason(frame: pd.DataFrame, mask: pd.Series, reason: str) -> None:
+        for idx in frame.index[mask]:
+            reasons = list(frame.at[idx, "rules_applied"])
+            reasons.append(reason)
+            frame.at[idx, "rules_applied"] = reasons
+
+
+__all__ = ["ContactGatingV2", "ContactGateResult"]

--- a/src/astroengine/synastry_composite.py
+++ b/src/astroengine/synastry_composite.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+
+@dataclass
+class CompositePoint:
+    name: str
+    degree: float
+
+
+@dataclass
+class CompositeTransitHit:
+    transit_body: str
+    composite_point: str
+    orb: float
+    exact: float
+
+
+@dataclass
+class CompositeTransitResult:
+    composite_points: List[CompositePoint]
+    hits: List[CompositeTransitHit]
+
+
+class CompositeChartCalculator:
+    """Derive midpoint composite points between two natal charts."""
+
+    def compute(self, chart_a: Dict[str, float], chart_b: Dict[str, float], tracked_points: Iterable[str]) -> List[CompositePoint]:
+        points: List[CompositePoint] = []
+        for point in tracked_points:
+            if point not in chart_a or point not in chart_b:
+                raise KeyError(f"Point '{point}' missing from natal charts")
+            degree = (chart_a[point] + chart_b[point]) / 2.0
+            points.append(CompositePoint(point, degree % 360))
+        return points
+
+
+class CompositeTransitPipeline:
+    """Match transits against composite points within a configurable orb."""
+
+    def __init__(self, orb: float, tracked_points: Iterable[str]):
+        self.orb = orb
+        self.tracked_points = list(tracked_points)
+        self.chart_calculator = CompositeChartCalculator()
+
+    def run(
+        self,
+        natal_a: Dict[str, float],
+        natal_b: Dict[str, float],
+        transits: Dict[str, float],
+    ) -> CompositeTransitResult:
+        composite_points = self.chart_calculator.compute(natal_a, natal_b, self.tracked_points)
+        hits: List[CompositeTransitHit] = []
+        for transit_body, transit_degree in transits.items():
+            for point in composite_points:
+                orb = self._orb_difference(transit_degree, point.degree)
+                if orb <= self.orb:
+                    hits.append(
+                        CompositeTransitHit(
+                            transit_body=transit_body,
+                            composite_point=point.name,
+                            orb=orb,
+                            exact=point.degree,
+                        )
+                    )
+        return CompositeTransitResult(composite_points, hits)
+
+    @staticmethod
+    def _orb_difference(a: float, b: float) -> float:
+        diff = abs((a - b + 180) % 360 - 180)
+        return diff
+
+    def to_frame(self, result: CompositeTransitResult) -> pd.DataFrame:
+        records = [hit.__dict__ for hit in result.hits]
+        return pd.DataFrame.from_records(records)
+
+
+__all__ = [
+    "CompositeTransitPipeline",
+    "CompositeTransitResult",
+]

--- a/src/astroengine/timelords.py
+++ b/src/astroengine/timelords.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+
+@dataclass
+class ZodiacalPeriod:
+    level: str
+    sign: str
+    start: date
+    end: date
+    duration_years: float
+
+
+class ZodiacalReleasingCalculator:
+    """Simplified zodiacal releasing calculator following Valens-style periods."""
+
+    def __init__(self, base_periods: Dict[str, float]):
+        if not base_periods:
+            raise ValueError("Zodiacal releasing requires at least one base period")
+        self.base_periods = base_periods
+
+    def compute(self, start_sign: str, start_date: date, spans: int = 4) -> pd.DataFrame:
+        if start_sign not in self.base_periods:
+            raise KeyError(f"Start sign '{start_sign}' missing from base period table")
+
+        periods: List[ZodiacalPeriod] = []
+        ordered_signs = list(self.base_periods.keys())
+        index = ordered_signs.index(start_sign)
+        current_start = start_date
+        for i in range(spans):
+            sign = ordered_signs[(index + i) % len(ordered_signs)]
+            duration_years = float(self.base_periods[sign])
+            delta_days = int(duration_years * 365.25)
+            current_end = current_start + timedelta(days=delta_days)
+            periods.append(
+                ZodiacalPeriod(
+                    level="L1",
+                    sign=sign,
+                    start=current_start,
+                    end=current_end,
+                    duration_years=duration_years,
+                )
+            )
+            current_start = current_end
+        return pd.DataFrame([p.__dict__ for p in periods])
+
+
+class ProfectionCalculator:
+    """Annual profection calculator using a repeating zodiac sequence."""
+
+    def __init__(self, zodiac_sequence: Iterable[str]):
+        sequence = list(zodiac_sequence)
+        if len(sequence) != 12:
+            raise ValueError("Profection sequence must contain exactly 12 signs")
+        self.sequence = sequence
+
+    def active_sign(self, ascendant_sign: str, age: int) -> str:
+        try:
+            start_index = self.sequence.index(ascendant_sign)
+        except ValueError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Ascendant sign '{ascendant_sign}' not found in zodiac sequence") from exc
+        return self.sequence[(start_index + age) % len(self.sequence)]
+
+    def tabulate(self, ascendant_sign: str, years: int) -> pd.DataFrame:
+        records = []
+        for year in range(years + 1):
+            records.append({"age": year, "sign": self.active_sign(ascendant_sign, year)})
+        return pd.DataFrame.from_records(records)
+
+
+__all__ = [
+    "ZodiacalReleasingCalculator",
+    "ProfectionCalculator",
+]

--- a/tests/test_contact_gating_v2.py
+++ b/tests/test_contact_gating_v2.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from astroengine import AstroEngine
+
+
+def test_contact_gating_v2(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    contacts = pd.DataFrame(
+        [
+            {
+                "contact_id": "c1",
+                "base_score": 10.0,
+                "angular_distance": 5.0,
+                "orb": 0.05,
+                "aspect": "conjunction",
+                "malefic_involved": False,
+                "benefic_involved": False,
+            },
+            {
+                "contact_id": "c2",
+                "base_score": 8.0,
+                "angular_distance": 15.0,
+                "orb": 1.0,
+                "aspect": "square",
+                "malefic_involved": True,
+                "benefic_involved": False,
+            },
+            {
+                "contact_id": "c3",
+                "base_score": 7.0,
+                "angular_distance": 60.0,
+                "orb": 1.2,
+                "aspect": "trine",
+                "malefic_involved": False,
+                "benefic_involved": True,
+            },
+        ]
+    )
+
+    result = engine.run(
+        {
+            "module": "gating",
+            "submodule": "contact_gating_v2",
+            "channel": "natal_to_transit",
+            "subchannel": "default",
+            "data": {"contacts": contacts},
+        }
+    )
+
+    assert result.summary["vetoed"] == 1
+    assert result.summary["dampened"] == 1
+    assert result.summary["boosted"] == 1
+
+    output_path = tmp_path / "tables" / "contact_gate_states.parquet"
+    assert output_path.exists()
+    written = pd.read_parquet(output_path)
+    assert list(written["state"]) == ["vetoed", "dampened", "boosted"]
+    assert written.loc[written["contact_id"] == "c2", "final_score"].iloc[0] == 4.0
+    assert written.loc[written["contact_id"] == "c3", "final_score"].iloc[0] == 8.75

--- a/tests/test_directions_progressions.py
+++ b/tests/test_directions_progressions.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from astroengine import AstroEngine
+
+
+def test_primary_directions(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    result = engine.run(
+        {
+            "module": "directions_progressions",
+            "submodule": "directions_progressions",
+            "channel": "primary_directions",
+            "subchannel": "default",
+            "data": {
+                "positions": {"Sun": 10.0, "Mars": 70.0},
+                "pairs": [{"significator": "Sun", "promissor": "Mars"}],
+            },
+        }
+    )
+    frame = result["primary_directions"]
+    assert frame.iloc[0]["aspect"] == "sextile"
+    assert frame.iloc[0]["orb"] == 0
+
+
+def test_secondary_progressions(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    result = engine.run(
+        {
+            "module": "directions_progressions",
+            "submodule": "directions_progressions",
+            "channel": "secondary_progressions",
+            "subchannel": "solar_arc",
+            "data": {
+                "positions": {"Sun": 10.0, "Moon": 120.0},
+                "years": [0, 1, 2],
+            },
+        }
+    )
+    frame = result["secondary_progressions"]
+    moon_year_two = frame[(frame["body"] == "Moon") & (frame["year"] == 2)]
+    assert moon_year_two.iloc[0]["degree"] == 122.0

--- a/tests/test_synastry_composite.py
+++ b/tests/test_synastry_composite.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from astroengine import AstroEngine, CompositeTransitPipeline
+
+
+def test_composite_transit_pipeline(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    result = engine.run(
+        {
+            "module": "synastry_composite",
+            "submodule": "synastry_composite",
+            "channel": "composite_transits",
+            "subchannel": "default",
+            "data": {
+                "natal_a": {"Sun": 15.0, "Moon": 120.0, "Ascendant": 90.0},
+                "natal_b": {"Sun": 195.0, "Moon": 300.0, "Ascendant": 270.0},
+                "transits": {"Jupiter": 105.0, "Saturn": 181.2},
+            },
+        }
+    )
+    pipeline = CompositeTransitPipeline(orb=2, tracked_points=["Sun", "Moon", "Ascendant"])
+    frame = pipeline.to_frame(result)
+    assert any(frame["composite_point"] == "Ascendant")
+    assert frame.loc[frame["transit_body"] == "Saturn", "orb"].iloc[0] <= 1.2

--- a/tests/test_timelords.py
+++ b/tests/test_timelords.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+from astroengine import AstroEngine
+
+
+def test_zodiacal_releasing(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    result = engine.run(
+        {
+            "module": "timelords",
+            "submodule": "timelords",
+            "channel": "releasing",
+            "subchannel": "lot_of_spirit",
+            "data": {
+                "start_sign": "Aries",
+                "start_date": date(2000, 1, 1),
+                "spans": 3,
+            },
+        }
+    )
+    releasing = result["zodiacal_releasing"]
+    assert list(releasing["sign"]) == ["Aries", "Taurus", "Gemini"]
+    assert releasing.iloc[0]["start"] == date(2000, 1, 1)
+    assert releasing.iloc[0]["end"] > releasing.iloc[0]["start"]
+
+
+def test_annual_profections(tmp_path: Path) -> None:
+    engine = AstroEngine(Path("rulesets/vca_astroengine_master.yaml"), output_root=tmp_path)
+    result = engine.run(
+        {
+            "module": "timelords",
+            "submodule": "timelords",
+            "channel": "profections",
+            "subchannel": "annual",
+            "data": {
+                "ascendant_sign": "Cancer",
+                "years": 5,
+            },
+        }
+    )
+    profections = result["profections"]
+    assert list(profections["sign"])[:3] == ["Cancer", "Leo", "Virgo"]
+    assert profections.iloc[5]["sign"] == "Sagittarius"


### PR DESCRIPTION
## Summary
- implement AstroEngine runtime orchestrator that loads modules from the consolidated ruleset and produces deterministic outputs
- add gating, timelord, directions/progressions, and synastry composite modules plus dataset connector utilities
- document the module/submodule/channel/subchannel workflow and introduce regression tests for each feature family

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2ffa66048324abcf40c51b189c94