### PR TITLE
Expand schema coverage for provider integrations and transit flags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "astroengine"
+version = "0.1.0"
+description = "Schema definitions and validation helpers for AstroEngine"
+readme = "README.md"
+requires-python = ">=3.9"
+authors = [{ name = "AstroEngine Operators" }]
+license = { text = "MIT" }
+
+[project.optional-dependencies]
+skyfield = ["skyfield", "jplephem", "numpy"]
+# Swiss Ephemeris bindings ship under a restrictive license; audit before enabling commercially.
+swe = ["pyswisseph"]
+parquet = ["pyarrow"]
+cli = ["click"]
+dev = ["pytest", "hypothesis", "ruff", "black", "mypy", "tzdata"]
+maps = ["pyproj", "shapely", "geopandas"]
+
+[project.urls]
+"Repository" = "https://example.com/astroengine"
+"Documentation" = "https://example.com/astroengine/docs"

--- a/schemas/contact_gate_schema_v2.json
+++ b/schemas/contact_gate_schema_v2.json
@@ -61,6 +61,10 @@
           "id",
           "channel",
           "decision",
+          "provenance",
+          "predicates",
+          "family",
+          "module",
           "score",
           "threshold",
           "window",
@@ -199,6 +203,73 @@
           },
           "recommendation": {
             "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "submodule": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string",
+            "enum": [
+              "transit",
+              "station",
+              "ingress",
+              "lunation",
+              "solar_eclipse",
+              "lunar_eclipse",
+              "combust",
+              "cazimi",
+              "under_beams",
+              "out_of_bounds",
+              "declination_parallel",
+              "declination_contraparallel",
+              "midpoint",
+              "fixed_star",
+              "antiscia",
+              "contra_antiscia",
+              "progression",
+              "return",
+              "minor_planet"
+            ]
+          },
+          "predicates": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "is_transit",
+                "is_station",
+                "is_ingress",
+                "is_lunation",
+                "is_eclipse",
+                "is_cazimi",
+                "is_combust",
+                "is_under_beams",
+                "is_oob",
+                "oob_transition",
+                "is_parallel",
+                "is_contraparallel",
+                "is_antiscia",
+                "is_contra_antiscia",
+                "hit_midpoint",
+                "hit_fixed_star",
+                "is_minor_planet",
+                "is_progression",
+                "is_return"
+              ]
+            }
+          },
+          "provenance": {
+            "$ref": "#/$defs/gateProvenance"
+          },
+          "datasets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }
@@ -211,7 +282,12 @@
       "required": [
         "event_id",
         "orb",
-        "valence"
+        "valence",
+        "family",
+        "predicates",
+        "provenance",
+        "module",
+        "submodule"
       ],
       "properties": {
         "event_id": {
@@ -234,6 +310,96 @@
           "type": "boolean"
         },
         "note": {
+          "type": "string"
+        },
+        "family": {
+          "type": "string",
+          "enum": [
+            "transit",
+            "station",
+            "ingress",
+            "lunation",
+            "solar_eclipse",
+            "lunar_eclipse",
+            "combust",
+            "cazimi",
+            "under_beams",
+            "out_of_bounds",
+            "declination_parallel",
+            "declination_contraparallel",
+            "midpoint",
+            "fixed_star",
+            "antiscia",
+            "contra_antiscia",
+            "progression",
+            "return",
+            "minor_planet"
+          ]
+        },
+        "predicates": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "is_transit",
+              "is_station",
+              "is_ingress",
+              "is_lunation",
+              "is_eclipse",
+              "is_cazimi",
+              "is_combust",
+              "is_under_beams",
+              "is_oob",
+              "oob_transition",
+              "is_parallel",
+              "is_contraparallel",
+              "is_antiscia",
+              "is_contra_antiscia",
+              "hit_midpoint",
+              "hit_fixed_star",
+              "is_minor_planet",
+              "is_progression",
+              "is_return"
+            ]
+          }
+        },
+        "provenance": {
+          "$ref": "#/$defs/gateProvenance"
+        },
+        "module": {
+          "type": "string"
+        },
+        "submodule": {
+          "type": "string"
+        }
+      }
+    },
+    "gateProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dataset",
+        "record_id"
+      ],
+      "properties": {
+        "dataset": {
+          "type": "string"
+        },
+        "record_id": {
+          "type": "string"
+        },
+        "source_module": {
+          "type": "string"
+        },
+        "calculation": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "notes": {
           "type": "string"
         }
       }

