### PR TITLE
chore: CP-PACK-R1 bootstrap transit API and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+
+# >>> AUTO-GEN BEGIN: CI v1.0
+name: ci
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install tools
+        run: |
+          python -m pip install -U pip
+          pip install ruff black mypy pytest jsonschema
+
+      - name: Lint (ruff)
+        run: ruff check .
+
+      - name: Format check (black)
+        run: black --check .
+
+      - name: Type check (mypy)
+        run: mypy --ignore-missing-imports .
+
+      - name: Tests
+        run: pytest -q
+# >>> AUTO-GEN END: CI v1.0
+

--- a/README.md
+++ b/README.md
@@ -55,3 +55,15 @@ Two utility layers support schema validation:
 The validation helpers are intentionally lightweight so they can
 be embedded into existing “doctor” or pre-flight scripts without
 risking accidental module removals.
+
+<!-- >>> AUTO-GEN BEGIN: Start Here v1.0 -->
+## Start Here
+
+- [Project Instructions](docs/PROJECT_INSTRUCTIONS.md)
+- [Astrology Coverage Index](docs/ASTROLOGY_COVERAGE_INDEX.md)
+- [Astro Reference](docs/ASTRO_REFERENCE.md)
+- Public API: `from astroengine import TransitEngine, TransitScanConfig`
+- Tests: `pytest -q`
+- CI: see `.github/workflows/ci.yml`
+<!-- >>> AUTO-GEN END: Start Here v1.0 -->
+

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
+from .transit.api import TransitEngine, TransitScanConfig  # ENSURE-LINE
+
+__all__ = ["__version__", "TransitEngine", "TransitScanConfig"]
 
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")

--- a/astroengine/transit/api.py
+++ b/astroengine/transit/api.py
@@ -1,0 +1,72 @@
+# >>> AUTO-GEN BEGIN: TransitAPI v1.0
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional, Sequence
+
+AspectName = Literal[
+    "conjunction",
+    "opposition",
+    "square",
+    "trine",
+    "sextile",
+    "quincunx",
+    "semisextile",
+    "semisquare",
+    "sesquisquare",
+]
+
+
+@dataclass
+class TransitScanConfig:
+    natal_id: str
+    start_iso: str
+    end_iso: str
+    step: str = "1h"
+    aspects: Sequence[AspectName] = (
+        "conjunction",
+        "opposition",
+        "square",
+        "trine",
+        "sextile",
+    )
+    include_declination: bool = False
+    include_antiscia: bool = False
+    topocentric: bool = False
+    site_lat: Optional[float] = None
+    site_lon: Optional[float] = None
+    site_elev_m: float = 0.0
+    ephemeris_profile: str = "default"
+    orb_policy: str = "default"
+    severity_profile: str = "standard"
+    family_cap_per_day: int = 3
+
+
+@dataclass
+class TransitEvent:
+    t_exact: str
+    t_applying: bool
+    partile: bool
+    aspect: AspectName
+    transiting_body: str
+    natal_point: str
+    orb_deg: float
+    severity: float
+    family: str
+    lon_transit: float
+    lon_natal: float
+    decl_transit: Optional[float] = None
+    notes: Optional[str] = None
+
+
+class TransitEngine:
+    """Facade: ephemeris → detect → refine → score. Implement in engine/detectors/refine."""
+
+    def __init__(self, engine_config) -> None:
+        self._engine_config = engine_config
+
+    def scan(self, cfg: TransitScanConfig) -> Iterable[TransitEvent]:
+        raise NotImplementedError(
+            "TransitEngine.scan must be implemented by concrete engines"
+        )
+
+
+# >>> AUTO-GEN END: TransitAPI v1.0

