### PR TITLE
Add CP-PACK-ALL v1.0 documentation specs

### DIFF
--- a/docs/ASTROJSON_SPEC.md
+++ b/docs/ASTROJSON_SPEC.md
@@ -1,0 +1,7 @@
+<!-- >>> AUTO-GEN BEGIN: AstroJSON v1.0 (instructions) -->
+Define JSON schemas (conceptually) for:
+- natal_v1: birth data, coords, tzid, house system, ayanamsha, privacy flags.
+- event_v1: a single transit event (fields match Export Schemas core).
+- transit_v1: collection with metadata (provider, ruleset, profile, ephemeris checksum).
+Guidelines: stable keys, ISO times, degrees as floats, no locale strings.
+<!-- >>> AUTO-GEN END: AstroJSON v1.0 (instructions) -->

--- a/docs/ATLAS_TZ_SPEC.md
+++ b/docs/ATLAS_TZ_SPEC.md
@@ -1,0 +1,9 @@
+<!-- >>> AUTO-GEN BEGIN: Atlas & TZ v1.0 (instructions) -->
+Inputs:
+- lat, lon, place_name?, datetime_local, tzid? (if tzid missing, resolve via timezonefinder).
+
+Rules:
+- Resolve tzid via coordinates; compute historical UTC offset via tzdb.
+- Document DST transitions and ambiguous times; require explicit disambiguation.
+- Do not embed proprietary atlases; document OSM/Nominatim usage & rate limits.
+<!-- >>> AUTO-GEN END: Atlas & TZ v1.0 (instructions) -->

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -1,0 +1,6 @@
+<!-- >>> AUTO-GEN BEGIN: Compatibility Matrix v1.0 (instructions) -->
+Matrix columns:
+- astroengine-core, rulesets, profiles, providers(skyfield/swe), exporters, fixed-stars data.
+Policy:
+- Update on every tagged release; CI checks matrix completeness.
+<!-- >>> AUTO-GEN END: Compatibility Matrix v1.0 (instructions) -->

--- a/docs/CONDA_FORGE_PLAN.md
+++ b/docs/CONDA_FORGE_PLAN.md
@@ -1,0 +1,6 @@
+<!-- >>> AUTO-GEN BEGIN: Conda-Forge Plan v1.0 (instructions) -->
+Steps:
+- After PyPI 0.1.0, open feedstock with split variants (core, -skyfield).
+- CI: build on Linux/macOS/Windows; run minimal tests.
+- Keep recipes updated on release via GitHub Actions workflow_call.
+<!-- >>> AUTO-GEN END: Conda-Forge Plan v1.0 (instructions) -->

--- a/docs/DETERMINISM_TEST_PLAN.md
+++ b/docs/DETERMINISM_TEST_PLAN.md
@@ -1,0 +1,10 @@
+<!-- >>> AUTO-GEN BEGIN: Determinism Tests v1.0 (instructions) -->
+Goal: identical inputs produce byte-for-byte identical outputs.
+
+Plan:
+- Golden JSONL for 3 scenarios (30-day windows) stored under tests/golden/.
+- Event list canonicalization: sort by t_exact, body, aspect, point; fixed float rounding.
+- Hash: SHA256 of canonical JSONL; compare against golden.
+- CI: fail if hash drifts; allow explicit update via env flag.
+- Ephemeris checksum recorded in outputs; CI uses pinned cache.
+<!-- >>> AUTO-GEN END: Determinism Tests v1.0 (instructions) -->

--- a/docs/DIGNITIES_SECT_SPEC.md
+++ b/docs/DIGNITIES_SECT_SPEC.md
@@ -1,0 +1,11 @@
+<!-- >>> AUTO-GEN BEGIN: Dignities & Sect v1.0 (instructions) -->
+Tables to maintain:
+- Rulerships, exaltations, triplicity (day/night), bounds/terms (Ptolemy/Egyptian variants), decans/faces.
+
+Modifiers:
+- +5–10% severity when dignified; − when in fall/detriment.
+- Day charts: benefics +10%, malefics −10%; night: adjust per tradition.
+
+Profiles:
+- Classical, Modern, Minimal — each with toggles and weights.
+<!-- >>> AUTO-GEN END: Dignities & Sect v1.0 (instructions) -->