--- a/schemas/orbs_policy.json
+++ b/schemas/orbs_policy.json
@@ -84,6 +84,167 @@
         "wide": 4.0
       },
       "notes": "Health and adjustments channel emphasises these hits."
+    },
+    "parallel": {
+      "category": "declination",
+      "base_orb": 0.5,
+      "notes": "Declination parallel treated similar to conjunction; Moon uses wider orb via conditions."
+    },
+    "contraparallel": {
+      "category": "declination",
+      "base_orb": 0.5,
+      "notes": "Contraparallel mirrors opposition in declination scoring."
     }
+  },
+  "conditions": {
+    "cazimi": {
+      "orb_deg": 0.2833,
+      "notes": "\u2264 0\u00b017\u2032 separation from the Sun."
+    },
+    "combust": {
+      "orb_deg": 8.0,
+      "notes": "Classical combustion window."
+    },
+    "under_beams": {
+      "orb_deg": 15.0,
+      "notes": "Under-beams tracking for Mercury and Venus."
+    },
+    "out_of_bounds": {
+      "declination_deg": 23.45,
+      "bodies": [
+        "Moon",
+        "Mercury",
+        "Venus",
+        "Mars"
+      ],
+      "notes": "Detect transitions beyond solar declination limits."
+    },
+    "declination_parallel": {
+      "orb_deg": 0.5,
+      "moon_orb_deg": 0.6667,
+      "notes": "Default \u00b10\u00b030\u2032, Moon \u00b10\u00b040\u2032."
+    },
+    "fixed_star": {
+      "default_orb_deg": 0.3333,
+      "bright_magnitude_threshold": 1.0,
+      "bright_orb_deg": 0.1667,
+      "notes": "Bright stars tighter orb, default \u22640\u00b020\u2032."
+    },
+    "midpoint": {
+      "orb_deg": 1.0,
+      "angles": [
+        0,
+        45,
+        90,
+        135,
+        180
+      ],
+      "notes": "Cosmobiology core midpoint aspects."
+    },
+    "lunation_boost": {
+      "angle_tight_deg": 3.0,
+      "boost_multiplier": 1.2,
+      "notes": "Boost when lunation within 3\u00b0 of angles or natal luminaries."
+    },
+    "eclipse": {
+      "orb_deg": 1.0,
+      "notes": "Eclipse inclusion when degree within 1\u00b0 of natal contact."
+    }
+  },
+  "minor_planets": {
+    "default_enabled": false,
+    "bodies": [
+      "Ceres",
+      "Pallas",
+      "Juno",
+      "Vesta",
+      "Chiron"
+    ],
+    "orb_profile": {
+      "personal_like": 6.0,
+      "outer_like": 4.0
+    },
+    "notes": "Minor planets available behind profile toggles."
+  },
+  "fixed_stars": {
+    "catalog": "astroengine-fixed-stars",
+    "default_orb_deg": 0.3333,
+    "bright_star_orb_deg": 0.1667,
+    "notes": "Curated bright-star list with proper motion applied."
+  },
+  "midpoints": {
+    "core_sets": [
+      "Sun/Moon",
+      "ASC/MC",
+      "MC/Node"
+    ],
+    "angles": [
+      0,
+      45,
+      90,
+      135,
+      180
+    ],
+    "orb_deg": 1.0,
+    "notes": "Extended Uranian sets remain profile gated."
+  },
+  "ayanamshas": {
+    "tropical": {
+      "offset_deg_at_j2000": 0.0,
+      "source": "Tropical zodiac reference.",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "lahiri": {
+      "offset_deg_at_j2000": -23.8531,
+      "source": "Hindu Calendar Reform Committee (1955).",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "fagan_bradley": {
+      "offset_deg_at_j2000": -24.0275,
+      "source": "Donald Bradley calculations.",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "krishnamurti": {
+      "offset_deg_at_j2000": -23.9617,
+      "source": "K. S. Krishnamurti ayanamsha.",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "raman": {
+      "offset_deg_at_j2000": -22.8586,
+      "source": "B. V. Raman sidereal zodiac.",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "true_chitra": {
+      "offset_deg_at_j2000": -23.8531,
+      "source": "True Chitra (Chitra Paksha).",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "yukteswar": {
+      "offset_deg_at_j2000": -23.501,
+      "source": "Sri Yukteswar ayanamsha.",
+      "offset_reference_epoch": "J2000.0"
+    },
+    "galactic_center": {
+      "offset_deg_at_j2000": -27.0,
+      "source": "Experimental alignment to Galactic Center.",
+      "offset_reference_epoch": "J2000.0"
+    }
+  },
+  "house_systems": {
+    "default": "whole_sign",
+    "supported": [
+      "whole_sign",
+      "equal",
+      "placidus",
+      "koch",
+      "regiomontanus",
+      "campanus",
+      "porphyry",
+      "topocentric",
+      "alcabitius",
+      "morinus",
+      "meridian"
+    ],
+    "notes": "Default Whole Sign; others selectable per profile."
   }
 }

--- a/schemas/result_schema_v1.json
+++ b/schemas/result_schema_v1.json
@@ -10,7 +10,9 @@
     "window",
     "subjects",
     "channels",
-    "events"
+    "events",
+    "modules",
+    "datasets"
   ],
   "properties": {
     "schema": {
@@ -39,7 +41,10 @@
         "profile",
         "generated_at",
         "engine_version",
-        "ruleset_version"
+        "ruleset_version",
+        "providers",
+        "ruleset_modules",
+        "data_integrity"
       ],
       "properties": {
         "id": {
@@ -64,6 +69,126 @@
         },
         "timezone": {
           "type": "string"
+        },
+        "providers": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "ephemeris"
+          ],
+          "properties": {
+            "ephemeris": {
+              "$ref": "#/$defs/ephemerisProvider"
+            },
+            "atlas": {
+              "$ref": "#/$defs/atlasProvider"
+            },
+            "fixed_stars": {
+              "$ref": "#/$defs/catalogProvider"
+            },
+            "time_scale": {
+              "$ref": "#/$defs/timeProvider"
+            }
+          }
+        },
+        "ruleset_modules": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "transit.stations",
+              "transit.ingresses",
+              "transit.lunations",
+              "transit.eclipses",
+              "transit.combust",
+              "transit.oob",
+              "transit.declination",
+              "transit.antiscia",
+              "transit.midpoints",
+              "transit.fixedstars"
+            ]
+          }
+        },
+        "extras": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "skyfield",
+              "swe",
+              "parquet",
+              "cli",
+              "dev",
+              "maps"
+            ]
+          }
+        },
+        "profile_settings": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "default_house_system": {
+              "$ref": "#/$defs/houseSystem"
+            },
+            "default_ayanamsha": {
+              "$ref": "#/$defs/ayanamsha"
+            },
+            "enable_minor_planets": {
+              "type": "boolean"
+            },
+            "enable_progressions": {
+              "type": "boolean"
+            },
+            "enable_returns": {
+              "type": "boolean"
+            },
+            "enable_fixed_stars": {
+              "type": "boolean"
+            },
+            "enable_declination": {
+              "type": "boolean"
+            },
+            "enable_midpoints": {
+              "type": "boolean"
+            },
+            "enable_lunations": {
+              "type": "boolean"
+            },
+            "enable_eclipses": {
+              "type": "boolean"
+            }
+          }
+        },
+        "data_integrity": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "datasets_verified"
+          ],
+          "properties": {
+            "datasets_verified": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "ephemeris_cross_checks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "house_system_checks": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "notes": {
+              "type": "string"
+            }
+          }
         }
       }
     },
