### PR TITLE
Add transit preflight utilities

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "TransitEngine", "TransitScanConfig"]
 
 try:  # pragma: no cover - package metadata not available during tests
     __version__ = version("astroengine")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.0.0"
+
+from .transit.api import TransitEngine, TransitScanConfig  # ENSURE-LINE

--- a/astroengine/dev/__init__.py
+++ b/astroengine/dev/__init__.py
@@ -1,0 +1,1 @@
+"""Developer utilities for AstroEngine."""

--- a/astroengine/dev/cli.py
+++ b/astroengine/dev/cli.py
@@ -1,0 +1,32 @@
+# >>> AUTO-GEN BEGIN: Transit Preflight CLI v1.0
+from __future__ import annotations
+
+import argparse
+import os
+from typing import List, Optional
+
+from astroengine.dev.preflight import preflight_transit_engine
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser("astroengine-codex-preflight")
+    parser.add_argument("command", choices=["preflight-transit"], help="Which preflight to run")
+    parser.add_argument("--repo-root", default=os.getcwd())
+    args = parser.parse_args(argv)
+
+    if args.command == "preflight-transit":
+        report = preflight_transit_engine(args.repo_root)
+        for skipped in report.skipped:
+            print(f"SKIP  {skipped}")
+        for action in report.actions:
+            print(f"WRITE {action}")
+        for diff in report.diffs:
+            if diff:
+                print(diff)
+        return 0
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+# >>> AUTO-GEN END: Transit Preflight CLI v1.0

