### PR TITLE
Add transit profiles, CLI demo, and acceptance test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+# <<< AUTO-GEN START: CI v1.0 >>>
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install click jsonschema ruff black mypy pytest
+      - name: Ruff
+        run: ruff check astroengine src tests
+      - name: Black
+        run: black --check astroengine/__init__.py src tests
+      - name: Mypy
+        run: mypy --ignore-missing-imports astroengine src tests
+      - name: Pytest
+        run: pytest -q
+# <<< AUTO-GEN END: CI v1.0 >>>

--- a/README.md
+++ b/README.md
@@ -55,3 +55,24 @@ Two utility layers support schema validation:
 The validation helpers are intentionally lightweight so they can
 be embedded into existing “doctor” or pre-flight scripts without
 risking accidental module removals.
+
+# <<< AUTO-GEN START: CLI Usage v1.0 >>>
+## CLI (demo)
+
+Run the mock transit scan without a real ephemeris by invoking:
+
+```bash
+python -m astroengine.transit.cli scan-mock \
+  --start 2025-01-01T00:00:00Z \
+  --end 2025-01-31T00:00:00Z \
+  --step 12 \
+  --body Mars \
+  --lon0 50 \
+  --speed 6 \
+  --natal-point Venus \
+  --natal-lon 100 \
+  --aspect square
+```
+
+The command uses a linear motion mock provider, so no external ephemeris is required for the demo run.
+# <<< AUTO-GEN END: CLI Usage v1.0 >>>

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -8,13 +8,23 @@ are left untouched to preserve the append-only
 workflow preferred by operators.
 """
 
+# ruff: noqa: E402
+
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "TransitEngine", "TransitScanConfig"]
+
+_PKG_DIR = Path(__file__).resolve().parent
+_SRC_TRANSIT = _PKG_DIR.parent / "src" / "astroengine"
+if _SRC_TRANSIT.exists():
+    __path__ = list(dict.fromkeys(list(__path__) + [str(_SRC_TRANSIT)]))
 
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
+
+from .transit.api import TransitEngine, TransitScanConfig  # ENSURE-LINE

--- a/src/astroengine/transit/__init__.py
+++ b/src/astroengine/transit/__init__.py
@@ -1,0 +1,13 @@
+"""Transit scanning utilities for AstroEngine."""
+
+from __future__ import annotations
+
+__all__ = [
+    "TransitEvent",
+    "TransitEngine",
+    "TransitScanConfig",
+    "build_default_profiles",
+]
+
+from .api import TransitEngine, TransitEvent, TransitScanConfig
+from .profiles import build_default_profiles

--- a/src/astroengine/transit/api.py
+++ b/src/astroengine/transit/api.py
@@ -1,0 +1,118 @@
+"""Public API for transit scanning."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Mapping, Sequence, cast
+
+from .detectors import detect_ecliptic_contacts
+from .profiles import OrbPolicy, SeverityModel
+from .refine import refine_exact
+
+
+@dataclass(frozen=True)
+class TransitScanConfig:
+    """Configuration payload for a scan request."""
+
+    start: datetime
+    end: datetime
+    step: timedelta
+    aspects: Sequence[str]
+    natal_point: str
+    natal_lon: float
+
+    def ticks(self) -> List[datetime]:
+        """Generate UTC timestamps for the configured window."""
+
+        ticks: List[datetime] = []
+        current = self.start
+        while current <= self.end:
+            ticks.append(current)
+            current += self.step
+        return ticks
+
+
+@dataclass
+class TransitEvent:
+    """Represents a detected transit contact."""
+
+    timestamp: datetime
+    aspect: str
+    transiting_body: str
+    natal_point: str
+    orb_deg: float
+    family: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def copy_with(self, **updates: Any) -> "TransitEvent":
+        payload = dict(self.metadata)
+        if "metadata" in updates:
+            payload = dict(updates.pop("metadata"))
+        result = replace(self, **updates)
+        result.metadata = payload
+        return result
+
+
+class TransitEngine:
+    """Utility that orchestrates transit detection and scoring."""
+
+    def __init__(
+        self,
+        provider: Any,
+        orb_policy: OrbPolicy | None = None,
+        severity_model: SeverityModel | None = None,
+    ) -> None:
+        self.provider = provider
+        self.orb_policy = orb_policy or OrbPolicy()
+        self.severity_model = severity_model or SeverityModel()
+
+    def scan(self, config: TransitScanConfig) -> List[TransitEvent]:
+        """Run a scan returning scored transit events."""
+
+        natal: Dict[str, float | str] = {
+            "name": config.natal_point,
+            "lon_deg": float(config.natal_lon),
+        }
+        results: List[TransitEvent] = []
+        for tick in config.ticks():
+            state = self._state_for_tick(tick)
+            events = detect_ecliptic_contacts(
+                state,
+                natal,
+                list(config.aspects),
+                self.orb_policy,
+            )
+            for event in events:
+                t_exact = refine_exact(self.provider, event, natal)
+                state_exact = self._state_for_tick(t_exact)
+                refined = self._with_orb(event, state_exact, natal)
+                severity = self.severity_model.score_event(refined, self.orb_policy)
+                refined.metadata["severity"] = severity
+                results.append(refined)
+        return results
+
+    def _state_for_tick(self, tick: datetime) -> Dict[str, Any]:
+        iso_ts = tick.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        raw_state = self.provider.ecliptic_state(iso_ts)
+        state: Dict[str, Any] = dict(raw_state)
+        state["__timestamp__"] = tick
+        return state
+
+    def _with_orb(
+        self,
+        event: TransitEvent,
+        state: Mapping[str, Any],
+        natal: Mapping[str, float | str],
+    ) -> TransitEvent:
+        from .detectors import compute_orb
+
+        payload = cast(Mapping[str, float], state[event.transiting_body])
+        timestamp = cast(datetime, state["__timestamp__"])
+        natal_lon = cast(float, natal["lon_deg"])
+        lon = float(payload["lon_deg"])
+        orb = abs(compute_orb(lon, natal_lon, event.aspect))
+        return event.copy_with(timestamp=timestamp, orb_deg=orb)
+
+
+__all__ = ["TransitEngine", "TransitEvent", "TransitScanConfig"]