@@ -101,7 +226,8 @@
         "required": [
           "token",
           "name",
-          "role"
+          "role",
+          "natal"
         ],
         "properties": {
           "token": {
@@ -118,6 +244,21 @@
           },
           "consent": {
             "type": "boolean"
+          },
+          "natal": {
+            "$ref": "#/$defs/natalRecord"
+          },
+          "house_system": {
+            "$ref": "#/$defs/houseSystem"
+          },
+          "ayanamsha": {
+            "$ref": "#/$defs/ayanamsha"
+          },
+          "data_sources": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }
@@ -129,6 +270,7 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
+          "module",
           "id",
           "name",
           "score",
@@ -218,6 +360,15 @@
                       }
                     }
                   }
+                },
+                "module": {
+                  "type": "string"
+                },
+                "submodule": {
+                  "type": "string"
+                },
+                "channel": {
+                  "type": "string"
                 }
               }
             }
@@ -254,6 +405,12 @@
                 }
               }
             }
+          },
+          "submodule": {
+            "type": "string"
+          },
+          "module": {
+            "type": "string"
           }
         }
       }
@@ -275,7 +432,13 @@
           "channel",
           "orb",
           "valence",
-          "strength"
+          "strength",
+          "module",
+          "submodule",
+          "subchannel",
+          "family",
+          "predicates",
+          "provenance"
         ],
         "properties": {
           "id": {
@@ -384,6 +547,721 @@
           },
           "notes": {
             "type": "string"
+          },
+          "module": {
+            "type": "string"
+          },
+          "submodule": {
+            "type": "string"
+          },
+          "subchannel": {
+            "type": "string"
+          },
+          "family": {
+            "type": "string",
+            "enum": [
+              "transit",
+              "station",
+              "ingress",
+              "lunation",
+              "solar_eclipse",
+              "lunar_eclipse",
+              "combust",
+              "cazimi",
+              "under_beams",
+              "out_of_bounds",
+              "declination_parallel",
+              "declination_contraparallel",
+              "midpoint",
+              "fixed_star",
+              "antiscia",
+              "contra_antiscia",
+              "progression",
+              "return",
+              "minor_planet"
+            ]
+          },
+          "predicates": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "string",
+              "enum": [
+                "is_transit",
+                "is_station",
+                "is_ingress",
+                "is_lunation",
+                "is_eclipse",
+                "is_cazimi",
+                "is_combust",
+                "is_under_beams",
+                "is_oob",
+                "oob_transition",
+                "is_parallel",
+                "is_contraparallel",
+                "is_antiscia",
+                "is_contra_antiscia",
+                "hit_midpoint",
+                "hit_fixed_star",
+                "is_minor_planet",
+                "is_progression",
+                "is_return"
+              ]
+            }
+          },
+          "feature_flags": {
+            "$ref": "#/$defs/featureFlags"
+          },
+          "provenance": {
+            "$ref": "#/$defs/eventProvenance"
+          },
+          "house_system": {
+            "$ref": "#/$defs/houseSystem"
+          },
+          "ayanamsha": {
+            "$ref": "#/$defs/ayanamsha"
+          },
+          "midpoint": {
+            "$ref": "#/$defs/midpointDescriptor"
+          },
+          "fixed_star": {
+            "$ref": "#/$defs/fixedStarDescriptor"
+          },
+          "dignity": {
+            "$ref": "#/$defs/dignityState"
+          },
+          "saros_series": {
+            "type": "string"
+          },
+          "lunar_phase": {
+            "type": "string"
+          },
+          "declination": {
+            "type": "number"
+          },
+          "progression_kind": {
+            "type": "string",
+            "enum": [
+              "secondary",
+              "solar_arc",
+              "lunar",
+              "other"
+            ]
+          },
+          "return_kind": {
+            "type": "string",
+            "enum": [
+              "solar",
+              "lunar",
+              "venus",
+              "mars",
+              "other"
+            ]
+          },
+          "dataset_refs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "severity_modifier": {
+            "type": "number"
+          }
+        }
+      }
+    },
+    "modules": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/moduleDescriptor"
+      }
+    },
+    "datasets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/dataSource"
+      }
+    }
+  },
+  "$defs": {
+    "houseSystem": {
+      "type": "string",
+      "enum": [
+        "whole_sign",
+        "equal",
+        "placidus",
+        "koch",
+        "regiomontanus",
+        "campanus",
+        "porphyry",
+        "topocentric",
+        "alcabitius",
+        "morinus",
+        "meridian"
+      ]
+    },
+    "ayanamsha": {
+      "type": "string",
+      "enum": [
+        "tropical",
+        "lahiri",
+        "fagan_bradley",
+        "krishnamurti",
+        "raman",
+        "true_chitra",
+        "yukteswar",
+        "galactic_center"
+      ]
+    },
+    "ephemerisProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "version",
+        "mode"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "ephemeris"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "skyfield",
+            "swiss_ephemeris",
+            "hybrid"
+          ]
+        },
+        "notes": {
+          "type": "string"
+        },
+        "ayanamsha": {
+          "$ref": "#/$defs/ayanamsha"
+        },
+        "house_system_default": {
+          "$ref": "#/$defs/houseSystem"
+        },
+        "supports_minor_planets": {
+          "type": "boolean"
+        },
+        "supports_fixed_stars": {
+          "type": "boolean"
+        },
+        "supports_lunations": {
+          "type": "boolean"
+        },
+        "supports_eclipses": {
+          "type": "boolean"
+        },
+        "parity_window_arcsec": {
+          "type": "number"
+        },
+        "house_cusp_tolerance_arcsec": {
+          "type": "number"
+        },
+        "tests_ran": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "atlasProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "atlas"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "supports_timezone_lookup": {
+          "type": "boolean"
+        },
+        "geocoder": {
+          "type": "string"
+        }
+      }
+    },
+    "catalogProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "fixed_star_catalog"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "epoch": {
+          "type": "string"
+        },
+        "magnitude_limit": {
+          "type": "number"
+        }
+      }
+    },
+    "timeProvider": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "kind",
+        "version"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "time_scale"
+          ]
+        },
+        "version": {
+          "type": "string"
+        },
+        "mode": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        },
+        "database": {
+          "type": "string"
+        }
+      }
+    },
+    "dataSource": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "format",
+        "path"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "format": {
+          "type": "string",
+          "enum": [
+            "csv",
+            "sqlite",
+            "parquet",
+            "json",
+            "jsonl",
+            "feather"
+          ]
+        },
+        "path": {
+          "type": "string"
+        },
+        "indexed": {
+          "type": "boolean"
+        },
+        "index_fields": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "row_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "checksum": {
+          "type": "string"
+        },
+        "last_updated": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "eventProvenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dataset",
+        "record_id"
+      ],
+      "properties": {
+        "dataset": {
+          "type": "string"
+        },
+        "record_id": {
+          "type": "string"
+        },
+        "source_module": {
+          "type": "string"
+        },
+        "calculation": {
+          "type": "string"
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "quality": {
+          "type": "string"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "featureFlags": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "is_station": {
+          "type": "boolean"
+        },
+        "is_ingress": {
+          "type": "boolean"
+        },
+        "is_lunation": {
+          "type": "boolean"
+        },
+        "is_eclipse": {
+          "type": "boolean"
+        },
+        "is_cazimi": {
+          "type": "boolean"
+        },
+        "is_combust": {
+          "type": "boolean"
+        },
+        "is_under_beams": {
+          "type": "boolean"
+        },
+        "is_out_of_bounds": {
+          "type": "boolean"
+        },
+        "entered_out_of_bounds": {
+          "type": "boolean"
+        },
+        "is_declination_parallel": {
+          "type": "boolean"
+        },
+        "is_declination_contraparallel": {
+          "type": "boolean"
+        },
+        "is_midpoint": {
+          "type": "boolean"
+        },
+        "is_fixed_star": {
+          "type": "boolean"
+        },
+        "is_antiscia": {
+          "type": "boolean"
+        },
+        "is_contra_antiscia": {
+          "type": "boolean"
+        },
+        "is_progressed": {
+          "type": "boolean"
+        },
+        "is_return": {
+          "type": "boolean"
+        },
+        "is_minor_planet": {
+          "type": "boolean"
+        }
+      }
+    },
+    "natalRecord": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "timestamp",
+        "tzid",
+        "utc_offset_minutes",
+        "latitude",
+        "longitude",
+        "source"
+      ],
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "tzid": {
+          "type": "string"
+        },
+        "utc_offset_minutes": {
+          "type": "integer"
+        },
+        "latitude": {
+          "type": "number"
+        },
+        "longitude": {
+          "type": "number"
+        },
+        "altitude_m": {
+          "type": "number"
+        },
+        "location_name": {
+          "type": "string"
+        },
+        "source": {
+          "type": "string"
+        },
+        "atlas_provider": {
+          "type": "string"
+        },
+        "house_system": {
+          "$ref": "#/$defs/houseSystem"
+        },
+        "ayanamsha": {
+          "$ref": "#/$defs/ayanamsha"
+        },
+        "notes": {
+          "type": "string"
+        }
+      }
+    },
+    "midpointDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "points"
+      ],
+      "properties": {
+        "points": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": "string"
+          }
+        },
+        "angle": {
+          "type": "number"
+        }
+      }
+    },
+    "fixedStarDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "magnitude": {
+          "type": "number"
+        },
+        "orb": {
+          "type": "number"
+        }
+      }
+    },
+    "dignityState": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rulership": {
+          "type": "string"
+        },
+        "exaltation": {
+          "type": "string"
+        },
+        "triplicity": {
+          "type": "string"
+        },
+        "term": {
+          "type": "string"
+        },
+        "face": {
+          "type": "string"
+        },
+        "sect": {
+          "type": "string"
+        },
+        "modifier": {
+          "type": "number"
+        }
+      }
+    },
+    "subchannelDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "channelDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "subchannels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/subchannelDescriptor"
+          }
+        }
+      }
+    },
+    "submoduleDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/channelDescriptor"
+          }
+        }
+      }
+    },
+    "moduleDescriptor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "channels"
+      ],
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "profile": {
+          "type": "string"
+        },
+        "channels": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/channelDescriptor"
+          }
+        },
+        "submodules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/submoduleDescriptor"
           }
         }
       }