--- a/astroengine/transit/detectors.py
+++ b/astroengine/transit/detectors.py
@@ -1,0 +1,71 @@
+# >>> AUTO-GEN BEGIN: Detectors v1.0 (ecliptic core)
+from typing import Iterable, Sequence
+from .api import TransitEvent, AspectName
+
+# Required state keys per body: lon_deg (0—360), lon_speed_deg_per_day (signed)
+
+ASPECT_ANGLES = {
+    "conjunction": 0.0,
+    "sextile": 60.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "opposition": 180.0,
+    "semisextile": 30.0,
+    "semisquare": 45.0,
+    "sesquisquare": 135.0,
+    "quincunx": 150.0,
+}
+
+
+def norm180(x: float) -> float:
+    """Map degrees to (-180, 180]."""
+    x = (x + 180.0) % 360.0 - 180.0
+    return x if x != -180.0 else 180.0
+
+
+def detect_ecliptic_contacts(
+    state: dict, natal: dict, aspects: Sequence[AspectName], orbs
+) -> Iterable[TransitEvent]:
+    """
+    Rough detection at a cadence tick.
+    - `state`: {body: {"lon_deg": float, "lon_speed_deg_per_day": float}}
+    - `natal`: {point: {"lon_deg": float}}
+    - `orbs`: callable (body, point, aspect) -> orb_deg
+    Yields coarse TransitEvent stubs (t_exact filled by refinement).
+    """
+    for body, bdat in state.items():
+        lon_t = bdat.get("lon_deg")
+        spd_t = bdat.get("lon_speed_deg_per_day", 0.0)
+        if lon_t is None:
+            continue
+        for point, pdat in natal.items():
+            lon_n = pdat.get("lon_deg")
+            if lon_n is None:
+                continue
+            d = norm180(lon_t - lon_n)
+            for asp in aspects:
+                theta = ASPECT_ANGLES.get(asp)
+                if theta is None:
+                    continue
+                diff = norm180(d - norm180(theta))
+                orb_allow = orbs(body, point, asp)
+                if abs(diff) <= orb_allow:
+                    applying = spd_t < 0 if diff > 0 else spd_t > 0
+                    yield TransitEvent(
+                        t_exact="",  # filled later
+                        t_applying=applying,
+                        partile=False,
+                        aspect=asp,
+                        transiting_body=body,
+                        natal_point=point,
+                        orb_deg=abs(diff),
+                        severity=0.0,
+                        family=f"{body}→{point} {asp}",
+                        lon_transit=lon_t,
+                        lon_natal=lon_n,
+                        decl_transit=None,
+                        notes=None,
+                    )
+
+
+# >>> AUTO-GEN END: Detectors v1.0 (ecliptic core)

--- a/astroengine/transit/refine.py
+++ b/astroengine/transit/refine.py
@@ -1,0 +1,64 @@
+# >>> AUTO-GEN BEGIN: Refine v1.0 (secant/bisection)
+from dataclasses import replace
+from .api import TransitEvent
+from .detectors import norm180, ASPECT_ANGLES
+
+
+def refine_exact(event: TransitEvent, provider, natal: dict, cfg) -> TransitEvent:
+    """Bracket and refine exactness for the event using secant → bisection fallback.
+    provider must expose: ecliptic_state(t_iso, topocentric, lat, lon, elev_m) -> state dict.
+    """
+    body, point, asp = event.transiting_body, event.natal_point, event.aspect
+    theta = ASPECT_ANGLES[asp]
+
+    def f(t_iso: str) -> float:
+        st = provider.ecliptic_state(
+            t_iso,
+            topocentric=cfg.topocentric,
+            lat=cfg.site_lat,
+            lon=cfg.site_lon,
+            elev_m=cfg.site_elev_m,
+        )
+        lon_t = st[body]["lon_deg"]
+        lon_n = natal[point]["lon_deg"]
+        return norm180((lon_t - lon_n) - theta)
+
+    # crude bracket: ±6h around current estimate
+    import datetime as _dt
+    from datetime import timezone
+
+    t0 = _dt.datetime.fromisoformat(cfg.start_iso.replace("Z", "+00:00"))
+    guess = t0
+    dt = _dt.timedelta(hours=6)
+    a = guess - dt
+    b = guess + dt
+
+    def iso(t: _dt.datetime) -> str:
+        return t.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    fa, fb = f(iso(a)), f(iso(b))
+    if fa * fb > 0:
+        a -= dt
+        b += dt
+        fa, fb = f(iso(a)), f(iso(b))
+
+    x0, x1 = a, b
+    y0, y1 = fa, fb
+    for _ in range(12):
+        if abs(y1 - y0) < 1e-9:
+            break
+        xn = _dt.datetime.fromtimestamp(
+            x1.timestamp() - y1 * (x1.timestamp() - x0.timestamp()) / (y1 - y0)
+        )
+        yn = f(iso(xn))
+        x0, y0, x1, y1 = x1, y1, xn, yn
+        if abs(yn) <= 1e-6:
+            break
+
+    t_exact = x1
+    partile = abs(f(iso(t_exact))) <= (1 / 6) / 60  # ≈ 0.01°
+
+    return replace(event, t_exact=iso(t_exact), partile=partile)
+
+
+# >>> AUTO-GEN END: Refine v1.0 (secant/bisection)

