### PR TITLE
Add ruleset, provider, and profile specifications

### DIFF
--- a/astroengine/providers/__init__.py
+++ b/astroengine/providers/__init__.py
@@ -1,0 +1,156 @@
+"""Provider plugin API contracts for AstroEngine.
+
+This module defines the runtime interfaces used by ruleset executors to
+communicate with ephemeris backends. Providers are discovered through the
+``astroengine.providers`` entry-point group and must implement the
+:class:`EphemerisProvider` protocol defined here. The design enforces the
+following guarantees:
+
+* Deterministic outputs – repeated queries with identical inputs MUST return
+  identical results and determinism hash inputs.
+* Cache transparency – providers surface cache metadata and validation hashes;
+  the caller never assumes implicit fallbacks.
+* Structured error taxonomy – all provider errors are reported using the
+  :class:`ProviderError` hierarchy so callers can differentiate retriable vs
+  fatal states.
+
+Providers are required to declare their supported bodies, coordinate frames,
+precision targets, and cache layout via :class:`ProviderMetadata`. The metadata
+structures and result containers defined here are intentionally lightweight so
+plugins can be implemented in pure Python or compiled extensions while still
+respecting the schema contracts enforced by the engine.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Mapping, Optional, Protocol, Sequence
+
+
+class ProviderError(RuntimeError):
+    """Base class for provider failures.
+
+    Subclasses MUST populate the ``provider_id`` field so structured logging
+    can attribute failures, and SHOULD supply a deterministic ``error_code``
+    string that matches documentation in ``docs/providers/registry.md``.
+    """
+
+    provider_id: str
+    error_code: str
+    retriable: bool
+
+    def __init__(self, message: str, *, provider_id: str, error_code: str, retriable: bool) -> None:
+        super().__init__(message)
+        self.provider_id = provider_id
+        self.error_code = error_code
+        self.retriable = retriable
+
+
+class CacheStatus(Enum):
+    """Enumerates cache states a provider may report."""
+
+    WARM = "warm"
+    COLD = "cold"
+    STALE = "stale"
+    INVALID = "invalid"
+
+
+@dataclass(frozen=True)
+class CacheInfo:
+    """Describes ephemeris cache provenance."""
+
+    cache_path: str
+    checksum: str
+    generated_at: datetime
+    status: CacheStatus
+
+
+@dataclass(frozen=True)
+class ProviderMetadata:
+    """Static metadata for provider registration."""
+
+    provider_id: str
+    version: str
+    supported_bodies: Sequence[str]
+    supported_frames: Sequence[str]
+    supports_declination: bool
+    supports_light_time: bool
+    cache_layout: Mapping[str, str]
+    extras_required: Sequence[str]
+    documentation_url: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class EphemerisVector:
+    """Represents a single ephemeris sample."""
+
+    body_id: str
+    timestamp: datetime
+    frame: str
+    position_km: Sequence[float]
+    velocity_km_s: Sequence[float]
+    longitude_deg: float
+    latitude_deg: float
+    right_ascension_deg: float
+    declination_deg: float
+    distance_au: float
+    speed_longitude_deg_per_day: float
+    data_provenance: Mapping[str, str]
+
+
+@dataclass(frozen=True)
+class EphemerisBatch:
+    """Vectorized result returned by :meth:`EphemerisProvider.query`."""
+
+    vectors: Sequence[EphemerisVector]
+    cache_info: CacheInfo
+    determinism_inputs: Mapping[str, str]
+
+
+class EphemerisProvider(Protocol):
+    """Protocol that all provider plugins must implement."""
+
+    metadata: ProviderMetadata
+
+    def configure(self, *, profile_flags: Mapping[str, object], options: Optional[Mapping[str, object]] = None) -> None:
+        """Apply profile-specific configuration.
+
+        Implementations MUST be idempotent and only mutate internal caches.
+        Raising :class:`ProviderError` signals misconfiguration.
+        """
+
+    def prime_cache(self, *, start: datetime, end: datetime, bodies: Sequence[str], cadence_hours: float) -> CacheInfo:
+        """Warm ephemeris caches for the requested window.
+
+        Providers may download ephemeris files, but MUST verify checksums and
+        refuse to continue when validation fails.
+        """
+
+    def query(self, *, timestamps: Sequence[datetime], bodies: Sequence[str], frame: str) -> EphemerisBatch:
+        """Return deterministic vectors for all timestamps/bodies in the requested frame."""
+
+    def query_window(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        bodies: Sequence[str],
+        cadence_hours: float,
+        frame: str,
+    ) -> EphemerisBatch:
+        """Return vectors sampled across a regular cadence within ``[start, end]`` inclusive."""
+
+    def close(self) -> None:
+        """Release open resources (files, network handles)."""
+
+
+__all__ = [
+    "CacheInfo",
+    "CacheStatus",
+    "EphemerisBatch",
+    "EphemerisProvider",
+    "EphemerisVector",
+    "ProviderError",
+    "ProviderMetadata",
+]

--- a/astroengine/providers/skyfield_provider.md
+++ b/astroengine/providers/skyfield_provider.md
@@ -1,0 +1,39 @@
+```AUTO-GEN[providers.skyfield]
+GOAL
+  - Define the reference Skyfield ephemeris provider implementing the `EphemerisProvider` protocol with deterministic caching, DE440s support, and telemetry hooks.
+
+INITIALIZATION FLOW
+  1. Validate extras: ensure `skyfield`, `jplephem`, `numpy`, `astropy`, `tzdata` (fallback) are installed. Abort with `ProviderError` (error_code=`missing_dependency`).
+  2. Resolve cache directory: default `${ASTROENGINE_CACHE}/skyfield/de440s`; support override via profile flag `providers.skyfield.cache_path`. Enforce path whitelist to avoid traversals.
+  3. Invoke `ephem pull` helper:
+        a. Check existing DE440s files (binary + checksum). If missing/stale, download from NASA/JPL using HTTPS with retry policy (3 attempts, exponential backoff) and SHA-256 verification.
+        b. Record `CacheInfo` (path, checksum, generated_at, status).
+  4. Construct Skyfield `Loader` pinned to cache directory and instantiate `Timescale` with timezone-safe settings (UTC + TT conversions using `astropy.time`).
+  5. Preload commonly-used bodies: Sun, Moon, Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus, Neptune, Pluto, lunar node approximations, selected asteroids (Ceres, Pallas, Juno, Vesta) when extras `minor_planets` present.
+
+QUERY HANDLING
+  - `prime_cache`: compute sampling cadence per body class (inners ≤6h, outers ≤24h, Moon ≤1h) and prefetch times using vectorized `timescale.utc`. Store deterministic list of sample timestamps.
+  - `query`: accept arbitrary timestamps; convert to Skyfield `Time` objects; fetch geocentric positions via `.at(time).observe(body).apparent()`; compute ecliptic longitude/latitude (true ecliptic of date) using `astropy.coordinates`. Include light-time correction metadata.
+  - `query_window`: generate uniform times; reuse `prime_cache` data when available to avoid duplicate work; ensure returned vectors sorted chronologically.
+  - Declination/out-of-bounds: compute from equatorial coordinates; attach `declination_deg` field.
+  - Provide `data_provenance`: {`ephemeris`: `de440s`, `timescale`: `skyfield`, `light_time`: bool, `frame`: requested frame, `source_checksum`: SHA-256}.
+
+DETERMINISM & CACHING
+  - All numpy arrays must be coerced to Python floats (rounded to 1e-9) before serialization to avoid platform drift.
+  - Cache metadata stored in JSON alongside ephemeris file; include `sha256`, `download_url`, `downloaded_at`, `skyfield_version`, `astroengine_version`.
+  - Determinism hash inputs must include: timestamps (ISO8601), body_id, frame, computed longitude/latitude, declination, speed, cache checksum.
+
+TELEMETRY
+  - Structured logs for each query: {`module`: `providers.skyfield`, `call`: `query|query_window|prime_cache`, `bodies`, `count`, `cache_status`, `duration_ms`, `errors` (if any)}.
+  - Metrics counters: `astroengine_provider_queries_total` (labels: provider_id, call), `astroengine_provider_cache_hits_total`, `astroengine_provider_failures_total` (labels include `error_code`).
+
+ERROR HANDLING
+  - Missing cache/failed checksum → `ProviderError` with `error_code=cache_invalid`, `retriable=True`.
+  - Network failure after retries → `ProviderError` with `error_code=download_failed`, `retriable=True`.
+  - Unsupported body/frame → `ProviderError` with `error_code=unsupported_target`, `retriable=False`.
+
+CONFORMANCE TESTS
+  - Compare positions for canonical timestamps vs Swiss Ephemeris within tolerances: inner planets ≤0.5 arcsec, outers ≤1.0 arcsec, Moon ≤2.0 arcsec.
+  - Determinism test: run `query_window` twice with identical inputs; ensure determinism hash identical.
+  - Cache reuse test: delete in-memory caches, re-run `prime_cache`, confirm `CacheInfo.status`=`WARM` when files unchanged.
+```

--- a/astroengine/providers/swe_provider.md
+++ b/astroengine/providers/swe_provider.md
@@ -1,0 +1,35 @@
+```AUTO-GEN[providers.swe]
+GOAL
+  - Scaffold an optional Swiss Ephemeris provider (`pyswisseph`) that mirrors the Skyfield API for parity testing while respecting licensing constraints.
+
+LICENSE & DISTRIBUTION
+  - `pyswisseph` is GPL; package behind `astroengine[swe]` extra with clear NOTICE file linking to Swiss Ephemeris license.
+  - Document that commercial distribution requires contacting Astrodienst; default build disables SWE provider unless user opts in.
+
+INITIALIZATION STEPS
+  1. Validate dependency availability (`pyswisseph`, `numpy`). If missing, raise `ProviderError` (`error_code=missing_dependency`, `retriable=False`).
+  2. Require explicit `swe_ephemeris_path` config (profile flag or env var). Disallow silent downloads.
+  3. Load Swiss Ephemeris data via `swe.set_ephe_path`; compute checksum of ephemeris directory and store in `CacheInfo`.
+  4. Configure delta-T model (default `swe.DELTAT_DEFAULT`); allow override via profile `providers.swe.delta_t`.
+
+QUERY IMPLEMENTATION
+  - `prime_cache`: verify ephemeris files exist for requested range; call `swe.set_topo` when geographic context required (for house calculations) but keep transit queries geocentric by default.
+  - `query`: convert timestamps to Julian day (`swe.julday`), call `swe.calc_ut` for body IDs mapped from AstroEngine canonical names; gather longitude, latitude, distance, speed. Enable `FLG_SWIEPH | FLG_SPEED | FLG_EQUATORIAL`. Convert equatorial coords to RA/Dec.
+  - `query_window`: iterate across cadence; maintain deterministic ordering; store `data_provenance` referencing Swiss ephemeris file names and versions.
+  - Ensure floating-point outputs rounded to 1e-9 precision to maintain parity with Skyfield determinism tests.
+
+FEATURE SUPPORT
+  - Bodies: Sun → Pluto, Moon, mean/true nodes, Chiron (optional), minor planets when element files present; declare support list in `ProviderMetadata`.
+  - Declination & right ascension natively available; ensure antiscia calculations align with Skyfield outputs within tolerance.
+  - Light-time corrections configurable via profile flag (default ON).
+
+PARITY & TESTING
+  - Provide conformance suite comparing SWE vs Skyfield across 50 timestamps (per body). Tolerances: inners ≤0.5 arcsec, outers ≤1.0 arcsec, Moon ≤2.0 arcsec.
+  - Determinism tests identical to Skyfield provider.
+  - Document how to disable SWE provider at runtime (profile `providers.swe.enabled = false`).
+
+SECURITY & LOGGING
+  - Enforce path whitelist for ephemeris directory; refuse relative paths escaping allowed roots.
+  - Log queries with structured metadata similar to Skyfield provider; include `ephemeris_version` and `delta_t_model`.
+  - On errors, raise `ProviderError` with `error_code` from set {`missing_dependency`, `invalid_path`, `unsupported_target`, `compute_failure`}.
+```

--- a/docs/providers/registry.md
+++ b/docs/providers/registry.md
@@ -1,0 +1,48 @@
+# AstroEngine Provider Registry
+
+```AUTO-GEN[providers.registry]
+PURPOSE
+  - Document discovery, configuration, and conformance expectations for provider plugins exposed through the ``astroengine.providers`` entry-point group.
+
+ENTRY POINT CONTRACT
+  - Group: ``astroengine.providers``.
+  - Each entry point must expose a callable ``load() -> EphemerisProvider``.
+  - Entry point name SHOULD match ``{provider_id}`` declared in :class:`ProviderMetadata`.
+
+METADATA REQUIREMENTS
+  - Providers must populate :class:`ProviderMetadata` with:
+        * ``provider_id``: snake_case identifier.
+        * ``version``: semantic version string.
+        * ``supported_bodies``: ordered list of canonical AstroEngine body IDs.
+        * ``supported_frames``: e.g., ``['ecliptic_true_date', 'equatorial_true']``.
+        * ``supports_declination`` / ``supports_light_time`` booleans.
+        * ``cache_layout``: mapping of cache component → relative path templates.
+        * ``extras_required``: extras marker (e.g., ``['skyfield']``).
+  - Metadata must be serializable to JSON for registry export.
+
+DISCOVERY FLOW
+  1. Importlib iterates over entry points in deterministic sorted order.
+  2. Call ``load()``; providers MUST raise ``ProviderError`` for misconfiguration.
+  3. Register provider metadata in internal registry keyed by ``provider_id``; reject duplicates.
+  4. Emit structured logs summarizing available providers, versions, cache paths, extras.
+
+CONFIGURATION HIERARCHY
+  - Global defaults from ``profiles/base_profile.yaml``.
+  - Profile overrides via nested keys ``providers.{provider_id}.*``.
+  - CLI/ENV overrides (highest precedence) using ``ASTROENGINE_PROVIDER_{ID}_*`` variables.
+
+SECURITY & COMPLIANCE
+  - Maintain whitelist of allowed cache directories; all paths resolved via ``Path.resolve()`` with root check.
+  - Validate checksums before trusting cached ephemerides; log mismatches.
+  - Store license metadata for each provider (SPDX identifier, URL) to support audits.
+
+CONFORMANCE TESTING
+  - Smoke test: instantiate each provider, run ``prime_cache`` + ``query`` for sample timestamp (2000-01-01T00:00:00Z) across bodies declared in metadata.
+  - Determinism test: run repeated queries, hash results using canonical serializer.
+  - Precision test: compare provider outputs vs reference (Skyfield) when available; enforce tolerance per body class.
+  - Failure-path test: simulate missing cache directory, confirm provider raises documented ``ProviderError`` with correct ``retriable`` flag.
+
+TELEMETRY REGISTRATION
+  - Each provider must emit metrics/log labels ``provider_id`` and ``version``.
+  - Registry module aggregates counters into Prometheus exporter (future work) and ensures consistent naming.
+```

--- a/profiles/base_profile.yaml
+++ b/profiles/base_profile.yaml
@@ -1,0 +1,231 @@
+# Base AstroEngine profile covering default orbs, severity weights, and feature toggles.
+profile_id: base
+version: 0.1.0
+schema_version: 1
+updated_at: 2024-05-01T00:00:00Z
+description: >-
+  Baseline profile enabling core transit techniques (stations, ingresses, lunations,
+  declination checks) with conservative orb policies and severity weights suited for
+  general natal transit monitoring.
+provenance:
+  dignities_table: profiles/dignities.csv
+  fixed_star_table: profiles/fixed_stars.csv
+  feature_flags_doc: profiles/feature_flags.md
+  maintainer: astroengine-core
+  notes: |
+    All orb/severity values derived from traditional sources (Ptolemy, Lilly) blended
+    with modern practice references (Houlding, Frawley). Modifiers calibrated for
+    deterministic scoring in schema v1.
+
+providers:
+  default: skyfield
+  skyfield:
+    cache_path: "${ASTROENGINE_CACHE}/skyfield/de440s"
+    cadence_hours:
+      inner: 6
+      outer: 24
+      moon: 1
+      minor: 12
+    extras: [skyfield]
+  swe:
+    enabled: false
+    ephemeris_path: null
+    cadence_hours:
+      inner: 6
+      outer: 24
+      moon: 1
+      minor: 12
+    extras: [swe]
+
+bodies:
+  classes:
+    inner: [sun, moon, mercury, venus, mars]
+    outer: [jupiter, saturn, uranus, neptune, pluto]
+    minor: [ceres, pallas, juno, vesta]
+    dwarf: [eris, sedna]
+    points: [asc, mc, ic, dsc, vertex, antivertex, fortune, spirit]
+  enablement:
+    sun: true
+    moon: true
+    mercury: true
+    venus: true
+    mars: true
+    jupiter: true
+    saturn: true
+    uranus: true
+    neptune: true
+    pluto: true
+    ceres: false
+    pallas: false
+    juno: false
+    vesta: false
+    eris: false
+    sedna: false
+    vertex: true
+    antivertex: true
+    fortune: true
+    spirit: true
+  severity_weights:
+    sun: 1.00
+    moon: 1.10
+    mercury: 1.00
+    venus: 0.95
+    mars: 1.15
+    jupiter: 0.85
+    saturn: 1.05
+    uranus: 0.80
+    neptune: 0.75
+    pluto: 0.85
+    ceres: 0.60
+    pallas: 0.55
+    juno: 0.55
+    vesta: 0.55
+    eris: 0.65
+    sedna: 0.60
+  benefic_malefic:
+    day_chart:
+      benefics: {venus: 1.10, jupiter: 1.10}
+      malefics: {mars: 0.90, saturn: 0.90}
+    night_chart:
+      benefics: {venus: 1.10}
+      malefics: {mars: 0.90, saturn: 0.85}
+
+orb_policies:
+  angular_priority_orb_deg: 3.0
+  natal_gate_orb_deg:
+    default: 2.0
+    outer: 2.0
+    inner: 3.0
+    moon: 4.0
+    minor: 2.0
+    dwarf: 2.0
+  transit_orbs_deg:
+    sun: 8.0
+    moon: 6.0
+    mercury: 6.0
+    venus: 6.0
+    mars: 6.0
+    jupiter: 6.0
+    saturn: 6.0
+    uranus: 5.0
+    neptune: 5.0
+    pluto: 5.0
+    ceres: 4.0
+    pallas: 4.0
+    juno: 4.0
+    vesta: 4.0
+    eris: 3.0
+    sedna: 3.0
+  fixed_star_orbs_deg:
+    default: 0.333
+    magnitude_le_1: 0.1667
+  declination_aspect_orb_deg:
+    default: 0.5
+    moon: 0.6667
+  antiscia_orb_deg:
+    default: 1.5
+    angular: 2.5
+  midpoint_orb_deg:
+    default: 1.0
+    angular: 1.5
+  combustion:
+    cazimi_deg: 0.2833   # 0°17′
+    under_beams_deg: 15.0
+    combust_deg: 8.0
+  lunations:
+    angular_orb_deg: 3.0
+    eclipse_lat_deg: 1.5
+    eclipse_node_orb_deg: 1.0
+
+severity_modifiers:
+  combust: 0.85
+  under_beams: 0.90
+  cazimi: 1.10
+  out_of_bounds: 1.05
+  eclipse_base: 1.40
+  angular_priority: 1.20
+  profected_lord_hit: 1.15
+  natal_luminary_hit: 1.10
+  eclipse_natal_tight: 1.30
+  detriment_penalty: 0.90
+  fall_penalty: 0.90
+  dignity_bonus: 1.05
+  benefic_day_bonus: 1.10
+  malefic_day_penalty: 0.90
+  benefic_night_bonus: 1.05
+  malefic_night_penalty: 0.90
+
+feature_flags:
+  stations:
+    enabled: true
+    outer_always_on: false
+    natal_gate_orb_deg: 2.0
+  ingresses:
+    enabled: true
+    include_moon: false
+    inner_mode: angles_only
+  lunations:
+    enabled: true
+    oob_bonus: true
+  eclipses:
+    enabled: true
+    max_orb_deg: 1.0
+  declination_aspects:
+    enabled: true
+    parallels: true
+    contraparallels: true
+  out_of_bounds:
+    enabled: true
+    threshold_deg: 23.45
+  antiscia:
+    enabled: false
+  midpoints:
+    enabled: true
+    base_pairs: [sun_moon, asc_mc, mc_node]
+  fixed_stars:
+    enabled: false
+    lunation_bonus: false
+  profections:
+    enabled: true
+    cycle: annual
+  returns:
+    enabled: true
+    solar: true
+    lunar: true
+    lunation_boost: true
+  progressions:
+    enabled: false
+  timelords:
+    enabled: false
+  maps:
+    enabled: false
+  draconic:
+    enabled: false
+  sidereal:
+    enabled: false
+    ayanamsha: lahiri
+  house_system:
+    default: whole_sign
+    available: [whole_sign, equal, placidus, koch, regiomontanus, campanus, porphyry, alcabitius, morinus, meridian, topocentric]
+  minor_planets:
+    enabled: false
+    stations: false
+    ingresses: false
+  dwarfs:
+    enabled: false
+
+validation:
+  determinism_hash: sha256
+  schema_version: 1
+  tests:
+    - determinism_repeat_run
+    - provider_parity
+    - profile_schema_check
+
+export:
+  formats:
+    - jsonl
+    - parquet
+    - csv
+    - ics
+  include_determinism_hash: true

--- a/profiles/dignities.csv
+++ b/profiles/dignities.csv
@@ -1,0 +1,175 @@
+planet,sign,dignity_type,sect,start_deg,end_deg,modifier,source
+sun,leo,rulership,neutral,,,1.10,Skyscript Rulership Tables
+moon,cancer,rulership,neutral,,,1.10,Skyscript Rulership Tables
+mercury,gemini,rulership,neutral,,,1.10,Skyscript Rulership Tables
+mercury,virgo,rulership,neutral,,,1.10,Skyscript Rulership Tables
+venus,taurus,rulership,neutral,,,1.10,Skyscript Rulership Tables
+venus,libra,rulership,neutral,,,1.10,Skyscript Rulership Tables
+mars,aries,rulership,neutral,,,1.10,Skyscript Rulership Tables
+mars,scorpio,rulership,neutral,,,1.10,Skyscript Rulership Tables
+jupiter,sagittarius,rulership,neutral,,,1.10,Skyscript Rulership Tables
+jupiter,pisces,rulership,neutral,,,1.10,Skyscript Rulership Tables
+saturn,capricorn,rulership,neutral,,,1.10,Skyscript Rulership Tables
+saturn,aquarius,rulership,neutral,,,1.10,Skyscript Rulership Tables
+sun,aquarius,detriment,neutral,,,0.90,Skyscript Rulership Tables
+sun,libra,detriment,neutral,,,0.90,Skyscript Rulership Tables
+moon,capricorn,detriment,neutral,,,0.90,Skyscript Rulership Tables
+moon,scorpio,detriment,neutral,,,0.90,Skyscript Rulership Tables
+mercury,sagittarius,detriment,neutral,,,0.90,Skyscript Rulership Tables
+mercury,pisces,detriment,neutral,,,0.90,Skyscript Rulership Tables
+venus,aries,detriment,neutral,,,0.90,Skyscript Rulership Tables
+venus,scorpio,detriment,neutral,,,0.90,Skyscript Rulership Tables
+mars,taurus,detriment,neutral,,,0.90,Skyscript Rulership Tables
+mars,libra,detriment,neutral,,,0.90,Skyscript Rulership Tables
+jupiter,gemini,detriment,neutral,,,0.90,Skyscript Rulership Tables
+jupiter,virgo,detriment,neutral,,,0.90,Skyscript Rulership Tables
+saturn,cancer,detriment,neutral,,,0.90,Skyscript Rulership Tables
+saturn,leo,detriment,neutral,,,0.90,Skyscript Rulership Tables
+sun,aries,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+moon,taurus,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+mercury,virgo,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+venus,pisces,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+mars,capricorn,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+jupiter,cancer,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+saturn,libra,exaltation,neutral,,,1.05,Skyscript Essential Dignities
+sun,libra,fall,neutral,,,0.90,Skyscript Essential Dignities
+moon,scorpio,fall,neutral,,,0.90,Skyscript Essential Dignities
+mercury,pisces,fall,neutral,,,0.90,Skyscript Essential Dignities
+venus,virgo,fall,neutral,,,0.90,Skyscript Essential Dignities
+mars,cancer,fall,neutral,,,0.90,Skyscript Essential Dignities
+jupiter,capricorn,fall,neutral,,,0.90,Skyscript Essential Dignities
+saturn,aries,fall,neutral,,,0.90,Skyscript Essential Dignities
+sun,aries,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+sun,leo,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+sun,sagittarius,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+jupiter,aries,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+jupiter,leo,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+jupiter,sagittarius,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+saturn,aries,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+saturn,leo,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+saturn,sagittarius,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+venus,taurus,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+venus,virgo,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+venus,capricorn,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+moon,taurus,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+moon,virgo,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+moon,capricorn,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+mars,taurus,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+mars,virgo,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+mars,capricorn,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+saturn,gemini,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+saturn,libra,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+saturn,aquarius,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+mercury,gemini,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+mercury,libra,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+mercury,aquarius,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+jupiter,gemini,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+jupiter,libra,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+jupiter,aquarius,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+venus,cancer,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+venus,scorpio,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+venus,pisces,triplicity_day,day,,,1.05,Dorothean Triplicity Rulers
+mars,cancer,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+mars,scorpio,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+mars,pisces,triplicity_night,night,,,1.05,Dorothean Triplicity Rulers
+moon,cancer,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+moon,scorpio,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+moon,pisces,triplicity_participating,neutral,,,1.02,Dorothean Triplicity Rulers
+jupiter,aries,bounds_egyptian,neutral,0,6,1.03,Skyscript Egyptian Terms
+venus,aries,bounds_egyptian,neutral,6,14,1.02,Skyscript Egyptian Terms
+mercury,aries,bounds_egyptian,neutral,14,21,1.02,Skyscript Egyptian Terms
+mars,aries,bounds_egyptian,neutral,21,26,1.05,Skyscript Egyptian Terms
+saturn,aries,bounds_egyptian,neutral,26,30,0.97,Skyscript Egyptian Terms
+venus,taurus,bounds_egyptian,neutral,0,8,1.03,Skyscript Egyptian Terms
+mercury,taurus,bounds_egyptian,neutral,8,15,1.02,Skyscript Egyptian Terms
+jupiter,taurus,bounds_egyptian,neutral,15,22,1.03,Skyscript Egyptian Terms
+saturn,taurus,bounds_egyptian,neutral,22,27,0.97,Skyscript Egyptian Terms
+mars,taurus,bounds_egyptian,neutral,27,30,0.97,Skyscript Egyptian Terms
+mercury,gemini,bounds_egyptian,neutral,0,7,1.02,Skyscript Egyptian Terms
+jupiter,gemini,bounds_egyptian,neutral,7,14,1.03,Skyscript Egyptian Terms
+venus,gemini,bounds_egyptian,neutral,14,21,1.02,Skyscript Egyptian Terms
+saturn,gemini,bounds_egyptian,neutral,21,26,0.97,Skyscript Egyptian Terms
+mars,gemini,bounds_egyptian,neutral,26,30,0.97,Skyscript Egyptian Terms
+moon,cancer,bounds_egyptian,neutral,0,7,1.05,Skyscript Egyptian Terms
+venus,cancer,bounds_egyptian,neutral,7,13,1.03,Skyscript Egyptian Terms
+mercury,cancer,bounds_egyptian,neutral,13,19,1.02,Skyscript Egyptian Terms
+jupiter,cancer,bounds_egyptian,neutral,19,26,1.03,Skyscript Egyptian Terms
+mars,cancer,bounds_egyptian,neutral,26,30,0.97,Skyscript Egyptian Terms
+saturn,leo,bounds_egyptian,neutral,0,6,0.97,Skyscript Egyptian Terms
+mercury,leo,bounds_egyptian,neutral,6,13,1.02,Skyscript Egyptian Terms
+venus,leo,bounds_egyptian,neutral,13,20,1.03,Skyscript Egyptian Terms
+jupiter,leo,bounds_egyptian,neutral,20,26,1.03,Skyscript Egyptian Terms
+mars,leo,bounds_egyptian,neutral,26,30,1.05,Skyscript Egyptian Terms
+mercury,virgo,bounds_egyptian,neutral,0,7,1.02,Skyscript Egyptian Terms
+venus,virgo,bounds_egyptian,neutral,7,13,1.03,Skyscript Egyptian Terms
+jupiter,virgo,bounds_egyptian,neutral,13,17,1.02,Skyscript Egyptian Terms
+mercury,virgo,bounds_egyptian,neutral,17,21,1.02,Skyscript Egyptian Terms
+saturn,virgo,bounds_egyptian,neutral,21,24,0.97,Skyscript Egyptian Terms
+venus,virgo,bounds_egyptian,neutral,24,27,1.03,Skyscript Egyptian Terms
+mercury,virgo,bounds_egyptian,neutral,27,30,1.02,Skyscript Egyptian Terms
+saturn,libra,bounds_egyptian,neutral,0,6,0.97,Skyscript Egyptian Terms
+mercury,libra,bounds_egyptian,neutral,6,14,1.02,Skyscript Egyptian Terms
+jupiter,libra,bounds_egyptian,neutral,14,21,1.03,Skyscript Egyptian Terms
+venus,libra,bounds_egyptian,neutral,21,28,1.05,Skyscript Egyptian Terms
+mars,libra,bounds_egyptian,neutral,28,30,0.97,Skyscript Egyptian Terms
+mars,scorpio,bounds_egyptian,neutral,0,7,1.05,Skyscript Egyptian Terms
+venus,scorpio,bounds_egyptian,neutral,7,13,1.03,Skyscript Egyptian Terms
+mercury,scorpio,bounds_egyptian,neutral,13,19,1.02,Skyscript Egyptian Terms
+jupiter,scorpio,bounds_egyptian,neutral,19,24,1.03,Skyscript Egyptian Terms
+saturn,scorpio,bounds_egyptian,neutral,24,30,0.97,Skyscript Egyptian Terms
+jupiter,sagittarius,bounds_egyptian,neutral,0,12,1.03,Skyscript Egyptian Terms
+venus,sagittarius,bounds_egyptian,neutral,12,17,1.03,Skyscript Egyptian Terms
+mercury,sagittarius,bounds_egyptian,neutral,17,21,1.02,Skyscript Egyptian Terms
+saturn,sagittarius,bounds_egyptian,neutral,21,26,0.97,Skyscript Egyptian Terms
+mars,sagittarius,bounds_egyptian,neutral,26,30,1.05,Skyscript Egyptian Terms
+mercury,capricorn,bounds_egyptian,neutral,0,7,1.02,Skyscript Egyptian Terms
+jupiter,capricorn,bounds_egyptian,neutral,7,14,1.03,Skyscript Egyptian Terms
+venus,capricorn,bounds_egyptian,neutral,14,22,1.03,Skyscript Egyptian Terms
+saturn,capricorn,bounds_egyptian,neutral,22,26,1.05,Skyscript Egyptian Terms
+mercury,capricorn,bounds_egyptian,neutral,26,30,1.02,Skyscript Egyptian Terms
+saturn,aquarius,bounds_egyptian,neutral,0,7,1.05,Skyscript Egyptian Terms
+mercury,aquarius,bounds_egyptian,neutral,7,13,1.02,Skyscript Egyptian Terms
+venus,aquarius,bounds_egyptian,neutral,13,20,1.03,Skyscript Egyptian Terms
+mercury,aquarius,bounds_egyptian,neutral,20,25,1.02,Skyscript Egyptian Terms
+moon,aquarius,bounds_egyptian,neutral,25,30,1.05,Skyscript Egyptian Terms
+venus,pisces,bounds_egyptian,neutral,0,12,1.03,Skyscript Egyptian Terms
+jupiter,pisces,bounds_egyptian,neutral,12,19,1.03,Skyscript Egyptian Terms
+mercury,pisces,bounds_egyptian,neutral,19,24,1.02,Skyscript Egyptian Terms
+venus,pisces,bounds_egyptian,neutral,24,27,1.03,Skyscript Egyptian Terms
+mercury,pisces,bounds_egyptian,neutral,27,30,1.02,Skyscript Egyptian Terms
+mars,aries,decans_chaldean,neutral,0,10,1.05,Chaldean Decans
+sun,aries,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+venus,aries,decans_chaldean,neutral,20,30,1.03,Chaldean Decans
+mercury,taurus,decans_chaldean,neutral,0,10,1.02,Chaldean Decans
+moon,taurus,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+saturn,taurus,decans_chaldean,neutral,20,30,0.97,Chaldean Decans
+jupiter,gemini,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+mars,gemini,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+sun,gemini,decans_chaldean,neutral,20,30,1.05,Chaldean Decans
+venus,cancer,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+mercury,cancer,decans_chaldean,neutral,10,20,1.02,Chaldean Decans
+moon,cancer,decans_chaldean,neutral,20,30,1.05,Chaldean Decans
+jupiter,leo,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+venus,leo,decans_chaldean,neutral,10,20,1.03,Chaldean Decans
+saturn,leo,decans_chaldean,neutral,20,30,0.97,Chaldean Decans
+mercury,virgo,decans_chaldean,neutral,0,10,1.02,Chaldean Decans
+venus,virgo,decans_chaldean,neutral,10,20,1.03,Chaldean Decans
+moon,virgo,decans_chaldean,neutral,20,30,1.05,Chaldean Decans
+saturn,libra,decans_chaldean,neutral,0,10,0.97,Chaldean Decans
+jupiter,libra,decans_chaldean,neutral,10,20,1.03,Chaldean Decans
+mercury,libra,decans_chaldean,neutral,20,30,1.02,Chaldean Decans
+mars,scorpio,decans_chaldean,neutral,0,10,1.05,Chaldean Decans
+sun,scorpio,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+venus,scorpio,decans_chaldean,neutral,20,30,1.03,Chaldean Decans
+jupiter,sagittarius,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+mars,sagittarius,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+sun,sagittarius,decans_chaldean,neutral,20,30,1.05,Chaldean Decans
+venus,capricorn,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+mercury,capricorn,decans_chaldean,neutral,10,20,1.02,Chaldean Decans
+moon,capricorn,decans_chaldean,neutral,20,30,1.05,Chaldean Decans
+saturn,aquarius,decans_chaldean,neutral,0,10,0.97,Chaldean Decans
+mercury,aquarius,decans_chaldean,neutral,10,20,1.02,Chaldean Decans
+venus,aquarius,decans_chaldean,neutral,20,30,1.03,Chaldean Decans
+jupiter,pisces,decans_chaldean,neutral,0,10,1.03,Chaldean Decans
+mars,pisces,decans_chaldean,neutral,10,20,1.05,Chaldean Decans
+moon,pisces,decans_chaldean,neutral,20,30,1.05,Chaldean Decans

--- a/profiles/feature_flags.md
+++ b/profiles/feature_flags.md
@@ -1,0 +1,56 @@
+# Feature Flags Reference
+
+```AUTO-GEN[profiles.feature_flags]
+OVERVIEW
+  - Document default feature toggles and configuration knobs referenced by rulesets and providers. Values align with `profiles/base_profile.yaml` and must remain schema-compatible.
+
+TABLE OF FLAGS
+
+| Flag Path | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `stations.enabled` | bool | true | Enable transit station detection for configured bodies. |
+| `stations.outer_always_on` | bool | false | Always include outer-planet stations regardless of natal proximity. |
+| `stations.natal_gate_orb_deg` | float | 2.0 | Orb threshold (degrees) for including conditional stations. |
+| `ingresses.enabled` | bool | true | Emit sign ingress events. |
+| `ingresses.include_moon` | bool | false | Require explicit opt-in for Moon ingresses. |
+| `ingresses.inner_mode` | enum | `angles_only` | Options: `always`, `angles_only`. Controls Mercury/Venus ingestion gates. |
+| `lunations.enabled` | bool | true | Emit lunations and baseline severity scores. |
+| `lunations.oob_bonus` | bool | true | Apply out-of-bounds severity bonus when Moon exceeds declination threshold. |
+| `eclipses.enabled` | bool | true | Allow eclipse tagging when orb criteria met. |
+| `eclipses.max_orb_deg` | float | 1.0 | Maximum separation between eclipse degree and natal/angle for inclusion. |
+| `declination_aspects.enabled` | bool | true | Detect parallels/contraparallels. |
+| `declination_aspects.parallels` | bool | true | Emit parallel declination events. |
+| `declination_aspects.contraparallels` | bool | true | Emit contraparallel declination events. |
+| `out_of_bounds.enabled` | bool | true | Track out-of-bounds entries/exits. |
+| `out_of_bounds.threshold_deg` | float | 23.45 | Declination threshold for out-of-bounds flagging. |
+| `antiscia.enabled` | bool | false | Enable antiscia/contra-antiscia detection. |
+| `midpoints.enabled` | bool | true | Enable midpoint detection. |
+| `midpoints.base_pairs` | list[str] | `[sun_moon, asc_mc, mc_node]` | Core midpoint pairs using Cosmobiology conventions. |
+| `fixed_stars.enabled` | bool | false | Emit fixed-star conjunction events. |
+| `fixed_stars.lunation_bonus` | bool | false | Apply severity bonus for lunations on bright stars. |
+| `profections.enabled` | bool | true | Generate annual profection timelines. |
+| `profections.cycle` | enum | `annual` | Supported: `annual`, `monthly` (future). |
+| `returns.enabled` | bool | true | Compute return events (solar/lunar). |
+| `returns.solar` | bool | true | Enable solar return detection. |
+| `returns.lunar` | bool | true | Enable lunar return detection. |
+| `returns.lunation_boost` | bool | true | Apply severity boost to lunations near returns. |
+| `progressions.enabled` | bool | false | Gate secondary progressions module. |
+| `timelords.enabled` | bool | false | Gate zodiacal releasing / Firdaria modules. |
+| `maps.enabled` | bool | false | Enable astrocartography/local space modules. |
+| `draconic.enabled` | bool | false | Enable draconic zodiac conversions. |
+| `sidereal.enabled` | bool | false | Toggle sidereal zodiac handling. |
+| `sidereal.ayanamsha` | enum | `lahiri` | Default ayanamsha when sidereal enabled. |
+| `house_system.default` | enum | `whole_sign` | Default house system. |
+| `house_system.available` | list[str] | see table | Supported house systems. |
+| `minor_planets.enabled` | bool | false | Enable Ceres/Pallas/Juno/Vesta as transit bodies. |
+| `minor_planets.stations` | bool | false | Allow minor-planet station detection. |
+| `minor_planets.ingresses` | bool | false | Allow minor-planet sign ingress detection. |
+| `dwarfs.enabled` | bool | false | Enable Eris/Sedna. |
+| `providers.skyfield.cache_path` | str | `${ASTROENGINE_CACHE}/skyfield/de440s` | Override cache directory. |
+| `providers.swe.enabled` | bool | false | Enable Swiss Ephemeris provider. |
+| `providers.swe.delta_t` | float | null | Override delta-T model when using SWE. |
+
+VALIDATION
+  - Profile loader must ensure boolean defaults evaluate correctly, enumerations match documented options, and list-valued flags only contain supported entries.
+  - Schema upgrades must retain backward compatibility by mapping deprecated flags or logging migrations.
+```

--- a/profiles/fixed_stars.csv
+++ b/profiles/fixed_stars.csv
@@ -1,0 +1,15 @@
+star_id,name,ra_deg,dec_deg,ecliptic_longitude_deg,epoch,magnitude,orb_default_deg,orb_mag_le_1_deg,provenance
+alf_Tau,Aldebaran,68.9800,16.5093,69.9710,J2000,0.87,0.333,0.1667,Hipparcos Catalog 2007
+alf_Leo,Regulus,152.0929,11.9672,150.0633,J2000,1.35,0.333,0.1667,Hipparcos Catalog 2007
+alf_Vir,Spica,201.2983,-11.1614,204.0511,J2000,0.97,0.333,0.1667,Hipparcos Catalog 2007
+alf_Sco,Antares,247.3519,-26.4320,249.0769,J2000,0.96,0.333,0.1667,Hipparcos Catalog 2007
+alf_CMa,Sirius,101.2875,-16.7161,104.0533,J2000,-1.46,0.333,0.1000,Hipparcos Catalog 2007
+alf_Lyr,Vega,279.2347,38.7837,285.0454,J2000,0.03,0.333,0.1200,Hipparcos Catalog 2007
+alf_Aql,Altair,297.6958,8.8683,301.1261,J2000,0.76,0.333,0.1667,Hipparcos Catalog 2007
+alf_Cep,Alderamin,343.1536,62.5856,346.6212,J2000,2.45,0.333,0.1667,Hipparcos Catalog 2007
+alf_Car,Canopus,95.9879,-52.6957,95.0754,J2000,-0.72,0.333,0.1200,Hipparcos Catalog 2007
+bet_Gem,Pollux,116.3298,28.0262,113.3720,J2000,1.14,0.333,0.1667,Hipparcos Catalog 2007
+alf_PsA,Fomalhaut,344.4128,-29.6222,345.8481,J2000,1.16,0.333,0.1667,Hipparcos Catalog 2007
+alf_Cas,Schedar,10.1260,56.5373,16.3452,J2000,2.24,0.333,0.1667,Hipparcos Catalog 2007
+bet_Orionis,Rigel,78.6345,-8.2016,78.0402,J2000,0.18,0.333,0.1200,Hipparcos Catalog 2007
+bet_And,Mirach,17.4333,35.6206,20.0297,J2000,2.05,0.333,0.1667,Hipparcos Catalog 2007

--- a/rulesets/transit/ingresses.ruleset.md
+++ b/rulesets/transit/ingresses.ruleset.md
@@ -1,0 +1,34 @@
+```AUTO-GEN[transit.ingresses]
+OVERVIEW
+  - Detect sign changes for enabled bodies, ensuring deterministic capture of ingress moments and natal gating when required.
+  - Channel hierarchy: module `transit.ingresses` → channel `ingresses` → subchannels `solar`, `lunar`, `inner`, `outer`, `minor`, `dwarf` keyed by body class.
+
+DATA REQUIREMENTS
+  - Geocentric ecliptic longitude samples with sign index (0–11) per timestamp.
+  - Provider metadata for interpolation (Hermite/lagrange) and timezone-safe timescales.
+  - Natal reference longitudes and angular positions; profile gating tables for angle proximity thresholds.
+
+BODY POLICY
+  - Always include Sun, Mars, Jupiter, Saturn across entire timeline.
+  - Mercury, Venus: include when profile `ingresses.inner_mode = always` OR when within ≤3° of natal angles flagged for ingress priority (ASC, MC, IC, DSC, Vertex/Antivertex, Fortune/Spirit when toggled).
+  - Moon: optional; include when profile `ingresses.include_moon = true` with gating by ≤3° to natal angles or luminaries.
+  - Outer planets (Uranus, Neptune, Pluto) and dwarfs (Eris, Sedna): include when profile toggles enable them or natal proximity ≤2°.
+  - Minor planets (Ceres, Pallas, Juno, Vesta): include when profile `minor_planets.ingresses = true` and severity weight > 0.
+
+DETECTION FLOW
+  1. For each body, compare consecutive longitude samples; detect sign index change (mod 30° crossing).
+  2. Use deterministic root finding to solve for longitude = boundary (k×30°); tolerance ≤5 minutes (UTC).
+  3. Derive event metadata: `ingress_sign`, `sign_from`, `sign_to`, `degree_in_sign` (0°), `house`, `motion` (`direct`/`retrograde`), `speed_deg_per_day`, `body_class`.
+  4. Apply natal gating for conditional bodies; compute `nearest_natal` (body/angle id, separation deg/min) and attach to event.
+  5. Evaluate severity: base severity from profile; ×1.2 when ingress hits domicile/exaltation sign for body; ×0.85 when in detriment/fall; ×1.1 when aligning with profected house ruler.
+  6. Log whether ingress occurs during retrograde; attach `retrograde_flag` and tie-in to station module for cross-validation.
+
+OUTPUT FIELDS
+  - `timestamp`, `body_id`, `ingress_sign`, `previous_sign`, `motion`, `retrograde_flag`, `orb_to_natal`, `natal_ref`, `severity`, `severity_modifiers`, `profile_flags`, `provider_samples`, `determinism_inputs`.
+
+VALIDATION
+  - Schema: `schemas/events/transit_ingress.schema.json`.
+  - Determinism: same inputs must produce identical timestamps and severity; include sign change boundary IDs in hash inputs.
+  - Cross-check: ensure each ingress is flanked by samples in old/new sign and that interpolation solution lies within bounds.
+  - Logging: JSON with `body_id`, `ingress_sign`, `timestamp`, `nearest_natal`, `severity`, `hash_fragment`.
+```

--- a/rulesets/transit/lunations.ruleset.md
+++ b/rulesets/transit/lunations.ruleset.md
@@ -1,0 +1,45 @@
+```AUTO-GEN[transit.lunations]
+OVERVIEW
+  - Emit lunation events (new, first quarter, full, last quarter) and eclipses with deterministic detection, severity weighting, and natal gating as per profile controls.
+  - Channel hierarchy: module `transit.lunations` → channel `lunations` → subchannels `new_moon`, `first_quarter`, `full_moon`, `last_quarter`, `solar_eclipse`, `lunar_eclipse`.
+
+DATA REQUIREMENTS
+  - Sun and Moon geocentric ecliptic longitudes and latitudes sampled ≤1h cadence; include declination and distance for parallax corrections.
+  - Node longitudes for eclipse gating; Saros catalog references when available for provenance.
+  - Natal luminary/angle positions and `lunations` profile table (orb thresholds, severity multipliers, eclipse gating toggles).
+
+DETECTION LOGIC
+  1. Compute synodic phase angle Δλ = λ_sun − λ_moon; detect zero crossings (new moon) and 180° crossings (full moon) via root solving. Quarter phases via Δλ = ±90°.
+  2. Timestamp accuracy requirement ≤2 minutes UTC; store interpolation inputs (timestamps, longitudes) for provenance.
+  3. Determine lunation type from solved Δλ value.
+  4. Evaluate eclipse potential for new/full lunations:
+        a. Compute absolute ecliptic latitude of Moon at event; require ≤ profile `eclipse_lat_deg` (default 1.5°).
+        b. Compute separation from nodes; require ≤ profile `eclipse_node_orb_deg` (default 1.0°).
+        c. Mark `eclipse_flag = true` and classify as solar (new moon) or lunar (full moon) when thresholds satisfied.
+  5. Cross-check natal proximity: compute orb to natal Sun, Moon, ASC, MC, IC, DSC, Vertex, Fortune/Spirit; attach nearest reference and orb.
+  6. Detect angular emphasis: if orb ≤ profile `lunations.angular_orb_deg` (default 3°) to any angle/luminary, tag `angular_priority = true`.
+
+SEVERITY MODEL
+  - Base severity values: new/full = 1.0, quarters = 0.7, eclipses = 1.4 baseline.
+  - Apply modifiers:
+        * ×1.2 when angular priority true.
+        * ×1.2 when lunation aligns with profected lord/house.
+        * ×0.9 when Moon out-of-bounds disabled; ×1.05 when OOB present and profile `lunations.oob_bonus = true`.
+        * ×0.85 when in detriment/fall sign for luminary per dignities table.
+        * Additional ×1.1 when within ≤1° of natal luminary; ×1.3 for eclipses within ≤1° of natal luminary/angle (hard requirement for emission per acceptance).
+  - Document modifiers in `severity_modifiers` with {source_flag, multiplier, justification}.
+
+OUTPUT FIELDS
+  - `timestamp`, `lunation_type`, `eclipse_flag`, `eclipse_class` (partial/total computed from magnitude when available), `sun_longitude`, `moon_longitude`, `phase_angle`, `orb_deg`, `orb_arcmin`, `natal_ref`, `angular_priority`, `severity`, `severity_modifiers`, `profile_flags`, `provider_samples`, `determinism_inputs`.
+
+VALIDATION & TESTS
+  - Schema: `schemas/events/transit_lunation.schema.json`.
+  - Determinism: repeated runs with same ephemeris inputs must produce identical timestamps/severity/hashes.
+  - Property tests: ensure Δλ evolution crosses the expected angle within buffer window; verify solar eclipses occur when Moon near node and near new moon.
+  - Logging: JSON entries with `lunation_type`, `timestamp`, `eclipse_flag`, `nearest_natal`, `severity`, `hash_fragment`, `provider_samples`.
+
+DEPENDENCIES & CROSS-LINKS
+  - Requires provider support for high-cadence sampling; enforce fetch of Sun/Moon positions + node data with caching.
+  - Cross-reference fixed star table for magnitude adjustments when Moon or Sun conjoins bright star within ≤0°20′ (profile toggle `fixed_stars.lunation_bonus`).
+  - Link with returns module to flag lunations within ±48h of solar/lunar returns for severity ×1.1 (profile `returns.lunation_boost`).
+```

--- a/rulesets/transit/scan.ruleset.md
+++ b/rulesets/transit/scan.ruleset.md
@@ -1,0 +1,47 @@
+```AUTO-GEN[transit.scan]
+SUMMARY
+  - Execute the umbrella transit scan pipeline responsible for coordinating station, ingress, lunation, declination, and auxiliary detectors under the module → submodule → channel → subchannel hierarchy demanded by the runtime schemas.
+  - Guarantee deterministic ordering by primary timestamp (UTC, ISO8601) and secondary severity score; emit determinism hash inputs sorted before hashing.
+
+DATA DEPENDENCIES
+  - Ephemeris providers: must supply barycentric positions, velocities, ecliptic longitudes/latitudes, right ascension/declination, speed status, and phase angles for Sun → Sedna, lunar nodes, and Earth-Moon barycenter sampled at ≤6h cadence for inner bodies (Sun, Moon, Mercury, Venus, Mars, Ceres, Pallas, Juno, Vesta) and ≤24h for Jupiter → Sedna and nodes.
+  - Natal dataset: ingest birth timestamp (UTC), geographic coordinates, house system selection, profile toggles, and pre-computed natal positions for all enabled bodies/points; cross-reference with natal hash for audit.
+  - Indexed reference tables: dignities.csv, fixed_stars.csv, benefic/malefic multipliers, declination thresholds, antiscia lookup pairs, midpoint definitions; each table versioned with checksum fields.
+
+PIPELINE LAYERS
+  - Module `transit.scan`: orchestrator; resolves active profile, provider, and techniques; seeds caches for ephemeris samples, timezone conversions, fixed star positions, midpoint targets, and antiscia mirrors.
+  - Submodules:
+      * `transit.stations`: retrograde/direct detection feed (see dedicated ruleset).
+      * `transit.ingresses`: sign boundary detection feed.
+      * `transit.lunations`: new/full/quarter moon and eclipse detection feed.
+      * `transit.declination`: out-of-bounds and declination aspect detectors.
+      * `transit.aux`: antiscia, midpoints, fixed stars, combustion/under-beams, timing overlays (returns, profections) gated by profile toggles.
+  - Channel Requirements: each submodule must emit events under a canonical channel key (e.g., `stations`, `ingresses`, `lunations`, `declination`, `overlays`) with deterministic subchannel naming (e.g., `retrograde`, `direct`, `solar`, `lunar`, `oob_enter`, `antiscia_exact`).
+
+EXECUTION FLOW (PSEUDOCODE)
+  1. Load profile → feature flags → severity/orb policies; verify schema version compatibility.
+  2. Build ephemeris cache window covering scan start/end ± 3 days buffer for interpolation and retrograde boundary detection.
+  3. Query provider for vectorized samples at configured cadence; store in deterministic cache keyed by (body_id, timestamp, frame).
+  4. For each enabled detector submodule:
+        a. Request required data slices (positions, speeds, declinations, etc.).
+        b. Run detector-specific logic to produce candidate events.
+        c. Deduplicate by (body_id, timestamp, channel, subchannel) hash.
+        d. Hydrate event metadata: natal cross-checks (closest natal body/angle distance), orb distances, severity weight, provenance (ephemeris sample IDs, profile flag names), determinism hash inputs.
+  5. Merge all events, sort (timestamp, severity desc, body_id), compute determinism hash (SHA-256 of canonical JSON serialization), and emit to downstream schema validator.
+  6. Persist structured logs (JSON) documenting provider sample counts, cache hits, total events, filtered events, and determinism hash.
+
+VALIDATION & LOGGING
+  - Schemas: events must validate against `schemas/events/transit_event.schema.json`; run determinism test (hash must match repeated run with identical inputs).
+  - Logging fields: `module`, `submodule`, `channel`, `subchannel`, `body_id`, `severity`, `orb`, `provider_sample_ids`, `profile_flags`, `natal_ref`, `hash_inputs`.
+  - Errors: classify as `CONFIG_ERROR`, `PROVIDER_ERROR`, `DATA_GAP`, or `COMPUTE_ERROR`; `PROVIDER_ERROR` must include retriable flag.
+
+PROFILE INTEGRATION
+  - Respect toggles for stations, ingresses, lunations, declination aspects, antiscia, midpoints, fixed stars, profections, returns, progressions, timelords, maps, draconic, sidereal, house systems, minor/dwarf bodies.
+  - Orb/severity policies pulled from profile tables; fallback to defaults only when profile explicitly omits entry.
+  - Draconic/sidereal modes require alternative coordinate frames; ensure provider exposes necessary transforms (Astropy/ERFA fallbacks).
+
+DETERMINISM REQUIREMENTS
+  - Hash seed includes: profile_id, provider_id, schema_version, time_window, sorted event payloads.
+  - Cache directories keyed by provider/version/profile/time_window; verify checksum before reuse.
+  - No random sampling; all filters deterministic and data-backed.
+```

--- a/rulesets/transit/stations.ruleset.md
+++ b/rulesets/transit/stations.ruleset.md
@@ -1,0 +1,41 @@
+```AUTO-GEN[transit.stations]
+OVERVIEW
+  - Detect retrograde and direct stations for enabled bodies with deterministic interpolation and gating rules that enforce natal proximity policies.
+  - Channel hierarchy: module `transit.stations` → channel `stations` → subchannels `retrograde_station`, `direct_station`.
+
+DATA SOURCES
+  - Ephemeris samples at ≤6h cadence (inner bodies) and ≤24h (outer bodies); include geocentric longitude, latitude, speed in longitude, and declination.
+  - Natal reference positions and angular longitudes for the birth chart; include angles (ASC, MC, IC, DSC), Vertex/Antivertex, Fortune/Spirit when toggled.
+  - Profile tables specifying orb thresholds, severity multipliers, body enablement flags, and natal gating toggles.
+
+BODY SCOPE
+  - Always scan: Sun (for cazimi/combust checks), Moon, Mercury, Venus, Mars.
+  - Conditional: Jupiter, Saturn, Uranus, Neptune, Pluto when within ≤2° of any natal body/angle flagged as `angular_priority` or when profile `stations.outer_always_on = true`.
+  - Optional minors: Ceres, Pallas, Juno, Vesta when profile `minor_planets.enabled = true` and `minor_planets.stations = true`.
+  - Optional dwarfs: Eris, Sedna when profile toggles enable them and provider declares precision support.
+
+DETECTION LOGIC
+  1. For each body, evaluate sign of longitudinal speed across consecutive ephemeris samples; identify zero crossings via Hermite interpolation or bracketing search (≤2h tolerance).
+  2. Confirm station timestamp by solving for speed = 0 using deterministic root finder (e.g., Brent) seeded with monotonic interval.
+  3. Compute event metadata: body_id, station_kind (`retrograde` when speed sign changes +→−, `direct` when −→+), ecliptic longitude, sign, house (per selected system), declination, geocentric distance, motion classification (`inner`, `outer`, `minor`, `dwarf`).
+  4. Evaluate natal gating:
+        a. Compute minimum orb to natal bodies/angles flagged for stations (per profile `stations.natal_gate_orb_deg`).
+        b. Accept event if body in always-on list OR orb ≤ threshold OR profile override forces inclusion.
+        c. Attach `natal_crosscheck`: nearest body/angle id, separation degrees, separation minutes, orb flag.
+  5. Apply modifiers: combust/under-beams/cazimi, out-of-bounds, benefic/malefic severity adjustments from profile tables.
+
+SEVERITY MODEL
+  - Base severity: use per-body severity weight from profile (e.g., Mercury 1.0, Venus 0.9, Mars 1.1, Jupiter 0.8, Saturn 1.0, outer/dwarf as configured).
+  - Increase severity ×1.25 when orb ≤ natal angle threshold; ×1.15 when hitting natal ruler/profected lord.
+  - Decrease severity ×0.85 when combust; ×0.9 when out-of-bounds disabled; ×0.75 when body flagged as minor and profile `minor_planets.weight = light`.
+  - Document each adjustment with `severity_modifiers` array: {source, value, rationale}.
+
+OUTPUT FIELDS
+  - `timestamp` (UTC, ISO8601), `body_id`, `station_kind`, `sign`, `degree`, `orb_deg`, `orb_arcmin`, `natal_ref`, `severity`, `severity_modifiers`, `profile_flags`, `provider_samples` (list of timestamps/ids), `determinism_inputs` (sorted field list).
+
+VALIDATION & TEST HOOKS
+  - Schema: `schemas/events/transit_station.schema.json`.
+  - Determinism: rerun detection with same inputs; hashed payload must match.
+  - Property tests: ensure station timestamp falls within interpolation bounds and preceding/following samples have opposite speed signs.
+  - Logging: emit JSON entries with `event_id`, `body_id`, `station_kind`, `orb`, `nearest_natal`, `severity`, `hash_fragment`.
+```


### PR DESCRIPTION
## Summary
- document the transit scan, station, ingress, and lunation modules with deterministic gating, severity, and logging policies
- establish the provider plugin protocol plus Skyfield/SWE implementation guides and registry documentation
- seed the base profile with orb and severity defaults, dignities and fixed-star tables, and feature flag reference material

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc888ecd9c8324b9545cfd57a1bfd6