--- a/tests/test_contact_gate_schema.py
+++ b/tests/test_contact_gate_schema.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from copy import deepcopy
 
 import pytest
@@ -21,6 +19,10 @@ def _valid_gate_payload() -> dict:
                 "id": "GATE-001A",
                 "channel": "relationship",
                 "subchannel": "relationship_bonding",
+                "module": "transits",
+                "submodule": "transits.relationship",
+                "family": "transit",
+                "predicates": ["is_transit"],
                 "decision": "include",
                 "score": 42.0,
                 "threshold": 35.0,
@@ -44,6 +46,16 @@ def _valid_gate_payload() -> dict:
                             "valence": 0.85,
                             "strength": 72.5,
                             "near_threshold": False,
+                            "family": "transit",
+                            "predicates": ["is_transit"],
+                            "provenance": {
+                                "dataset": "ephemeris_jpl",
+                                "record_id": "EVT-0001",
+                                "source_module": "transits.core",
+                                "timestamp": "2025-09-03T12:00:01Z",
+                            },
+                            "module": "transits",
+                            "submodule": "transits.relationship",
                         }
                     ],
                     "confidence": 0.93,
@@ -55,6 +67,13 @@ def _valid_gate_payload() -> dict:
                     "source": "scoring.contact_gate",
                     "manual_override": False,
                 },