--- a/astroengine/validation/_simple_validator.py
+++ b/astroengine/validation/_simple_validator.py
@@ -53,7 +53,9 @@ class SimpleValidator:
         if "$ref" in schema:
             target = self._resolve_ref(schema["$ref"], path)
             if target is None:
-                yield SimpleValidationError(path, f"Unresolvable reference {schema['$ref']}")
+                yield SimpleValidationError(
+                    path, f"Unresolvable reference {schema['$ref']}"
+                )
             else:
                 yield from self._iter_errors(target, value, path)
             return
@@ -63,13 +65,15 @@ class SimpleValidator:
             if isinstance(schema_type, list):
                 if not any(self._matches_type(t, value) for t in schema_type):
                     yield SimpleValidationError(
-                        path, f"Expected type {schema_type} but got {type(value).__name__}"
+                        path,
+                        f"Expected type {schema_type} but got {type(value).__name__}",
                     )
                     return
             else:
                 if not self._matches_type(schema_type, value):
                     yield SimpleValidationError(
-                        path, f"Expected type {schema_type} but got {type(value).__name__}"
+                        path,
+                        f"Expected type {schema_type} but got {type(value).__name__}",
                     )
                     return
 
@@ -80,7 +84,9 @@ class SimpleValidator:
             required = schema.get("required", [])
             for key in required:
                 if key not in value:
-                    yield SimpleValidationError(path + (key,), "Missing required property")
+                    yield SimpleValidationError(
+                        path + (key,), "Missing required property"
+                    )
             props = schema.get("properties", {})
             additional_allowed = schema.get("additionalProperties", True)
             if additional_allowed is False:
@@ -115,9 +121,13 @@ class SimpleValidator:
                 return
             pattern = schema.get("pattern")
             if pattern and not re.fullmatch(pattern, value):
-                yield SimpleValidationError(path, f"Value does not match pattern {pattern}")
+                yield SimpleValidationError(
+                    path, f"Value does not match pattern {pattern}"
+                )
             if "enum" in schema and value not in schema["enum"]:
-                yield SimpleValidationError(path, f"Value {value!r} is not one of {schema['enum']}")
+                yield SimpleValidationError(
+                    path, f"Value {value!r} is not one of {schema['enum']}"
+                )
             fmt = schema.get("format")
             if fmt == "date-time" and not _is_datetime(value):
                 yield SimpleValidationError(path, "Invalid date-time format")
@@ -135,9 +145,13 @@ class SimpleValidator:
             minimum = schema.get("minimum")
             maximum = schema.get("maximum")
             if minimum is not None and value < minimum:
-                yield SimpleValidationError(path, f"Value {value} is less than minimum {minimum}")
+                yield SimpleValidationError(
+                    path, f"Value {value} is less than minimum {minimum}"
+                )
             if maximum is not None and value > maximum:
-                yield SimpleValidationError(path, f"Value {value} exceeds maximum {maximum}")
+                yield SimpleValidationError(
+                    path, f"Value {value} exceeds maximum {maximum}"
+                )
             return
 
         if schema_type == "number":