--- a/astroengine/dev/preflight.py
+++ b/astroengine/dev/preflight.py
@@ -1,0 +1,249 @@
+# >>> AUTO-GEN BEGIN: Transit Preflight v1.1
+from __future__ import annotations
+
+import ast
+import difflib
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+AUTOGEN_BEGIN = "# >>> AUTO-GEN BEGIN: {name}"
+AUTOGEN_END = "# >>> AUTO-GEN END: {name}"
+
+
+# ---------- Helpers ----------
+
+def _read(path: str) -> str:
+    if not os.path.exists(path):
+        return ""
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _write_atomic(path: str, content: str) -> None:
+    os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+    tmp_path = f"{path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8", newline="\n") as handle:
+        handle.write(content)
+    os.replace(tmp_path, path)
+
+
+def sha256(data: str) -> str:
+    return hashlib.sha256(data.encode("utf-8")).hexdigest()
+
+
+# ---------- Symbol introspection ----------
+
+def has_class(path: str, class_name: str) -> bool:
+    source = _read(path)
+    if not source:
+        return False
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return any(isinstance(node, ast.ClassDef) and node.name == class_name for node in tree.body)
+
+
+def has_function(path: str, func_name: str) -> bool:
+    source = _read(path)
+    if not source:
+        return False
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    return any(isinstance(node, ast.FunctionDef) and node.name == func_name for node in tree.body)
+
+
+def export_exists(init_path: str, symbol: str) -> bool:
+    """Detect direct imports or __all__ entries for `symbol`."""
+
+    source = _read(init_path)
+    if not source:
+        return False
+    if f"{symbol}" in source and ("__all__" in source or "from ." in source or "from astroengine." in source):
+        return True
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return False
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            targets = [getattr(target, "id", None) for target in node.targets]
+            if "__all__" in targets:
+                values = getattr(node.value, "elts", [])
+                if any(getattr(value, "value", None) == symbol for value in values):
+                    return True
+    return False
+
+
+# ---------- Auto-gen block upsert ----------
+
+def upsert_autogen_block(path: str, name: str, new_block: str) -> Tuple[str, str, bool]:
+    """Ensure a named AUTO-GEN block matches `new_block`.
+
+    Returns (old_content, new_content, changed?). Creates file when missing.
+    """
+
+    begin = AUTOGEN_BEGIN.format(name=name)
+    end = AUTOGEN_END.format(name=name)
+    current = _read(path)
+
+    block = f"{begin}\n{new_block.rstrip()}\n{end}\n"
+
+    if not current:
+        return "", block, True
+
+    if begin in current and end in current:
+        prefix, remainder = current.split(begin, 1)
+        inside, suffix = remainder.split(end, 1)
+        existing_block = f"{begin}{inside}{end}"
+        desired_block = block.strip("\n")
+        if existing_block.strip("\n") == desired_block:
+            return current, current, False
+        new_source = f"{prefix}{block}{suffix}"
+        return current, new_source, True
+
+    new_source = current + ("\n\n" if not current.endswith("\n") else "") + block
+    return current, new_source, True
+
+
+# ---------- YAML ruleset helpers ----------
+
+def _find_module_ids(source: str) -> list[str]:
+    pattern = re.compile(r"^\s*-\s+id:\s*(?P<id>[^\s#]+)", re.MULTILINE)
+    return [match.group("id") for match in pattern.finditer(source or "")]
+
+
+def ruleset_has_module(path: str, module_id: str) -> bool:
+    source = _read(path)
+    if not source:
+        return False
+    return module_id in _find_module_ids(source)
+
+
+def _extract_module_id(module_yaml: str) -> Optional[str]:
+    ids = _find_module_ids(module_yaml)
+    if ids:
+        return ids[0]
+    pattern = re.compile(r"^\s*id:\s*(?P<id>[^\s#]+)", re.MULTILINE)
+    match = pattern.search(module_yaml)
+    return match.group("id") if match else None
+
+
+def add_ruleset_module_if_missing(path: str, module_block_yaml: str) -> Tuple[str, str, bool]:
+    """Append `module_block_yaml` under modules when absent."""
+
+    source = _read(path)
+    if not source:
+        content = module_block_yaml if module_block_yaml.endswith("\n") else module_block_yaml + "\n"
+        return "", content, True
+    module_id = _extract_module_id(module_block_yaml)
+    if module_id and ruleset_has_module(path, module_id):
+        return source, source, False
+    new_source = source.rstrip() + "\n\n" + module_block_yaml.rstrip() + "\n"
+    return source, new_source, True
+
+
+# ---------- Reporting ----------
+
+
+def preview_diff(old: str, new: str, path: str) -> str:
+    if old == new:
+        return ""
+    diff = difflib.unified_diff(
+        old.splitlines(True), new.splitlines(True), fromfile=f"a/{path}", tofile=f"b/{path}"
+    )
+    return "".join(diff)
+
+
+@dataclass
+class PreflightReport:
+    actions: list[str]
+    skipped: list[str]
+    diffs: list[str]
+
+    def is_clean(self) -> bool:
+        return not self.actions
+
+
+def apply_if_changed(path: str, old: str, new: str, report: PreflightReport) -> None:
+    if old == new:
+        report.skipped.append(f"unchanged: {path}")
+        return
+    report.actions.append(f"write: {path}")
+    diff = preview_diff(old, new, path)
+    if diff:
+        report.diffs.append(diff)
+    _write_atomic(path, new)
+
+
+# ---------- Repository-specific recipes ----------
+
+def preflight_transit_engine(repo_root: str) -> PreflightReport:
+    """Apply idempotent updates for the transit engine API + exports + ruleset wiring."""
+
+    report = PreflightReport(actions=[], skipped=[], diffs=[])
+
+    api_path = os.path.join(repo_root, "src", "astroengine", "transit", "api.py")
+    block_name = "TransitAPI v0.1"
+    block_code = """from dataclasses import dataclass\nfrom typing import Iterable, Literal, Optional, Sequence\n\nAspectName = Literal[\n    \"conjunction\",\"opposition\",\"square\",\"trine\",\"sextile\",\n    \"quincunx\",\"semisextile\",\"semisquare\",\"sesquisquare\"\n]\n\n@dataclass\nclass TransitScanConfig:\n    natal_id: str\n    start_iso: str\n    end_iso: str\n    step: str = \"1h\"\n    aspects: Sequence[AspectName] = (\"conjunction\",\"opposition\",\"square\",\"trine\",\"sextile\")\n    include_declination: bool = False\n    include_antiscia: bool = False\n    topocentric: bool = False\n    site_lat: Optional[float] = None\n    site_lon: Optional[float] = None\n    site_elev_m: float = 0.0\n    ephemeris_profile: str = \"default\"\n    orb_policy: str = \"default\"\n    severity_profile: str = \"standard\"\n    family_cap_per_day: int = 3\n\n@dataclass\nclass TransitEvent:\n    t_exact: str\n    t_applying: bool\n    partile: bool\n    aspect: AspectName\n    transiting_body: str\n    natal_point: str\n    orb_deg: float\n    severity: float\n    family: str\n    lon_transit: float\n    lon_natal: float\n    decl_transit: Optional[float] = None\n    notes: Optional[str] = None\n\nclass TransitEngine:\n    def __init__(self, engine_config): ...\n    def scan(self, cfg: TransitScanConfig) -> Iterable[TransitEvent]: ...\n"""
+
+    old_api, new_api, _changed_api = upsert_autogen_block(api_path, block_name, block_code)
+    apply_if_changed(api_path, old_api, new_api, report)
+
+    init_path = os.path.join(repo_root, "src", "astroengine", "__init__.py")
+    init_source = _read(init_path)
+    ensure_line = "from .transit.api import TransitEngine, TransitScanConfig\n"
+    if ensure_line not in init_source:
+        updated = init_source + ("\n" if not init_source.endswith("\n") else "") + ensure_line
+        apply_if_changed(init_path, init_source, updated, report)
+    else:
+        report.skipped.append("export exists: astroengine.__init__.py")
+
+    ruleset_path = os.path.join(repo_root, "rulesets", "vca_astroengine_master.yaml")
+    module_yaml = """
+modules:
+  - id: transit.scan
+    channels:
+      ingest: { group: natal }
+      process:
+        provider: skyfield_default
+        step: 1h
+        aspects: [conjunction, opposition, square, trine, sextile]
+        options:
+          include_declination: true
+          include_antiscia: false
+      gate: |
+        family_cap_per_day(3) and (
+          (aspect in [conjunction, opposition, square] and severity >= 0.65) or
+          (aspect in [trine, sextile] and transiting_body in [Jupiter, Venus])
+        )
+      score: { profile: standard }
+      export: { sqlite: data/transits.db }
+"""
+    old_ruleset, new_ruleset, _changed_ruleset = add_ruleset_module_if_missing(ruleset_path, module_yaml)
+    apply_if_changed(ruleset_path, old_ruleset, new_ruleset, report)
+
+    return report
+
+
+__all__ = [
+    "AUTOGEN_BEGIN",
+    "AUTOGEN_END",
+    "PreflightReport",
+    "add_ruleset_module_if_missing",
+    "apply_if_changed",
+    "export_exists",
+    "has_class",
+    "has_function",
+    "preflight_transit_engine",
+    "preview_diff",
+    "ruleset_has_module",
+    "sha256",
+    "upsert_autogen_block",
+]
+# >>> AUTO-GEN END: Transit Preflight v1.1

