### PR TITLE
Add Conda doctor utility and environment docs

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -30,6 +30,7 @@ from .engine import (
 from .profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES
 from .rulesets import VCA_RULESET, get_vca_aspect, vca_orb_for
 from .scoring import compute_domain_factor
+from .doctor_conda import main as conda_doctor_main  # ENSURE-LINE
 
 __all__ = [
     "__version__",
@@ -58,6 +59,7 @@ __all__ = [
     "VCA_CENTAURS",
     "VCA_TNOS",
     "VCA_SENSITIVE_POINTS",
+    "conda_doctor_main",
 ]
 
 try:  # pragma: no cover - package metadata not available during tests

--- a/astroengine/doctor_conda.py
+++ b/astroengine/doctor_conda.py
@@ -1,0 +1,114 @@
+# >>> AUTO-GEN BEGIN: Doctor Conda v1.0
+from __future__ import annotations
+import argparse
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+PREFERRED = ("micromamba", "mamba", "conda")
+
+
+def _which() -> tuple[str | None, list[str]]:
+    found = []
+    for exe in PREFERRED:
+        path = shutil.which(exe)
+        if path:
+            found.append(f"{exe}={path}")
+    first = found[0].split("=")[0] if found else None
+    return first, found
+
+
+def _run(cmd: list[str]) -> tuple[int, str]:
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        out = (p.stdout or "") + (p.stderr or "")
+        return p.returncode, out
+    except Exception as e:
+        return 2, str(e)
+
+
+def _env_exists(runner: str, name: str) -> bool:
+    code, out = _run([runner, "env", "list"])
+    if code != 0:
+        return False
+    lines = out.splitlines()
+    for ln in lines:
+        if ln.strip().startswith("#"):
+            continue
+        if name in ln.split():
+            return True
+    return False
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(prog="astroengine.doctor_conda")
+    ap.add_argument("--expect-name", default="py311", help="expected env name")
+    ap.add_argument("--check", action="store_true", help="perform checks and report status")
+    ap.add_argument("--fix-cache", action="store_true", help="clean package caches")
+    ap.add_argument("--remove-env", metavar="NAME", help="remove the given environment")
+    ap.add_argument("--recreate-env", action="store_true", help="recreate env from environment.yml using the preferred runner")
+    args = ap.parse_args(argv)
+
+    runner, found = _which()
+    if args.check or not any([args.fix_cache, args.remove_env, args.recreate_env]):
+        sys.stdout.write("# Env Doctor — Check\n")
+        sys.stdout.write(f"Detected runners: {', '.join(found) if found else 'None'}\n")
+        if not runner:
+            sys.stdout.write("No Conda/Mamba/Micromamba found on PATH. Install Micromamba and retry.\n")
+            return 0
+        # Versions
+        code, out = _run([runner, "--version"])
+        sys.stdout.write(f"{runner} --version => code={code}\n")
+        if out:
+            sys.stdout.write(out + "\n")
+        # Env presence
+        exists = _env_exists(runner, args.expect_name)
+        sys.stdout.write(f"env '{args.expect_name}': {'present' if exists else 'missing'}\n")
+
+    # Optional: clean caches
+    if args.fix_cache:
+        if not runner:
+            sys.stderr.write("Cannot clean caches: no runner found.\n")
+            return 2
+        cmd = [runner, "clean", "--all", "--yes"] if runner != "conda" else [runner, "clean", "--all", "-y"]
+        code, out = _run(cmd)
+        sys.stdout.write(out)
+        if code != 0:
+            return 2
+
+    # Optional: remove env
+    if args.remove_env:
+        if not runner:
+            sys.stderr.write("Cannot remove env: no runner found.\n")
+            return 2
+        name = args.remove_env
+        cmd = [runner, "env", "remove", "-n", name]
+        if runner == "conda":
+            cmd.append("-y")
+        code, out = _run(cmd)
+        sys.stdout.write(out)
+        if code != 0:
+            return 2
+
+    # Optional: recreate env
+    if args.recreate_env:
+        if not runner:
+            sys.stderr.write("Cannot recreate env: no runner found.\n")
+            return 2
+        env_yml = Path("environment.yml")
+        if not env_yml.exists():
+            sys.stderr.write("environment.yml not found in CWD.\n")
+            return 2
+        cmd = [runner, "create", "-f", str(env_yml), "-y"] if runner != "micromamba" else [runner, "create", "-f", str(env_yml), "-y"]
+        code, out = _run(cmd)
+        sys.stdout.write(out)
+        if code != 0:
+            return 2
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+# >>> AUTO-GEN END: Doctor Conda v1.0

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -1,0 +1,87 @@
+# >>> AUTO-GEN BEGIN: Docs Env Setup v1.0
+# AstroEngine — Environment Setup & Doctor
+
+This guide helps you verify a healthy Conda/Mamba/Micromamba setup and safely clean/recreate the project env.
+
+## TL;DR
+- Prefer **Micromamba**. If you already use Conda/Mamba, that's fine.
+- Target env name: **py311** (configurable).
+- One-liners:
+  - Check: `python -m astroengine.doctor_conda --check`
+  - Clean caches: `python -m astroengine.doctor_conda --fix-cache`
+  - Remove env: `python -m astroengine.doctor_conda --remove-env py311`
+  - Recreate env: `python -m astroengine.doctor_conda --recreate-env`
+
+## 1) Verify installation
+Run:
+```bash
+which micromamba || which mamba || which conda
+conda --version 2>/dev/null || true
+micromamba --version 2>/dev/null || true
+```
+
+Windows (PowerShell):
+
+```powershell
+Get-Command micromamba, mamba, conda -ErrorAction SilentlyContinue
+```
+
+If none are found, install **Micromamba**:
+
+* Linux/macOS: [https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html)
+* Windows: Scoop/Chocolatey or the official installer. Ensure it’s on PATH.
+
+## 2) Create/activate env
+
+```bash
+# Create (Micromamba recommended)
+micromamba create -f environment.yml -y   # or: conda env create -f environment.yml
+
+# Activate
+micromamba activate py311                 # or: conda activate py311
+```
+
+## 3) Common cleanups
+
+* **Caches** (safe):
+
+  * `micromamba clean --all --yes`
+  * `conda clean --all -y`
+* **Remove env** (irreversible):
+
+  * `micromamba env remove -n py311`
+  * `conda env remove -n py311 -y`
+* **Recreate env**:
+
+  * `micromamba create -f environment.yml -y`
+
+## 4) Doctor utility (scripted)
+
+Run checks:
+
+```bash
+python -m astroengine.doctor_conda --check --expect-name py311
+```
+
+Optional fixes:
+
+```bash
+python -m astroengine.doctor_conda --fix-cache
+python -m astroengine.doctor_conda --remove-env py311
+python -m astroengine.doctor_conda --recreate-env
+```
+
+Exit codes: `0` success, `2` operational error; removal/creation failures will return `2`.
+
+## 5) Fallback: pure venv
+
+If Conda/Mamba are not desired:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+pip install -r requirements-dev.txt
+```
+
+# >>> AUTO-GEN END: Docs Env Setup v1.0
+

--- a/docs/SCHEMA_CONTRACTS.md
+++ b/docs/SCHEMA_CONTRACTS.md
@@ -1,0 +1,4 @@
+# >>> AUTO-GEN BEGIN: Docs Schema Contracts — Env Link v1.0
+See also: `docs/ENV_SETUP.md` for Conda/Mamba setup, cleanups, and the `astroengine.doctor_conda` helper.
+# >>> AUTO-GEN END: Docs Schema Contracts — Env Link v1.0
+


### PR DESCRIPTION
## Summary
- add an env doctor module that inspects, cleans, removes, and recreates Conda-style environments
- document environment setup, doctor usage, and cross-link schema docs to the new guide
- export the doctor entry point from the package for programmatic reuse

## Testing
- python -m astroengine.doctor_conda --check

------
https://chatgpt.com/codex/tasks/task_e_68cca9fd77e483248f69b58d98a42f08