+                "provenance": {
+                    "dataset": "contact_gates",
+                    "record_id": "GATE-001A",
+                    "source_module": "scoring.contact_gate",
+                    "timestamp": "2025-09-03T12:05:01Z",
+                },
+                "datasets": ["ephemeris_jpl", "contact_gates"],
                 "recommendation": "Highlight in daily narrative",
             }
         ],

--- a/tests/test_orbs_policy.py
+++ b/tests/test_orbs_policy.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from astroengine.data.schemas import list_schema_keys, load_schema_document
 from astroengine.validation import available_schema_keys
 
@@ -16,7 +14,22 @@ def test_orbs_policy_contains_expected_entries():
         "trine",
         "sextile",
         "quincunx",
+        "parallel",
+        "contraparallel",
     }
+    assert data["conditions"]["cazimi"]["orb_deg"] == 0.2833
+    assert data["conditions"]["fixed_star"]["bright_orb_deg"] == 0.1667
+    assert data["minor_planets"]["bodies"] == [
+        "Ceres",
+        "Pallas",
+        "Juno",
+        "Vesta",
+        "Chiron",
+    ]
+    assert data["fixed_stars"]["catalog"] == "astroengine-fixed-stars"
+    assert data["midpoints"]["orb_deg"] == 1.0
+    assert data["ayanamshas"]["lahiri"]["offset_deg_at_j2000"] == -23.8531
+    assert data["house_systems"]["default"] == "whole_sign"
 
 
 def test_available_schema_keys_filters_jsonschemas():