--- a/docs/DOCKER_PLAN.md
+++ b/docs/DOCKER_PLAN.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Docker Plan v1.0 (instructions) -->
+Images:
+- runtime: astroengine[skyfield,parquet,cli] + cached de440s.
+- lab: adds notebooks + dev extras.
+Entrypoints:
+- `astroengine transits scan` (future) and `ephem pull` helper.
+Cache volume for ephemeris; non-root user.
+<!-- >>> AUTO-GEN END: Docker Plan v1.0 (instructions) -->

--- a/docs/EPHEMERIS_CACHE_SPEC.md
+++ b/docs/EPHEMERIS_CACHE_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Ephemeris Cache v1.0 (instructions) -->
+Commands:
+- ephem pull --set de440s; ephem list; ephem verify (checksums); ephem purge.
+Cache policy:
+- User cache dir; record checksum + source; offline mode flag.
+CI:
+- Pre-populate cache; verify before tests.
+<!-- >>> AUTO-GEN END: Ephemeris Cache v1.0 (instructions) -->

--- a/docs/EXPORT_ICS_SPEC.md
+++ b/docs/EXPORT_ICS_SPEC.md
@@ -1,0 +1,11 @@
+<!-- >>> AUTO-GEN BEGIN: ICS Export v1.0 (instructions) -->
+Purpose: export exact events as .ics calendar entries.
+
+Rules:
+- One VEVENT per exact; DTSTART = t_exact (UTC); SUMMARY = "<body> <aspect> <point>".
+- Optional PRIORITY from severity bands; DESCRIPTION includes provider/profile/ruleset tag.
+- Calendar name includes natal_id and window.
+- Timezones optional (default UTC); allow user tz in CLI.
+Acceptance:
+- Valid ICS loads in major calendar apps; round-trip t_exact preserved.
+<!-- >>> AUTO-GEN END: ICS Export v1.0 (instructions) -->

--- a/docs/EXPORT_SCHEMAS.md
+++ b/docs/EXPORT_SCHEMAS.md
@@ -1,0 +1,11 @@
+<!-- >>> AUTO-GEN BEGIN: Export Schemas v1.0 (instructions) -->
+Define versioned export schemas for CSV/Parquet/JSONL.
+
+Fields (minimum):
+- t_exact (ISO UTC), aspect, transiting_body, natal_point, orb_deg, severity, family,
+- lon_transit, lon_natal, decl_transit?, notes?,
+- provider, profile, ruleset_tag, ephemeris_checksum, scan_window_start, scan_window_end, tzid?, ayanamsha?, house_system?
+
+Partitioning (Parquet): by natal_id/year.
+CSV conventions: UTF-8, header row, comma-separated, RFC4180 escaping.
+<!-- >>> AUTO-GEN END: Export Schemas v1.0 (instructions) -->

--- a/docs/FIXED_STARS_DATA_SPEC.md
+++ b/docs/FIXED_STARS_DATA_SPEC.md
@@ -1,0 +1,11 @@
+<!-- >>> AUTO-GEN BEGIN: Fixed Stars Data v1.0 (instructions) -->
+Dataset:
+- Curated bright-star subset: name, id, magnitude, RA/Dec (epoch), proper motion, spectral class, myth tags.
+- Precompute ecliptic longitude for epochs; include precession model reference.
+
+Orbs:
+- Default ≤ 0°20′; ≤ 0°10′ for mag ≤ 1.0. Ruleset gate only when body is angular/personal.
+
+Provenance & License:
+- Record source catalogs and transformation pipeline; publish checksums.
+<!-- >>> AUTO-GEN END: Fixed Stars Data v1.0 (instructions) -->