--- a/astroengine/transit/__init__.py
+++ b/astroengine/transit/__init__.py
@@ -1,0 +1,1 @@
+"""Transit engine package."""

--- a/astroengine/transit/api.py
+++ b/astroengine/transit/api.py
@@ -1,0 +1,48 @@
+# >>> AUTO-GEN BEGIN: TransitAPI v1.0
+from dataclasses import dataclass
+from typing import Iterable, Literal, Optional, Sequence
+
+AspectName = Literal[
+    "conjunction","opposition","square","trine","sextile",
+    "quincunx","semisextile","semisquare","sesquisquare"
+]
+
+@dataclass
+class TransitScanConfig:
+    natal_id: str
+    start_iso: str
+    end_iso: str
+    step: str = "1h"
+    aspects: Sequence[AspectName] = ("conjunction","opposition","square","trine","sextile")
+    include_declination: bool = False
+    include_antiscia: bool = False
+    topocentric: bool = False
+    site_lat: Optional[float] = None
+    site_lon: Optional[float] = None
+    site_elev_m: float = 0.0
+    ephemeris_profile: str = "default"
+    orb_policy: str = "default"
+    severity_profile: str = "standard"
+    family_cap_per_day: int = 3
+
+@dataclass
+class TransitEvent:
+    t_exact: str
+    t_applying: bool
+    partile: bool
+    aspect: AspectName
+    transiting_body: str
+    natal_point: str
+    orb_deg: float
+    severity: float
+    family: str
+    lon_transit: float
+    lon_natal: float
+    decl_transit: Optional[float] = None
+    notes: Optional[str] = None
+
+class TransitEngine:
+    """Facade: ephemeris → detect → refine → score. See detectors/refine modules."""
+    def __init__(self, engine_config): ...
+    def scan(self, cfg: TransitScanConfig) -> Iterable[TransitEvent]: ...
+# >>> AUTO-GEN END: TransitAPI v1.0