@@ -147,14 +161,20 @@ class SimpleValidator:
             minimum = schema.get("minimum")
             maximum = schema.get("maximum")
             if minimum is not None and value < minimum:
-                yield SimpleValidationError(path, f"Value {value} is less than minimum {minimum}")
+                yield SimpleValidationError(
+                    path, f"Value {value} is less than minimum {minimum}"
+                )
             if maximum is not None and value > maximum:
-                yield SimpleValidationError(path, f"Value {value} exceeds maximum {maximum}")
+                yield SimpleValidationError(
+                    path, f"Value {value} exceeds maximum {maximum}"
+                )
             return
 
         if "enum" in schema:
             if value not in schema["enum"]:
-                yield SimpleValidationError(path, f"Value {value!r} is not one of {schema['enum']}")
+                yield SimpleValidationError(
+                    path, f"Value {value!r} is not one of {schema['enum']}"
+                )
 
     # ------------------------------------------------------------------
     # Utility helpers

--- a/docs/ASTROLOGY_COVERAGE_INDEX.md
+++ b/docs/ASTROLOGY_COVERAGE_INDEX.md
@@ -1,0 +1,24 @@
+
+<!-- >>> AUTO-GEN BEGIN: Astrology Coverage Index v1.0 -->
+# Astrology Coverage Index (Baseline)
+
+## Bodies (MVP)
+Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Mean/True Node; Chiron (opt).
+
+## Points
+ASC, MC, IC, DSC; (Tier 2) Vertex/Antivertex; Lots of Fortune/Spirit.
+
+## Aspect Families
+- Major: 0°, 60°, 90°, 120°, 180°
+- Minor: 30°, 45°, 135°, 150°
+- Harmonic highlights (later): 72°/144° (quintile), 40°/80° (novile), ~51.4286° (septile), ~32.727° (undecile)
+- Declination: parallel / contraparallel
+- Mirror: antiscia / contra-antiscia
+
+## Orb Defaults
+Luminaries 8°, personal 6°, social 5°, outer 4°, minors 2°, declination 0°30′; partile ≤ 0°10′.
+
+## Applying/Separating
+From the sign of relative longitudinal rate; analogous logic for declination.
+<!-- >>> AUTO-GEN END: Astrology Coverage Index v1.0 -->
+

--- a/docs/ASTRO_REFERENCE.md
+++ b/docs/ASTRO_REFERENCE.md
@@ -1,0 +1,22 @@
+
+<!-- >>> AUTO-GEN BEGIN: Astro Reference v1.0 -->
+# Astro Reference — Baseline
+
+## Bodies & Points (MVP)
+Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Mean/True Node, Chiron (opt);
+Angles: ASC, MC, IC, DSC; Vertex (Tier 2); Lots: Fortune/Spirit (Tier 2).
+
+## Aspect Families
+- Major: 0, 60, 90, 120, 180
+- Minor: 30, 45, 135, 150; quintile: 72/144; novile: 40/80; undecile (≈32.727°), etc. (enable via harmonic N)
+- Declination: parallel / contraparallel
+- Mirror: antiscia / contra-antiscia
+
+## Orbs (defaults)
+Luminaries 8°, personal 6°, social 5°, outer 4°, minors 2°, declination 0°30′; partile ≤ 0°10′.
+
+## Notes
+- Applying/Separating from relative longitudinal speed sign.
+- Δλ continuity preserved across 0°/360°.
+<!-- >>> AUTO-GEN END: Astro Reference v1.0 -->
+