--- a/src/astroengine/transit/cli.py
+++ b/src/astroengine/transit/cli.py
@@ -1,0 +1,153 @@
+"""Command line helpers for the transit module."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+import click
+
+from .detectors import compute_orb, detect_ecliptic_contacts
+from .profiles import build_default_profiles
+from .refine import refine_exact
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _parse_iso8601(value: str) -> datetime:
+    try:
+        dt = datetime.strptime(value, ISO_FORMAT)
+    except ValueError as exc:  # pragma: no cover - validated via click
+        raise click.BadParameter(f"Invalid timestamp '{value}'") from exc
+    return dt.replace(tzinfo=timezone.utc)
+
+
+def _format_iso8601(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime(ISO_FORMAT)
+
+
+# <<< AUTO-GEN START: CLI v1.0 (mock scan) >>>
+class MockLinearProvider:
+    """Linear motion provider used for demonstration purposes."""
+
+    def __init__(
+        self,
+        body: str,
+        lon0_deg: float,
+        speed_deg_per_day: float,
+        t0_iso: str,
+    ) -> None:
+        self.body = body
+        self.lon0_deg = lon0_deg % 360.0
+        self.speed_deg_per_day = speed_deg_per_day
+        self.t0 = _parse_iso8601(t0_iso)
+
+    def ecliptic_state(self, t_iso: str, **_: object) -> dict[str, dict[str, float]]:
+        target = _parse_iso8601(t_iso)
+        delta_days = (target - self.t0).total_seconds() / 86400.0
+        lon = (self.lon0_deg + self.speed_deg_per_day * delta_days) % 360.0
+        return {
+            self.body: {
+                "lon_deg": lon,
+                "lon_speed_deg_per_day": self.speed_deg_per_day,
+            }
+        }
+
+
+@click.group()
+def main() -> None:
+    """Transit command line utilities."""
+
+
+@main.command("scan-mock")
+@click.option("--start", "start_iso", required=True, help="Scan window start (UTC)")
+@click.option("--end", "end_iso", required=True, help="Scan window end (UTC)")
+@click.option(
+    "--step",
+    type=int,
+    default=6,
+    show_default=True,
+    help="Tick spacing in hours",
+)
+@click.option("--body", "body_name", required=True, help="Transiting body name")
+@click.option("--lon0", type=float, required=True, help="Body longitude at start")
+@click.option("--speed", type=float, required=True, help="Body speed in deg/day")
+@click.option("--natal-point", "natal_point", required=True, help="Natal point name")
+@click.option("--natal-lon", type=float, required=True, help="Natal longitude")
+@click.option(
+    "--aspect",
+    type=click.Choice(
+        [
+            "conjunction",
+            "sextile",
+            "square",
+            "trine",
+            "opposition",
+            "semisextile",
+            "semisquare",
+            "sesquisquare",
+            "quincunx",
+        ]
+    ),
+    required=True,
+    help="Aspect to track",
+)
+def scan_mock(
+    start_iso: str,
+    end_iso: str,
+    step: int,
+    body_name: str,
+    lon0: float,
+    speed: float,
+    natal_point: str,
+    natal_lon: float,
+    aspect: str,
+) -> None:
+    """Run a mock transit scan using the linear provider."""
+
+    start_dt = _parse_iso8601(start_iso)
+    end_dt = _parse_iso8601(end_iso)
+    if end_dt < start_dt:
+        raise click.BadParameter("--end must be after --start")
+
+    provider = MockLinearProvider(body_name, lon0, speed, start_iso)
+    orb_policy, severity_model = build_default_profiles()
+    natal: Dict[str, float | str] = {"name": natal_point, "lon_deg": float(natal_lon)}
+
+    tick = start_dt
+    step_delta = timedelta(hours=step)
+    while tick <= end_dt:
+        state_raw = provider.ecliptic_state(_format_iso8601(tick))
+        state: Dict[str, Any] = dict(state_raw)
+        state["__timestamp__"] = tick
+        events = detect_ecliptic_contacts(state, natal, [aspect], orb_policy)
+        for event in events:
+            t_exact = refine_exact(provider, event, natal)
+            exact_raw = provider.ecliptic_state(_format_iso8601(t_exact))
+            exact_state: Dict[str, Any] = dict(exact_raw)
+            exact_state["__timestamp__"] = t_exact
+            lon = float(exact_state[event.transiting_body]["lon_deg"])
+            natal_lon_val = float(natal["lon_deg"])
+            orb = abs(compute_orb(lon, natal_lon_val, event.aspect))
+            metadata = dict(event.metadata)
+            metadata["signed_orb"] = compute_orb(lon, natal_lon_val, event.aspect)
+            refined = event.copy_with(timestamp=t_exact, orb_deg=orb, metadata=metadata)
+            severity = severity_model.score_event(refined, orb_policy)
+            payload = {
+                "t_exact": _format_iso8601(t_exact),
+                "aspect": refined.aspect,
+                "transiting_body": refined.transiting_body,
+                "natal_point": refined.natal_point,
+                "orb_deg": round(refined.orb_deg, 3),
+                "severity": round(severity, 3),
+                "family": refined.family,
+            }
+            click.echo(json.dumps(payload))
+        tick += step_delta
+
+
+# <<< AUTO-GEN END: CLI v1.0 (mock scan) >>>
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/astroengine/transit/detectors.py
+++ b/src/astroengine/transit/detectors.py
@@ -1,0 +1,113 @@
+"""Angular helpers and contact detection routines."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from math import fmod
+from typing import Any, TYPE_CHECKING, Dict, List, Mapping, Sequence, cast
+
+if TYPE_CHECKING:
+    from .api import TransitEvent
+    from .profiles import OrbPolicy
+
+ASPECT_ANGLES: Dict[str, float] = {
+    "conjunction": 0.0,
+    "semisextile": 30.0,
+    "semisquare": 45.0,
+    "sextile": 60.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "sesquisquare": 135.0,
+    "quincunx": 150.0,
+    "opposition": 180.0,
+}
+
+MINOR_ASPECTS = {"semisextile", "semisquare", "sesquisquare", "quincunx"}
+MAJOR_ASPECTS = {
+    "conjunction",
+    "opposition",
+    "square",
+    "trine",
+    "sextile",
+}
+
+
+def normalize_degrees(value: float) -> float:
+    """Return an angle in the range [0, 360)."""
+
+    return fmod(fmod(value, 360.0) + 360.0, 360.0)
+
+
+def normalize_signed(value: float) -> float:
+    """Return an angle in the range (-180, 180]."""
+
+    value = fmod(value + 180.0, 360.0)
+    if value < 0:
+        value += 360.0
+    return value - 180.0
+
+
+def compute_orb(transit_lon: float, natal_lon: float, aspect: str) -> float:
+    """Compute the signed orb from the exact aspect."""
+
+    aspect_key = aspect.lower()
+    if aspect_key not in ASPECT_ANGLES:
+        raise ValueError(f"Unknown aspect '{aspect}'")
+    delta = normalize_degrees(transit_lon - natal_lon)
+    target = ASPECT_ANGLES[aspect_key]
+    return normalize_signed(delta - target)
+
+
+def detect_ecliptic_contacts(
+    state: Mapping[str, Mapping[str, float] | Any],
+    natal: Mapping[str, float | str],
+    aspects: Sequence[str],
+    orb_policy: OrbPolicy,
+) -> List[TransitEvent]:
+    """Detect contacts within the allowed orb at the provided timestamp."""
+
+    from .api import TransitEvent
+
+    timestamp = cast(datetime | None, state.get("__timestamp__"))
+    if timestamp is None:
+        raise ValueError("State mapping must include a '__timestamp__' entry")
+
+    results: List[TransitEvent] = []
+    for aspect in aspects:
+        aspect_key = aspect.lower()
+        if aspect_key not in ASPECT_ANGLES:
+            continue
+        natal_name = cast(str, natal["name"])
+        natal_lon = cast(float, natal["lon_deg"])
+        for body, payload in state.items():
+            if body == "__timestamp__":
+                continue
+            payload_map = cast(Mapping[str, float], payload)
+            orb_allow = orb_policy(body, natal_name, aspect_key)
+            diff = compute_orb(payload_map["lon_deg"], natal_lon, aspect_key)
+            if abs(diff) <= orb_allow:
+                family = "minor" if aspect_key in MINOR_ASPECTS else "major"
+                metadata = {"signed_orb": diff}
+                results.append(
+                    TransitEvent(
+                        timestamp=timestamp,
+                        aspect=aspect_key,
+                        transiting_body=body,
+                        natal_point=natal_name,
+                        orb_deg=abs(diff),
+                        family=family,
+                        metadata=metadata,
+                    )
+                )
+    return results
+
+
+__all__ = [
+    "ASPECT_ANGLES",
+    "MINOR_ASPECTS",
+    "MAJOR_ASPECTS",
+    "normalize_degrees",
+    "normalize_signed",
+    "compute_orb",
+    "detect_ecliptic_contacts",
+]