--- a/astroengine/transit/detectors.py
+++ b/astroengine/transit/detectors.py
@@ -1,0 +1,67 @@
+# >>> AUTO-GEN BEGIN: Detectors v1.0 (ecliptic core)
+from typing import Iterable, Sequence
+from .api import TransitEvent, AspectName
+
+# Required state keys per body: lon_deg (0—360), lon_speed_deg_per_day (signed)
+
+ASPECT_ANGLES = {
+    "conjunction": 0.0,
+    "sextile": 60.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "opposition": 180.0,
+    "semisextile": 30.0,
+    "semisquare": 45.0,
+    "sesquisquare": 135.0,
+    "quincunx": 150.0,
+}
+
+
+def norm180(x: float) -> float:
+    """Map degrees to (-180, 180]."""
+    x = (x + 180.0) % 360.0 - 180.0
+    return x if x != -180.0 else 180.0
+
+
+def detect_ecliptic_contacts(state: dict, natal: dict, aspects: Sequence[AspectName], orbs) -> Iterable[TransitEvent]:
+    """
+    Rough detection at a cadence tick.
+    - `state`: {body: {"lon_deg": float, "lon_speed_deg_per_day": float}}
+    - `natal`: {point: {"lon_deg": float}}
+    - `orbs`: callable (body, point, aspect) -> orb_deg
+    Yields coarse TransitEvent stubs (t_exact filled by refinement).
+    """
+    for body, bdat in state.items():
+        lon_t = bdat.get("lon_deg")
+        spd_t = bdat.get("lon_speed_deg_per_day", 0.0)
+        if lon_t is None:
+            continue
+        for point, pdat in natal.items():
+            lon_n = pdat.get("lon_deg")
+            if lon_n is None:
+                continue
+            d = norm180(lon_t - lon_n)
+            for asp in aspects:
+                theta = ASPECT_ANGLES.get(asp)
+                if theta is None:
+                    continue
+                diff = norm180(d - norm180(theta))
+                orb_allow = orbs(body, point, asp)
+                if abs(diff) <= orb_allow:
+                    applying = spd_t < 0 if diff > 0 else spd_t > 0
+                    yield TransitEvent(
+                        t_exact="",  # filled later
+                        t_applying=applying,
+                        partile=False,
+                        aspect=asp,
+                        transiting_body=body,
+                        natal_point=point,
+                        orb_deg=abs(diff),
+                        severity=0.0,
+                        family=f"{body}→{point} {asp}",
+                        lon_transit=lon_t,
+                        lon_natal=lon_n,
+                        decl_transit=None,
+                        notes=None,
+                    )
+# >>> AUTO-GEN END: Detectors v1.0 (ecliptic core)