--- a/docs/HARMONICS_SPEC.md
+++ b/docs/HARMONICS_SPEC.md
@@ -1,0 +1,6 @@
+<!-- >>> AUTO-GEN BEGIN: Harmonics v1.0 (instructions) -->
+Enable harmonic families via profiles:
+- H5 (quintiles 72/144), H7 (septiles ~51.4286), H9 (noviles 40/80), H11 (undeciles ~32.727).
+Defaults:
+- OFF by default; when ON, orbs ≤ 1° (≤ 1.5° to angles); severity weights conservative.
+<!-- >>> AUTO-GEN END: Harmonics v1.0 (instructions) -->

--- a/docs/HOUSES_FALLBACK_SPEC.md
+++ b/docs/HOUSES_FALLBACK_SPEC.md
@@ -1,0 +1,7 @@
+<!-- >>> AUTO-GEN BEGIN: House Fallbacks v1.0 (instructions) -->
+Rules:
+- When quadrant system fails (e.g., Placidus near poles), fall back to Whole Sign with a warning flag.
+- Record chosen fallback in outputs.
+QA:
+- Tests with latitudes > 66° verify graceful fallback, not crash.
+<!-- >>> AUTO-GEN END: House Fallbacks v1.0 (instructions) -->

--- a/docs/I18N_SPEC.md
+++ b/docs/I18N_SPEC.md
@@ -1,0 +1,6 @@
+<!-- >>> AUTO-GEN BEGIN: I18N v1.0 (instructions) -->
+Scope:
+- Locale maps for sign names, house names, aspect labels, month/day names in outputs.
+Rules:
+- Default en; allow locale override per scan; avoid mixing locale in machine exports.
+<!-- >>> AUTO-GEN END: I18N v1.0 (instructions) -->

--- a/docs/MAPS_SPEC.md
+++ b/docs/MAPS_SPEC.md
@@ -1,0 +1,10 @@
+<!-- >>> AUTO-GEN BEGIN: Maps v1.0 (instructions) -->
+Scope:
+- A*C*G lines (MC/IC/ASC/DSC) and local-space azimuths.
+Requirements:
+- Frame conversions; world basemap; exporters emitting line coords.
+Extras:
+- maps extra: pyproj, shapely, geopandas.
+Acceptance:
+- Visual parity with known tools for a sample chart.
+<!-- >>> AUTO-GEN END: Maps v1.0 (instructions) -->

--- a/docs/MUNDANE_SPEC.md
+++ b/docs/MUNDANE_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Mundane v1.0 (instructions) -->
+Scope:
+- National charts; Aries ingress chart; eclipse path proximity; sector tags (finance, politics, weather) optional.
+Ruleset:
+- Separate modules; strict orbs; robust sources for national charts.
+Ethics:
+- Avoid deterministic claims; present as research tooling.
+<!-- >>> AUTO-GEN END: Mundane v1.0 (instructions) -->

--- a/docs/OBSERVABILITY_SPEC.md
+++ b/docs/OBSERVABILITY_SPEC.md
@@ -1,0 +1,12 @@
+<!-- >>> AUTO-GEN BEGIN: Observability v1.0 (instructions) -->
+Logging:
+- JSON logs; levels TRACE..ERROR; include request_id, provider, profile, ruleset_tag.
+- Event counters per module; refine iterations; cache hits/misses.
+
+Metrics:
+- Prometheus text or statsd: scan_duration_ms, events_emitted, events_refined, severity_mean, cache_hit_ratio.
+
+CLI flags:
+- --log-level, --metrics-exporter, --metrics-path.
+Acceptance: metrics increment appropriately in integration test.
+<!-- >>> AUTO-GEN END: Observability v1.0 (instructions) -->