--- a/docs/PROJECT_INSTRUCTIONS.md
+++ b/docs/PROJECT_INSTRUCTIONS.md
@@ -1,0 +1,32 @@
+
+<!-- >>> AUTO-GEN BEGIN: Project Instructions v1.0 -->
+# AstroEngine — Project Instructions
+
+## Mission
+Build a modular, testable engine to compute astrological transits (MVP) and, over time, broader techniques (declination, antiscia, midpoints, harmonics, ingresses, lunations, returns, etc.). Accuracy, reproducibility, and clean APIs are non-negotiable.
+
+## Roles & Workflow (Chat-Only)
+- You: prioritize features and approve defaults (house system, orbs, profiles).
+- Assistant: deliver deterministic **Change Packets (CPs)** with `AUTO-GEN` blocks and `# ENSURE-LINE` hints.
+- Apply rule: if a same-name block exists, replace that region; otherwise append. Re-pasting is safe.
+
+## Scope (MVP)
+- Bodies: Sun–Pluto, Mean/True Nodes; Chiron (opt).
+- Points: ASC/MC/IC/DSC; Lots (Fortune/Spirit, later).
+- Aspects: 0/60/90/120/180 (core); optional 30/45/135/150; declination parallels/contra; antiscia.
+- Time: I/O in ISO-8601 UTC; ephemeris eval in TT.
+- Angles: normalize to [0°, 360°); track Δλ continuously across 0°/360°.
+- Orbs (defaults): luminaries 8°, personal 6°, social 5°, outer 4°, minors 2°; declination 0°30′; partile ≤ 0°10′.
+
+## Public API (stable imports)
+`TransitEngine`, `TransitScanConfig`, `TransitEvent` in `astroengine.transit.api`.
+
+## Quality Bar
+Deterministic results; documented units; retrograde guards; tests (unit + acceptance); CI for ruff/black/mypy/pytest.
+
+## Roadmap
+R1: Transit API + detectors + refinement + schema CI →  
+R2: declination + antiscia + severity/orb profiles + CLI →  
+R3: ingresses/lunations/stations calendar + exporters.
+<!-- >>> AUTO-GEN END: Project Instructions v1.0 -->
+

--- a/rulesets/vca_astroengine_master.yaml
+++ b/rulesets/vca_astroengine_master.yaml
@@ -1,0 +1,18 @@
+modules:
+  - id: transit.scan
+    channels:
+      ingest: { group: natal }
+      process:
+        provider: skyfield_default
+        step: 1h
+        aspects: [conjunction, opposition, square, trine, sextile]
+        options:
+          include_declination: true
+          include_antiscia: false
+      gate: |
+        family_cap_per_day(3) and (
+          (aspect in [conjunction, opposition, square] and severity >= 0.65) or
+          (aspect in [trine, sextile] and transiting_body in [Jupiter, Venus])
+        )
+      score: { profile: standard }
+      export: { sqlite: data/transits.db }

--- a/tests/test_result_schema_meta.py
+++ b/tests/test_result_schema_meta.py
@@ -1,0 +1,33 @@
+# >>> AUTO-GEN BEGIN: Test Result Schema Meta v1.0
+import json
+import os
+import pytest
+
+try:
+    import jsonschema
+except Exception:  # pragma: no cover
+    jsonschema = None
+
+
+def test_result_schema_is_valid_jsonschema():
+    schema_path = os.path.join("schemas", "result_schema_v1.json")
+    if not os.path.exists(schema_path):
+        pytest.skip("schemas/result_schema_v1.json not found")
+    if jsonschema is None:
+        pytest.skip("jsonschema not installed")
+
+    with open(schema_path, "r", encoding="utf-8") as f:
+        schema = json.load(f)
+
+    metas = [
+        getattr(jsonschema, "Draft202012Validator", None),
+        getattr(jsonschema, "Draft201909Validator", None),
+        getattr(jsonschema, "Draft7Validator", None),
+    ]
+    metas = [m for m in metas if m is not None]
+    assert metas, "No suitable jsonschema meta-validator available"
+
+    metas[0].check_schema(schema)
+
+
+# >>> AUTO-GEN END: Test Result Schema Meta v1.0


### PR DESCRIPTION
## Summary
- add Start Here README section and baseline docs outlining mission, scope, and reference material
- introduce transit API/engine scaffolding with detector/refinement modules and export them from the package
- wire up schema meta-test, CI workflow, and optional ruleset entry for transit scanning while formatting existing tooling for the new checks

## Testing
- ruff check .
- black --check .
- mypy --ignore-missing-imports .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc7db67b548324946dd7a47b734eac