--- a/astroengine/transit/refine.py
+++ b/astroengine/transit/refine.py
@@ -1,0 +1,56 @@
+# >>> AUTO-GEN BEGIN: Refine v1.0 (secant/bisection)
+from dataclasses import replace
+from .api import TransitEvent
+from .detectors import norm180, ASPECT_ANGLES
+
+
+def refine_exact(event: TransitEvent, provider, natal: dict, cfg) -> TransitEvent:
+    """Bracket and refine exactness for the event using secant → bisection fallback.
+    provider must expose: ecliptic_state(t_iso, topocentric, lat, lon, elev_m) -> state dict.
+    """
+    body, point, asp = event.transiting_body, event.natal_point, event.aspect
+    theta = ASPECT_ANGLES[asp]
+
+    def f(t_iso: str) -> float:
+        st = provider.ecliptic_state(t_iso, topocentric=cfg.topocentric,
+                                     lat=cfg.site_lat, lon=cfg.site_lon, elev_m=cfg.site_elev_m)
+        lon_t = st[body]["lon_deg"]; lon_n = natal[point]["lon_deg"]
+        return norm180((lon_t - lon_n) - theta)
+
+    # crude bracket: ±6h around current estimate
+    import datetime as _dt
+    from datetime import timezone
+
+    t0 = _dt.datetime.fromisoformat(cfg.start_iso.replace("Z", "+00:00"))
+    # If event has a better guess, prefer that; else fallback to start
+    guess = t0
+    dt = _dt.timedelta(hours=6)
+    a = guess - dt; b = guess + dt
+
+    def iso(t: _dt.datetime) -> str:
+        return t.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+    fa, fb = f(iso(a)), f(iso(b))
+    # if same sign, widen once
+    if fa * fb > 0:
+        a -= dt; b += dt
+        fa, fb = f(iso(a)), f(iso(b))
+
+    # Secant iterations
+    x0, x1 = a, b
+    y0, y1 = fa, fb
+    for _ in range(12):
+        if abs(y1 - y0) < 1e-9:
+            break
+        xn = _dt.datetime.fromtimestamp(
+            x1.timestamp() - y1*(x1.timestamp()-x0.timestamp())/(y1 - y0))
+        yn = f(iso(xn))
+        x0, y0, x1, y1 = x1, y1, xn, yn
+        if abs(yn) <= 1e-6:  # ~0.000001°
+            break
+
+    t_exact = x1
+    partile = abs(f(iso(t_exact))) <= (1/6)/60  # ≈ 0.01° ≈ 0°00′36″
+
+    return replace(event, t_exact=iso(t_exact), partile=partile)
+# >>> AUTO-GEN END: Refine v1.0 (secant/bisection)

--- a/docs/ASTRO_REFERENCE.md
+++ b/docs/ASTRO_REFERENCE.md
@@ -1,0 +1,20 @@
+<!-- >>> AUTO-GEN BEGIN: Astro Reference v1.0 -->
+# Astro Reference — Baseline
+
+## Bodies & Points (MVP)
+Sun, Moon, Mercury, Venus, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, Mean/True Node, Chiron (opt);
+Angles: ASC, MC, IC, DSC; Vertex (Tier 2); Lots: Fortune/Spirit (Tier 2).
+
+## Aspect Families
+- Major: 0, 60, 90, 120, 180
+- Minor: 30, 45, 135, 150; quintile: 72/144; novile: 40/80; undecile (≈32.727°), etc. (enable via harmonic N)
+- Declination: parallel / contraparallel
+- Mirror: antiscia / contra-antiscia
+
+## Orbs (defaults)
+Luminaries 8°, personal 6°, social 5°, outer 4°, minors 2°, declination 0°30′; partile ≤ 0°10′.
+
+## Notes
+- Applying/Separating from relative longitudinal speed sign.
+- Δλ continuity preserved across 0°/360°.
+<!-- >>> AUTO-GEN END: Astro Reference v1.0 -->

--- a/docs/PROJECT_GUIDE.md
+++ b/docs/PROJECT_GUIDE.md
@@ -1,0 +1,24 @@
+<!-- >>> AUTO-GEN BEGIN: Project Guide v1.0 -->
+# AstroEngine — Project Guide
+
+## Purpose
+Authoritative transit computation and astrology tooling with stable APIs, predictable math, and concise outputs.
+
+## Components
+- **Ephemeris Provider**: skyfield/swe backends behind a common interface.
+- **Detectors**: ecliptic aspects (core), declination, antiscia, (later) midpoints/ingresses.
+- **Refinement**: secant/bisection to exactness.
+- **Scoring**: severity profiles and partile boosts.
+- **Export**: SQLite/Parquet.
+
+## Conventions
+- UTC for all timestamps; internal ephemeris time in TT.
+- Angles normalized to [0,360), Δλ tracked continuously.
+- Orbs by body + aspect family; partile at 0°10′ unless profile overrides.
+
+## Change Packets (Chat-Only)
+Use the `AUTO-GEN` markers and `# ENSURE-LINE` hints. Replace blocks with the same name; otherwise append.
+
+## Roadmap
+R1: Transit MVP → R2: declination+antiscia+DSL → R3: ingresses/lunations/stations.
+<!-- >>> AUTO-GEN END: Project Guide v1.0 -->