--- a/tests/test_result_schema.py
+++ b/tests/test_result_schema.py
@@ -18,6 +18,89 @@ def _valid_result_payload() -> dict:
             "ruleset_version": "v2.18.13",
             "seed": 42,
             "timezone": "America/New_York",
+            "providers": {
+                "ephemeris": {
+                    "id": "astroengine.ephemeris.skyfield",
+                    "name": "Skyfield Ephemeris",
+                    "kind": "ephemeris",
+                    "version": "2025.9",
+                    "mode": "skyfield",
+                    "ayanamsha": "tropical",
+                    "house_system_default": "whole_sign",
+                    "supports_minor_planets": True,
+                    "supports_fixed_stars": True,
+                    "supports_lunations": True,
+                    "supports_eclipses": True,
+                    "parity_window_arcsec": 1.2,
+                    "house_cusp_tolerance_arcsec": 15.0,
+                    "tests_ran": [
+                        "sun_pluto_parity_window<2arcsec",
+                        "placidus_vs_whole_sign_delta<0.5deg",
+                    ],
+                },
+                "atlas": {
+                    "id": "astroengine.atlas.tzdb",
+                    "name": "TimezoneFinder Atlas",
+                    "kind": "atlas",
+                    "version": "2025.8",
+                    "mode": "timezonefinder",
+                    "supports_timezone_lookup": True,
+                    "geocoder": "nominatim",
+                },
+                "fixed_stars": {
+                    "id": "astroengine.catalog.fixedstars",
+                    "name": "Fixed Star Catalog",
+                    "kind": "fixed_star_catalog",
+                    "version": "2025.8",
+                    "mode": "catalog",
+                    "epoch": "J2000.0",
+                    "magnitude_limit": 2.0,
+                },
+                "time_scale": {
+                    "id": "astroengine.time.tzdb",
+                    "name": "IANA TZDB",
+                    "kind": "time_scale",
+                    "version": "2025a",
+                    "mode": "tzdb",
+                    "database": "tzdata",
+                },
+            },
+            "ruleset_modules": [
+                "transit.stations",
+                "transit.ingresses",
+                "transit.lunations",
+                "transit.eclipses",
+                "transit.combust",
+                "transit.oob",
+                "transit.declination",
+                "transit.antiscia",
+                "transit.midpoints",
+                "transit.fixedstars",
+            ],
+            "extras": ["skyfield", "parquet"],
+            "profile_settings": {
+                "default_house_system": "whole_sign",
+                "default_ayanamsha": "tropical",
+                "enable_minor_planets": True,
+                "enable_progressions": True,
+                "enable_returns": True,
+                "enable_fixed_stars": True,
+                "enable_declination": True,
+                "enable_midpoints": True,
+                "enable_lunations": True,
+                "enable_eclipses": True,
+            },
+            "data_integrity": {
+                "datasets_verified": ["ephemeris_jpl", "fixed_star_catalog"],
+                "ephemeris_cross_checks": [
+                    "Sun-Pluto arcsecond parity < 2.0",
+                    "Swiss Ephemeris parity verified",
+                ],
+                "house_system_checks": [
+                    "Placidus vs Whole Sign cusp delta < 0.5°",
+                ],
+                "notes": "All integrity checks passed",
+            },
         },
         "window": {
             "start": "2025-09-03T00:00:00Z",
@@ -32,10 +115,28 @@ def _valid_result_payload() -> dict:
                 "role": "primary",
                 "id": "IND-001",
                 "consent": True,
+                "natal": {
+                    "timestamp": "1992-04-10T14:32:00Z",
+                    "tzid": "America/New_York",
+                    "utc_offset_minutes": -240,
+                    "latitude": 40.7128,
+                    "longitude": -74.006,
+                    "altitude_m": 10.0,
+                    "location_name": "New York, NY",
+                    "source": "user_provided",
+                    "atlas_provider": "timezonefinder",
+                    "house_system": "whole_sign",
+                    "ayanamsha": "tropical",
+                    "notes": "Verified via tzdb",
+                },
+                "house_system": "whole_sign",
+                "ayanamsha": "tropical",
+                "data_sources": ["natal_index"],
             }
         ],
         "channels": [
             {
+                "module": "transits",
                 "id": "relationship",
                 "name": "Relationship",
                 "score": 42.5,
@@ -54,6 +155,9 @@ def _valid_result_payload() -> dict:
                                 "timestamp": "2025-09-03T18:00:00Z",
                             }
                         ],