--- a/src/astroengine/transit/profiles.py
+++ b/src/astroengine/transit/profiles.py
@@ -1,0 +1,161 @@
+"""Orb and severity profiles for transit evaluations."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Dict, Tuple
+
+if TYPE_CHECKING:
+    from .api import TransitEvent
+
+# <<< AUTO-GEN START: Profiles v1.0 >>>
+DECLINATION_ORB = 0.5
+PARTILE_ORB = 0.1667
+
+
+class OrbPolicy:
+    """Callable policy that resolves allowable orbs for aspects."""
+
+    MINOR_ASPECTS = {
+        "semisextile",
+        "semisquare",
+        "sesquisquare",
+        "quincunx",
+    }
+
+    LUMINARIES = {"sun", "moon"}
+    PERSONAL = {"mercury", "venus", "mars"}
+    SOCIAL = {"jupiter", "saturn"}
+    OUTER = {"uranus", "neptune", "pluto"}
+    NODES = {
+        "mean node",
+        "true node",
+        "north node",
+        "south node",
+        "node",
+    }
+
+    DEFAULT_ORBS = {
+        "luminary": 8.0,
+        "personal": 6.0,
+        "social": 5.0,
+        "outer": 4.0,
+        "node": 4.0,
+        "minor": 2.0,
+    }
+
+    def __call__(self, transiting_body: str, natal_point: str, aspect: str) -> float:
+        aspect_key = aspect.lower()
+        if aspect_key in self.MINOR_ASPECTS:
+            return self.DEFAULT_ORBS["minor"]
+        category = self._classify_body(transiting_body)
+        return self.DEFAULT_ORBS.get(category, self.DEFAULT_ORBS["personal"])
+
+    def _classify_body(self, body: str) -> str:
+        key = body.lower()
+        if key in self.LUMINARIES:
+            return "luminary"
+        if key in self.PERSONAL:
+            return "personal"
+        if key in self.SOCIAL:
+            return "social"
+        if key in self.OUTER:
+            return "outer"
+        if key in self.NODES:
+            return "node"
+        return "personal"
+
+
+class SeverityModel:
+    """Score transit strength using quadratic falloff."""
+
+    ASPECT_WEIGHTS = {
+        "conjunction": 1.0,
+        "opposition": 1.0,
+        "square": 0.95,
+        "trine": 0.75,
+        "sextile": 0.60,
+        "semisextile": 0.5,
+        "semisquare": 0.45,
+        "sesquisquare": 0.5,
+        "quincunx": 0.55,
+    }
+
+    BODY_WEIGHTS = {
+        "luminary": 1.0,
+        "personal": 0.95,
+        "social": 1.0,
+        "outer": 1.05,
+        "node": 0.90,
+    }
+
+    def __init__(
+        self,
+        aspect_weights: Dict[str, float] | None = None,
+        body_weights: Dict[str, float] | None = None,
+    ) -> None:
+        self.aspect_weights = aspect_weights or dict(self.ASPECT_WEIGHTS)
+        self.body_weights = body_weights or dict(self.BODY_WEIGHTS)
+
+    def score_from_diff(
+        self,
+        diff_deg: float,
+        orb_allow: float,
+        aspect: str,
+        body: str,
+        partile: bool,
+    ) -> float:
+        if orb_allow <= 0:
+            return 0.0
+        diff = abs(diff_deg)
+        if diff > orb_allow:
+            return 0.0
+        closeness = 1.0 - (diff / orb_allow) ** 2
+        closeness = max(closeness, 0.0)
+        aspect_weight = self.aspect_weights.get(aspect.lower(), 0.5)
+        body_weight = self.body_weights.get(self._classify_body(body), 1.0)
+        score = closeness * aspect_weight * body_weight
+        if partile:
+            score *= 1.1
+            score = min(score, 1.2)
+        return max(0.0, min(score, 1.0))
+
+    def score_event(self, event: TransitEvent, orb_policy: OrbPolicy) -> float:
+        orb_allow = orb_policy(event.transiting_body, event.natal_point, event.aspect)
+        partile = event.orb_deg <= PARTILE_ORB
+        return self.score_from_diff(
+            event.orb_deg,
+            orb_allow,
+            event.aspect,
+            event.transiting_body,
+            partile,
+        )
+
+    def _classify_body(self, body: str) -> str:
+        key = body.lower()
+        if key in OrbPolicy.LUMINARIES:
+            return "luminary"
+        if key in OrbPolicy.PERSONAL:
+            return "personal"
+        if key in OrbPolicy.SOCIAL:
+            return "social"
+        if key in OrbPolicy.OUTER:
+            return "outer"
+        if key in OrbPolicy.NODES:
+            return "node"
+        return "personal"
+
+
+def build_default_profiles() -> Tuple[OrbPolicy, SeverityModel]:
+    """Factory returning the default orb policy and severity model."""
+
+    return OrbPolicy(), SeverityModel()
+
+
+__all__ = [
+    "DECLINATION_ORB",
+    "PARTILE_ORB",
+    "OrbPolicy",
+    "SeverityModel",
+    "build_default_profiles",
+]
+# <<< AUTO-GEN END: Profiles v1.0 >>>

--- a/src/astroengine/transit/refine.py
+++ b/src/astroengine/transit/refine.py
@@ -1,0 +1,46 @@
+"""Refinement helpers for contact events."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING, Any, Mapping, cast
+
+from .detectors import compute_orb
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+if TYPE_CHECKING:
+    from .api import TransitEvent
+
+
+def _to_iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime(ISO_FORMAT)
+
+
+def refine_exact(
+    provider: Any,
+    event: TransitEvent,
+    natal: Mapping[str, float | str],
+    max_iter: int = 8,
+    tolerance: float = 1e-3,
+) -> datetime:
+    """Refine the timestamp of an event using Newton-style iteration."""
+
+    guess = event.timestamp
+    for _ in range(max_iter):
+        state = provider.ecliptic_state(_to_iso(guess))
+        body_state = state[event.transiting_body]
+        lon = float(body_state["lon_deg"])
+        speed = float(body_state.get("lon_speed_deg_per_day", 0.0))
+        natal_lon = cast(float, natal["lon_deg"])
+        diff = compute_orb(lon, natal_lon, event.aspect)
+        if abs(diff) <= tolerance:
+            break
+        if abs(speed) < 1e-6:
+            break
+        delta_days = -diff / speed
+        guess += timedelta(days=delta_days)
+    return guess
+
+
+__all__ = ["refine_exact"]