--- a/docs/PERFORMANCE_BENCH_PLAN.md
+++ b/docs/PERFORMANCE_BENCH_PLAN.md
@@ -1,0 +1,9 @@
+<!-- >>> AUTO-GEN BEGIN: Performance Bench v1.0 (instructions) -->
+Targets (example):
+- 30-day scan, Sun–Pluto + Nodes + Chiron, 1h step: < 250 ms on laptop with cached ephemeris.
+- Refinement iterations: median ≤ 6 per exact.
+
+Bench harness:
+- Fixed seeds; pinned ephemeris; report wall-time, CPU, allocations.
+- CI threshold: warn at +20%, fail at +35% regression.
+<!-- >>> AUTO-GEN END: Performance Bench v1.0 (instructions) -->

--- a/docs/PII_PROVENANCE_POLICY.md
+++ b/docs/PII_PROVENANCE_POLICY.md
@@ -1,0 +1,9 @@
+<!-- >>> AUTO-GEN BEGIN: PII & Provenance v1.0 (instructions) -->
+PII handling:
+- Natal names optional; prefer IDs; redact or hash PII in exports by default.
+- Store consent metadata if distribution intended.
+Provenance:
+- Attach source versions (provider, ephemeris, ruleset tag, profiles) and checksums in every artifact.
+Security:
+- No secrets in repo; use OIDC for publish; license audit for data.
+<!-- >>> AUTO-GEN END: PII & Provenance v1.0 (instructions) -->

--- a/docs/PROGRESSIONS_DIRECTIONS_SPEC.md
+++ b/docs/PROGRESSIONS_DIRECTIONS_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Progressions & Directions v1.0 (instructions) -->
+Secondary progressions:
+- Naibod day→year mapping; progressed luminaries & angles; separate profile gate.
+Solar arc directions:
+- Uniform arc; hits to natal angles/planets with tight orbs.
+Caveat:
+- Keep behind feature flags until validation.
+<!-- >>> AUTO-GEN END: Progressions & Directions v1.0 (instructions) -->

--- a/docs/PROPERTY_TESTS_PLAN.md
+++ b/docs/PROPERTY_TESTS_PLAN.md
@@ -1,0 +1,10 @@
+<!-- >>> AUTO-GEN BEGIN: Property Tests v1.0 (instructions) -->
+Properties:
+- Angle normalization: wrapping to [0,360) and deltas to (-180,180].
+- Δλ continuity across 359°↔1° boundaries.
+- Severity monotonicity: approaches max at exact; symmetric within tolerance.
+- Parallel/antiscia symmetry invariants.
+- Determinism under identical seeds and inputs.
+
+Use Hypothesis strategies for angles/times; cap test time in CI.
+<!-- >>> AUTO-GEN END: Property Tests v1.0 (instructions) -->

--- a/docs/PROVIDERS_SPEC.md
+++ b/docs/PROVIDERS_SPEC.md
@@ -1,0 +1,24 @@
+<!-- >>> AUTO-GEN BEGIN: Providers Spec v1.0 (instructions) -->
+Purpose: define a plugin contract for ephemeris/providers (Skyfield default, SWE optional, Mock for tests) and discovery via entry points.
+
+Contract (capabilities):
+- ecliptic_state(t_iso, topocentric: bool, lat, lon, elev_m) -> {body: {lon_deg, lon_speed_deg_per_day, decl_deg?}}
+- lunation(type: new|full, window) -> list[exact_iso]
+- eclipse(window) -> list[{exact_iso, kind: solar|lunar, saros?}]
+- station(body, window) -> list[{exact_iso, kind: retro|direct}]
+- houses(dt_iso, lat, lon, system) -> {ASC, MC, IC, DSC, cusps[1..12]}
+- ayanamsha(name) -> offset_deg
+- ephemeris_info() -> {name, version, checksum}
+
+Discovery:
+- entry point group `astroengine.providers` with names: `skyfield`, `swe`, `mock`.
+
+Profiles & options:
+- Parameters: house_system, ayanamsha, observatory (lat/lon/elev), de_set.
+- Defaults: Whole Sign houses; Tropical zodiac; de440s; geocentric/topocentric toggle.
+
+Acceptance:
+- Cross-backend parity for Sun–Pluto longitudes within arcsecond bands.
+- House cusp checks for common systems.
+- Lunation/eclipse exacts match published tables within minutes.
+<!-- >>> AUTO-GEN END: Providers Spec v1.0 (instructions) -->