+                        "module": "transits",
+                        "submodule": "transits.relationship",
+                        "channel": "relationship",
                     }
                 ],
                 "peaks": [
@@ -64,6 +168,7 @@ def _valid_result_payload() -> dict:
                         "tier": "major",
                     }
                 ],
+                "submodule": "transits.relationship",
             }
         ],
         "events": [
@@ -98,7 +203,102 @@ def _valid_result_payload() -> dict:
                 "is_near_threshold": False,
                 "tags": ["Venus", "Mars", "trine"],
                 "notes": "Favorable connection",
+                "module": "transits",
+                "submodule": "transits.relationship",
+                "subchannel": "relationship_bonding",
+                "family": "transit",
+                "predicates": ["is_transit"],
+                "feature_flags": {
+                    "is_combust": False,
+                    "is_under_beams": False,
+                    "is_out_of_bounds": False,
+                    "is_progressed": False,
+                    "is_return": False,
+                    "is_minor_planet": False,
+                },
+                "provenance": {
+                    "dataset": "ephemeris_jpl",
+                    "record_id": "VENUS-2025-09-03T17:45Z",
+                    "source_module": "transits.core",
+                    "calculation": "skyfield.ephemeris",
+                    "timestamp": "2025-09-03T12:00:00Z",
+                    "quality": "verified",
+                },
+                "house_system": "whole_sign",
+                "ayanamsha": "tropical",
+                "declination": 8.2,
+                "progression_kind": "other",
+                "return_kind": "other",
+                "dataset_refs": ["ephemeris_jpl", "fixed_star_catalog"],
+                "severity_modifier": 0.1,
             }