--- a/tests/test_transit_acceptance.py
+++ b/tests/test_transit_acceptance.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict
+
+from astroengine.transit.detectors import compute_orb, detect_ecliptic_contacts
+from astroengine.transit.profiles import build_default_profiles
+from astroengine.transit.refine import refine_exact
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+def _parse_iso(value: str) -> datetime:
+    return datetime.strptime(value, ISO_FORMAT).replace(tzinfo=timezone.utc)
+
+
+def _format_iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime(ISO_FORMAT)
+
+
+# <<< AUTO-GEN START: Transit Acceptance v1.0 >>>
+class MockLinearProvider:
+    def __init__(
+        self,
+        body: str,
+        lon0_deg: float,
+        speed_deg_per_day: float,
+        t0_iso: str,
+    ) -> None:
+        self.body = body
+        self.lon0_deg = lon0_deg % 360.0
+        self.speed_deg_per_day = speed_deg_per_day
+        self.t0 = _parse_iso(t0_iso)
+
+    def ecliptic_state(self, t_iso: str, **_: object) -> dict[str, dict[str, float]]:
+        target = _parse_iso(t_iso)
+        delta_days = (target - self.t0).total_seconds() / 86400.0
+        lon = (self.lon0_deg + self.speed_deg_per_day * delta_days) % 360.0
+        return {
+            self.body: {
+                "lon_deg": lon,
+                "lon_speed_deg_per_day": self.speed_deg_per_day,
+            }
+        }
+
+
+def test_transit_acceptance() -> None:
+    start_iso = "2025-01-01T00:00:00Z"
+    end_iso = "2025-01-31T00:00:00Z"
+    provider = MockLinearProvider("Mars", 50.0, 6.0, start_iso)
+    orb_policy, severity_model = build_default_profiles()
+    start_dt = _parse_iso(start_iso)
+    end_dt = _parse_iso(end_iso)
+    step = timedelta(hours=12)
+
+    natal: Dict[str, float | str] = {"name": "Venus", "lon_deg": 100.0}
+    aspect = "square"
+
+    events = []
+    tick = start_dt
+    while tick <= end_dt:
+        raw_state = provider.ecliptic_state(_format_iso(tick))
+        state: Dict[str, Any] = dict(raw_state)
+        state["__timestamp__"] = tick
+        events.extend(detect_ecliptic_contacts(state, natal, [aspect], orb_policy))
+        tick += step
+
+    assert events, "Expected at least one transit contact"
+
+    refined_events = []
+    for event in events:
+        t_exact = refine_exact(provider, event, natal)
+        exact_raw = provider.ecliptic_state(_format_iso(t_exact))
+        exact_state: Dict[str, Any] = dict(exact_raw)
+        exact_state["__timestamp__"] = t_exact
+        lon = float(exact_state[event.transiting_body]["lon_deg"])
+        natal_lon_val = float(natal["lon_deg"])
+        signed_orb = compute_orb(lon, natal_lon_val, event.aspect)
+        metadata = dict(event.metadata)
+        metadata["signed_orb"] = signed_orb
+        refined = event.copy_with(
+            timestamp=t_exact,
+            orb_deg=abs(signed_orb),
+            metadata=metadata,
+        )
+        severity = severity_model.score_event(refined, orb_policy)
+        refined.metadata["severity"] = severity
+        refined_events.append(refined)
+
+    peak_event = max(refined_events, key=lambda item: item.metadata["severity"])
+
+    orb_allow = orb_policy(peak_event.transiting_body, peak_event.natal_point, aspect)
+    assert peak_event.orb_deg <= orb_allow
+
+    before_time = peak_event.timestamp - step
+    after_time = peak_event.timestamp + step
+
+    def _severity_for(moment: datetime) -> float:
+        state = provider.ecliptic_state(_format_iso(moment))
+        lon_val = float(state[peak_event.transiting_body]["lon_deg"])
+        natal_lon_val = float(natal["lon_deg"])
+        diff = abs(compute_orb(lon_val, natal_lon_val, aspect))
+        return severity_model.score_from_diff(
+            diff,
+            orb_allow,
+            aspect,
+            peak_event.transiting_body,
+            partile=False,
+        )
+
+    before_severity = _severity_for(before_time)
+    after_severity = _severity_for(after_time)
+
+    assert peak_event.metadata["severity"] >= before_severity
+    assert peak_event.metadata["severity"] >= after_severity
+    assert peak_event.orb_deg <= min(orb_allow, 0.01)
+
+
+# <<< AUTO-GEN END: Transit Acceptance v1.0 >>>


### PR DESCRIPTION
## Summary
- add transit orb policy and severity scoring profiles for default builds
- implement a mock transit scan CLI using the linear provider and severity scoring
- introduce an acceptance test and CI workflow for the new transit pipeline

## Testing
- ruff check astroengine src tests
- black --check astroengine/__init__.py src tests
- mypy --ignore-missing-imports astroengine src tests
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc7f7d05e4832491553c0c6744ee1a