--- a/rulesets/main.yaml
+++ b/rulesets/main.yaml
@@ -1,0 +1,91 @@
+# >>> AUTO-GEN BEGIN: Ruleset Modules v1.0 (instructions)
+# PURPOSE: Define which modules the main ruleset must include and how to gate them.
+# NOTE: These are text instructions. Do not treat as YAML. Implement each item in proper YAML under `modules:`.
+#
+# GLOBAL RULE: When adding any module below, APPEND UNDER `modules:` ONLY IF an entry with the same `id:` is MISSING.
+#
+# 0) Core Transit Scan (baseline)
+#    id: transit.scan
+#    Channels to implement:
+#      - ingest: use natal group from your manifest (e.g., `ingest: { group: natal }`).
+#      - process: set provider profile (e.g., `skyfield_default`), scan `step` (e.g., 1h), and aspects [0,60,90,120,180].
+#                 Options flags: `include_declination: true|false`, `include_antiscia: true|false` per profile.
+#      - gate: use this gate phrase: "family_cap_per_day(3) and ((aspect in [conjunction, opposition, square] and severity >= 0.65) or (aspect in [trine, sextile] and transiting_body in [Jupiter, Venus]))". Always pass partile.
+#      - score: reference `profile: standard` (quadratic falloff + partile boost; outers slightly heavier).
+#      - export: choose one: `sqlite: data/transits.db` or `parquet: data/transits/` partitioned by natal_id/year.
+#
+# 1) Declination Parallels/Contraparallels (enable when declination available)
+#    id: transit.declination
+#    Detect: parallel/contraparallel when |δ1−δ2| <= 0°30′ (Moon: 0°40′).
+#    Gate: include for luminaries and angles; treat as hard-aspect equivalence; partile priority.
+#    Score: map to hard-aspect weights; apply angularity boost if point is an angle.
+#
+# 2) Antiscia / Contra-Antiscia (profile-toggled)
+#    id: transit.antiscia
+#    Detect: solstitial mirrors (Cancer–Capricorn axis). Use tight orbs (≤1.5°; 2–3° to angles per profile).
+#    Gate: OFF by default; when ON, include only tight hits. Prioritize benefics and angles.
+#
+# 3) Stations (Retrograde/Direct)
+#    id: transit.stations
+#    Detect: sign-change of longitudinal speed; mark `station_kind` {retro,direct} and optional `in_shadow`.
+#    Gate: always include Mercury/Venus/Mars stations; include outer stations if within 2° of any natal planet/angle.
+#    Score: modest base; apply pre-station boost for applying, post-station reduction for separating.
+#
+# 4) Sign Ingresses
+#    id: transit.ingresses
+#    Detect: body crosses multiples of 30°. Record `ingress_sign`.
+#    Gate: always include Sun, Mars, Jupiter, Saturn ingresses; include inner-planet ingresses when within 3° of angles.
+#
+# 5) Lunations
+#    id: transit.lunations
+#    Detect: Sun–Moon conjunction (new) / opposition (full).
+#    Gate: include all lunations; boost ×1.2 if within 3° of angles or natal luminaries.
+#
+# 6) Eclipses
+#    id: transit.eclipses
+#    Detect: lunation with nodal proximity (e.g., |Sun−Node| ≤ 18.5°). Record `eclipse_kind` {solar,lunar} and optional `saros`.
+#    Gate: include when eclipse degree is within 1° of a natal planet/angle.
+#
+# 7) Combust / Cazimi / Under Beams
+#    id: transit.combust
+#    Detect: distances to Sun — cazimi ≤ 0°17′; combust ≤ 8°; under-beams ≤ 15° (overridable by profile).
+#    Gate: always include cazimi; include combust/under-beams for Mercury/Venus. Apply −15% severity for combust, +10% for cazimi.
+#
+# 8) Out-of-Bounds (OOB)
+#    id: transit.oob
+#    Detect: |δ| > 23°27′ (or profile threshold). Record transitions enter/exit and `is_oob` state.
+#    Gate: include Moon, Mercury, Venus, Mars OOB enter/exit by default.
+#
+# 9) Midpoints (limited set)
+#    id: transit.midpoints
+#    Detect: transits to Sun/Moon, ASC/MC, MC/Node midpoints by hard aspects (0/45/90/135/180). Orb ≤ 1°.
+#    Gate: prioritize outer planets; pass when to angles or luminaries.
+#
+# 10) Fixed Stars (bright list)
+#     id: transit.fixedstars
+#     Detect: conjunctions to magnitude ≤ 1.5 stars (e.g., Regulus, Spica, Algol). Orbs: ≤ 0°20′ (≤ 0°10′ for very bright).
+#     Gate: include only when body is angular or a personal significator. Record `star_id`.
+#
+# 11) Vertex / Antivertex (if available)
+#     id: transit.vertex
+#     Detect: hard aspects to natal Vertex/Antivertex with 1°–2° orbs.
+#     Gate: include when personal or outer planets are involved.
+#
+# Cross-cutting Gate Modifiers (apply across modules)
+#   - Angular weighting: multiply severity ×1.2 for angles; ×1.1 when transiting body rules the activated house.
+#   - Sect & dignity: day chart boosts for benefics (+10%), malefic penalty (−10%); +5–10% for rulership/exaltation; − for fall/detriment.
+#   - Retrograde phase: pre-station (applying) boost, post-station (separating) reduction.
+#   - Partile priority: partile hits always pass gate.
+#   - Caps: keep `family_cap_per_day(3)` and add `family_cap_per_week(5)` to reduce clustering.
+#
+# Required DSL Predicates/Functions to implement (so gates can reference them):
+#   is_station(body, kind), in_shadow(body), is_ingress(body), is_lunation(type), is_eclipse(type),
+#   is_cazimi(body), is_combust(body), is_under_beams(body),
+#   is_oob(body), oob_transition(body),
+#   is_parallel(body, natal_point), is_contraparallel(body, natal_point),
+#   is_antiscia(body, natal_point), is_contra_antiscia(body, natal_point),
+#   hit_midpoint(body, pair, aspect), hit_fixed_star(body, star_id),
+#   near(natal_point, deg), within_orb(natal_point, deg),
+#   is_angle(natal_point), has_dignity(body, kind), is_day_chart(natal_id), phase(body),
+#   family_cap_per_day(n), family_cap_per_week(n).
+# >>> AUTO-GEN END: Ruleset Modules v1.0 (instructions)