+        ],
+        "modules": [
+            {
+                "id": "transits",
+                "name": "Transits Core",
+                "description": "Primary transit scoring module",
+                "profile": "AP-SUPER",
+                "channels": [
+                    {
+                        "id": "relationship",
+                        "name": "Relationship",
+                        "description": "Relationship composite scoring",
+                        "subchannels": [
+                            {
+                                "id": "relationship_bonding",
+                                "name": "Bonding",
+                                "description": "High-trust bonding focus",
+                            }
+                        ],
+                    }
+                ],
+                "submodules": [
+                    {
+                        "id": "transits.relationship",
+                        "name": "Relationship Focus",
+                        "description": "Transits tuned to relationship channel",
+                        "channels": [
+                            {
+                                "id": "relationship",
+                                "name": "Relationship",
+                                "description": "Relationship composite scoring",
+                                "subchannels": [
+                                    {
+                                        "id": "relationship_bonding",
+                                        "name": "Bonding",
+                                        "description": "High-trust bonding focus",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+        "datasets": [
+            {
+                "id": "ephemeris_jpl",
+                "description": "JPL DE441 ephemeris subset",
+                "format": "sqlite",
+                "path": "db/ephemeris_jpl.sqlite",
+                "indexed": True,
+                "index_fields": ["jd"],
+                "row_count": 123456,
+                "checksum": "sha256:abc123",
+                "last_updated": "2025-09-01T00:00:00Z",
+            },
+            {
+                "id": "fixed_star_catalog",
+                "description": "Curated fixed star table",
+                "format": "csv",
+                "path": "data/fixed_stars.csv",
+                "indexed": True,
+                "index_fields": ["name"],
+                "row_count": 58,
+                "checksum": "sha256:def456",
+                "last_updated": "2025-08-20T00:00:00Z",
+            },
         ],
     }
 
@@ -106,6 +306,18 @@ def _valid_result_payload() -> dict:
 def test_result_schema_accepts_valid_payload():
     payload = _valid_result_payload()
     validate_payload("result_v1", payload)
+    assert {
+        "transit.stations",
+        "transit.ingresses",
+        "transit.lunations",
+        "transit.eclipses",
+        "transit.combust",
+        "transit.oob",
+        "transit.declination",
+        "transit.antiscia",
+        "transit.midpoints",
+        "transit.fixedstars",
+    }.issubset(set(payload["run"]["ruleset_modules"]))
 
 
 def test_result_schema_rejects_invalid_event_payload():


### PR DESCRIPTION
## Summary
- extend the result payload schema with provider metadata, module/submodule hierarchies, dataset references, and detailed transit feature flags
- require module, predicate, and provenance data in the contact gate schema and synchronize referenced events with the expanded enumerations
- enrich the orbs policy with declination aspects, condition thresholds, minor planet guidance, and sidereal ayanamsha listings while updating tests and optional dependencies accordingly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc87ac91308324bde58b1d11fd9e29