--- a/docs/README_CP_INDEX.md
+++ b/docs/README_CP_INDEX.md
@@ -1,0 +1,29 @@
+<!-- >>> AUTO-GEN BEGIN: CP Index v1.0 (instructions) -->
+List of spec documents included in CP-PACK-ALL v1.0:
+- PROVIDERS_SPEC.md — Provider entry-point contract (Skyfield/SWE/Mock).
+- RULESET_LINTER_SPEC.md — Ruleset linter checks.
+- DETERMINISM_TEST_PLAN.md — Golden files & determinism.
+- EXPORT_ICS_SPEC.md — iCalendar export plan.
+- EXPORT_SCHEMAS.md — CSV/Parquet/JSONL event schemas.
+- OBSERVABILITY_SPEC.md — Logging & metrics.
+- PROPERTY_TESTS_PLAN.md — Hypothesis property tests.
+- PERFORMANCE_BENCH_PLAN.md — Benchmarks & targets.
+- ATLAS_TZ_SPEC.md — Atlas/timezone resolution.
+- FIXED_STARS_DATA_SPEC.md — Bright-star data pack.
+- DIGNITIES_SECT_SPEC.md — Dignities/sect weights.
+- RELEASE_PACKAGING_PLAN.md — PyPI/Conda/Docker releases.
+- MAPS_SPEC.md — Astrocartography/local space (optional).
+- SCENARIO_SNAPSHOT_SPEC.md — Repro snapshot bundles.
+- SCHEDULERS_SPEC.md — Batch & streaming.
+- EPHEMERIS_CACHE_SPEC.md — Offline ephemeris manager.
+- HOUSES_FALLBACK_SPEC.md — High-latitude fallbacks.
+- I18N_SPEC.md — Internationalization hooks.
+- PII_PROVENANCE_POLICY.md — PII & provenance policy.
+- COMPATIBILITY_MATRIX.md — Version matrix.
+- ASTROJSON_SPEC.md — Interop data formats.
+- SYNASTRY_COMPOSITE_SPEC.md — Synastry/composite flows.
+- MUNDANE_SPEC.md — Mundane triggers.
+- HARMONICS_SPEC.md — Harmonics profiles.
+- TIMING_SYSTEMS_SPEC.md — Returns & profections.
+- PROGRESSIONS_DIRECTIONS_SPEC.md — Progressions/directions (optional).
+<!-- >>> AUTO-GEN END: CP Index v1.0 (instructions) -->

--- a/docs/RELEASE_PACKAGING_PLAN.md
+++ b/docs/RELEASE_PACKAGING_PLAN.md
@@ -1,0 +1,10 @@
+<!-- >>> AUTO-GEN BEGIN: Release & Packaging v1.0 (instructions) -->
+PyPI:
+- Extras: skyfield, swe, parquet, cli, dev, maps. Wheels for Linux/macOS/Windows.
+Conda-forge:
+- After 0.1.0, publish core + -skyfield variant.
+Docker:
+- Runtime image with cached ephemeris; lab image with notebooks.
+Versioning:
+- 0.0.x schemas/validation; 0.1.0 adds engine API; maintain compatibility matrix.
+<!-- >>> AUTO-GEN END: Release & Packaging v1.0 (instructions) -->