--- a/rulesets/vca_astroengine_master.yaml
+++ b/rulesets/vca_astroengine_master.yaml
@@ -1,0 +1,18 @@
+modules:
+  - id: transit.scan
+    channels:
+      ingest: { group: natal }
+      process:
+        provider: skyfield_default
+        step: 1h
+        aspects: [conjunction, opposition, square, trine, sextile]
+        options:
+          include_declination: true
+          include_antiscia: false
+      gate: |
+        family_cap_per_day(3) and (
+          (aspect in [conjunction, opposition, square] and severity >= 0.65) or
+          (aspect in [trine, sextile] and transiting_body in [Jupiter, Venus])
+        )
+      score: { profile: standard }
+      export: { sqlite: data/transits.db }

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,0 +1,23 @@
+# >>> AUTO-GEN BEGIN: Transit Preflight Tests v1.0
+from __future__ import annotations
+
+from pathlib import Path
+
+from astroengine.dev.preflight import ruleset_has_module, upsert_autogen_block
+
+
+def test_upsert_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "sample.py"
+    old, new, changed = upsert_autogen_block(str(path), "X", "print('hi')\n")
+    assert changed
+    path.write_text(new, encoding="utf-8")
+    old2, new2, changed2 = upsert_autogen_block(str(path), "X", "print('hi')\n")
+    assert not changed2
+    assert new2 == old2
+
+
+def test_ruleset_has_module(tmp_path: Path) -> None:
+    ruleset = tmp_path / "rules.yaml"
+    ruleset.write_text("modules:\n  - id: transit.scan\n", encoding="utf-8")
+    assert ruleset_has_module(str(ruleset), "transit.scan")
+# >>> AUTO-GEN END: Transit Preflight Tests v1.0


### PR DESCRIPTION
## Summary
- add developer preflight helpers for managing transit scaffolding and ruleset entries
- expose a CLI wrapper to run the transit preflight workflow from the command line
- cover the helpers with regression tests ensuring idempotent block updates and module detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cc837841e48324b7af334c1d7de7df