--- a/docs/RULESET_LINTER_SPEC.md
+++ b/docs/RULESET_LINTER_SPEC.md
@@ -1,0 +1,15 @@
+<!-- >>> AUTO-GEN BEGIN: Ruleset Linter v1.0 (instructions) -->
+Purpose: static checks for ruleset YAMLs.
+
+Checks:
+- Unknown module ids; duplicate ids; missing `channels` keys.
+- Gate expression validation: unknown predicates, mismatched parentheses, unused variables.
+- Overlapping gates producing identical families; missing caps (`family_cap_per_day/week`).
+- Orphan exports (no events emitted for module).
+- Profile references that do not exist.
+- Severity range enforcement [0,1]; partile rule present for aspect modules.
+
+Outputs:
+- Lint summary with file:line; severity (ERROR/WARN/INFO); fix-suggestions.
+- CI mode: fail on ERROR; warn on WARN.
+<!-- >>> AUTO-GEN END: Ruleset Linter v1.0 (instructions) -->

--- a/docs/SCENARIO_SNAPSHOT_SPEC.md
+++ b/docs/SCENARIO_SNAPSHOT_SPEC.md
@@ -1,0 +1,6 @@
+<!-- >>> AUTO-GEN BEGIN: Scenario Snapshots v1.0 (instructions) -->
+Bundle fields:
+- inputs (natal, window, profile), provider info, ephemeris checksum, ruleset tag, outputs (events JSONL), export checksums.
+CLI:
+- `snapshot create` writes a tarball; `snapshot verify` checks hashes and determinism.
+<!-- >>> AUTO-GEN END: Scenario Snapshots v1.0 (instructions) -->

--- a/docs/SCHEDULERS_SPEC.md
+++ b/docs/SCHEDULERS_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Schedulers v1.0 (instructions) -->
+Batch:
+- One-shot scans for windows; concurrency controls; resumable checkpoints.
+Streaming:
+- Rolling horizon from now; backoff strategies; daily family caps.
+Common API:
+- Same scan call; schedulers differ only in how they call it.
+<!-- >>> AUTO-GEN END: Schedulers v1.0 (instructions) -->

--- a/docs/SYNASTRY_COMPOSITE_SPEC.md
+++ b/docs/SYNASTRY_COMPOSITE_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Synastry & Composite v1.0 (instructions) -->
+Synastry:
+- A→B and B→A transits with own caps and profile; combined narrative sorts by severity.
+Composite:
+- Midpoint-composite chart; transits to composite with tight orbs; optional Davidson later.
+Acceptance:
+- At least one acceptance scenario covering A↔B with symmetric outputs; composite exacts refined.
+<!-- >>> AUTO-GEN END: Synastry & Composite v1.0 (instructions) -->

--- a/docs/TIMING_SYSTEMS_SPEC.md
+++ b/docs/TIMING_SYSTEMS_SPEC.md
@@ -1,0 +1,8 @@
+<!-- >>> AUTO-GEN BEGIN: Timing Systems v1.0 (instructions) -->
+Returns:
+- Solar/lunar return exacts; timeline emitters; boost transits within ±48h of return.
+Profections:
+- Annual/monthly profection rulers; context flags consumed by gates; document rules used.
+Acceptance:
+- One acceptance test plan combining profection year lord + a transit hit to that lord.
+<!-- >>> AUTO-GEN END: Timing Systems v1.0 (instructions) -->

--- a/docs/UI_CONVENTIONS.md
+++ b/docs/UI_CONVENTIONS.md
@@ -1,0 +1,7 @@
+<!-- >>> AUTO-GEN BEGIN: UI Conventions v1.0 (instructions) -->
+Aspect family palette & labels:
+- Hard (0/90/180), Soft (60/120), Minor (30/45/135/150), Declination, Mirror (antiscia).
+Severity bands:
+- 0.0–0.2 weak; 0.2–0.5 moderate; 0.5–0.8 strong; 0.8–1.0 peak.
+Localization-ready label keys; avoid hard-coded English in data.
+<!-- >>> AUTO-GEN END: UI Conventions v1.0 (instructions) -->


### PR DESCRIPTION
## Summary
- add the CP-PACK-ALL v1.0 index enumerating the specification documents
- add the CP-PACK-ALL v1.0 specification documents covering providers, exports, testing, observability, data management, and release operations

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68cc8abae6bc8324a80855d07d110c23