### PR TITLE
Refactor ruleset consolidation workflow

### DIFF
--- a/Version Consolidation/consolidate_rulesets.py
+++ b/Version Consolidation/consolidate_rulesets.py
@@ -36,20 +36,25 @@ def iso_to_dt(value: object | None) -> datetime.datetime | None:
         return value
 
     text: str | None
-    try:
-        if isinstance(value, (bytes, bytearray, memoryview)):
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, (bytes, bytearray, memoryview)):
+        try:
             text = bytes(value).decode("utf-8")
-        else:
+        except Exception:  # pragma: no cover - defensive guardrails
+            return None
+    else:
+        try:
             text = str(value)
-    except Exception:  # pragma: no cover - defensive guardrails
-        return None
+        except Exception:  # pragma: no cover - defensive guardrails
+            return None
 
     if text is None:
         return None
 
     try:
         cleaned = text.strip()
-    except AttributeError:  # pragma: no cover - defensive guardrails
+    except Exception:  # pragma: no cover - defensive guardrails
         return None
 
     if not cleaned:

--- a/Version Consolidation/consolidate_rulesets.py
+++ b/Version Consolidation/consolidate_rulesets.py
@@ -1,75 +1,292 @@
 #!/usr/bin/env python3
-import argparse, os, sys, json, re, hashlib, csv, datetime
+"""Utilities for consolidating historical astrology rulesets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import datetime
+import json
+import sys
+from collections.abc import Iterable, Sequence
 from pathlib import Path
+from typing import Any
 
 try:
     import yaml
-except ImportError:
-    print("Please `pip install pyyaml` and rerun.", file=sys.stderr); sys.exit(1)
+except ImportError:  # pragma: no cover - guidance for manual invocations
+    print("Please `pip install pyyaml` and rerun.", file=sys.stderr)
+    sys.exit(1)
 
-REQUIRED_MODULE_IDS = {"aspects","transits","scoring","narrative"}
-TS_FMT_FILE = "%Y%m%d-%H%M"   # for filenames
+REQUIRED_MODULE_IDS = {"aspects", "transits", "scoring", "narrative"}
+TS_FMT_FILE = "%Y%m%d-%H%M"  # for filenames
 
-def iso_to_dt(s: str):
-    try:
-        s = s.strip()
-        if s.endswith("Z"):
-            s = s[:-1]
-        # try multiple formats
-        fmts = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d")
-        for fmt in fmts:
-            try:
-                return datetime.datetime.strptime(s, fmt)
-            except ValueError:
-                continue
-    except Exception:
-        pass
+
+ModuleRegistry = dict[str, list[dict[str, Any]]]
+ParsingErrors = list[tuple[str, str]]
+
+
+def iso_to_dt(value: str | None) -> datetime.datetime | None:
+    """Parse a loose ISO 8601 timestamp to a datetime."""
+
+    if not value:
+        return None
+
+    cleaned = value.strip()
+    if cleaned.endswith("Z"):
+        cleaned = cleaned[:-1]
+
+    formats = ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M", "%Y-%m-%d")
+    for fmt in formats:
+        try:
+            return datetime.datetime.strptime(cleaned, fmt)
+        except ValueError:
+            continue
     return None
 
-def load_any(path: Path):
-    txt = path.read_text(encoding="utf-8")
+
+def load_any(path: Path) -> tuple[Any | None, str | None]:
+    """Load YAML or JSON data from *path* and return (data, error)."""
+
+    text = path.read_text(encoding="utf-8")
     try:
-        if path.suffix.lower() in (".yaml",".yml"):
-            data = yaml.safe_load(txt)
-        elif path.suffix.lower() == ".json":
-            data = json.loads(txt)
+        suffix = path.suffix.lower()
+        if suffix in {".yaml", ".yml"}:
+            data = yaml.safe_load(text)
+        elif suffix == ".json":
+            data = json.loads(text)
         else:
             return None, "Unsupported extension"
-        return data, None
-    except Exception as e:
-        return None, f"Parse error: {e}"
+    except Exception as exc:  # pragma: no cover - defensive guardrails
+        return None, f"Parse error: {exc}"
+    return data, None
 
-def extract_header(doc: dict, src: Path):
-    if not isinstance(doc, dict):
+
+def extract_header(document: Any, source: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Extract standard metadata from a ruleset document."""
+
+    if not isinstance(document, dict):
         return None, "Top-level must be a mapping"
-    hdr = {
-        "id": doc.get("id"),
-        "name": doc.get("name"),
-        "version": doc.get("version"),
-        "status": doc.get("status","active"),
-        "supersedes": doc.get("supersedes"),
-        "source_file": str(src),
+
+    header = {
+        "id": document.get("id"),
+        "name": document.get("name"),
+        "version": document.get("version"),
+        "status": document.get("status", "active"),
+        "supersedes": document.get("supersedes"),
+        "source_file": str(source),
     }
-    errs = []
-    if not hdr["id"]:
-        errs.append("Missing 'id'")
-    if not hdr["version"]:
-        errs.append("Missing 'version'")
-    dt = iso_to_dt(hdr["version"]) if hdr["version"] else None
-    if not dt:
-        errs.append("Bad 'version' (expect ISO like 2025-09-03T22:41Z)")
-    hdr["_version_dt"] = dt
-    return (hdr if not errs else None), (", ".join(errs) if errs else None)
 
-def ensure_dir(p: Path):
-    p.mkdir(parents=True, exist_ok=True)
+    errors: list[str] = []
+    if not header["id"]:
+        errors.append("Missing 'id'")
+    if not header["version"]:
+        errors.append("Missing 'version'")
 
-def main():
-    ap = argparse.ArgumentParser(description="Rebuild consolidated astrology ruleset from all iterations (append-only).")
-    ap.add_argument("--in", dest="in_dir", required=True, help="Folder containing ALL past iterations (yaml/json)")
-    ap.add_argument("--out", dest="out_dir", default="./rulesets", help="Output folder (default ./rulesets)")
-    ap.add_argument("--single", dest="emit_single", action="store_true", help="Emit combined ruleset.main.yaml")
-    args = ap.parse_args()
+    version_dt = iso_to_dt(header["version"])
+    if not version_dt:
+        errors.append("Bad 'version' (expect ISO like 2025-09-03T22:41Z)")
+    header["_version_dt"] = version_dt
+
+    if errors:
+        return None, ", ".join(errors)
+    return header, None
+
+
+def ensure_dirs(paths: Iterable[Path]) -> None:
+    for directory in paths:
+        directory.mkdir(parents=True, exist_ok=True)
+
+
+def discover_source_files(root: Path) -> list[Path]:
+    return sorted(
+        path
+        for path in root.rglob("*")
+        if path.suffix.lower() in {".yaml", ".yml", ".json"}
+    )
+
+
+def build_registry(files: Iterable[Path]) -> tuple[ModuleRegistry, ParsingErrors]:
+    registry: ModuleRegistry = {}
+    parsing_errors: ParsingErrors = []
+
+    for path in files:
+        data, parse_error = load_any(path)
+        if parse_error:
+            parsing_errors.append((str(path), parse_error))
+            continue
+
+        header, header_error = extract_header(data, path)
+        if header_error:
+            parsing_errors.append((str(path), header_error))
+            continue
+
+        entry = {
+            "id": header["id"],
+            "name": header["name"],
+            "version": header["version"],
+            "status": header["status"],
+            "supersedes": header["supersedes"],
+            "_version_dt": header["_version_dt"],
+            "source_file": header["source_file"],
+            "body": data,
+        }
+        registry.setdefault(header["id"], []).append(entry)
+
+    return registry, parsing_errors
+
+
+def compute_lineage(registry: ModuleRegistry) -> tuple[dict[str, dict[str, Any]], ModuleRegistry]:
+    latest_by_id: dict[str, dict[str, Any]] = {}
+    lineage_by_id: ModuleRegistry = {}
+
+    for module_id, entries in registry.items():
+        valid_entries = [entry for entry in entries if entry["_version_dt"] is not None]
+        valid_entries.sort(key=lambda entry: entry["_version_dt"])
+        if not valid_entries:
+            continue
+        latest_by_id[module_id] = valid_entries[-1]
+        lineage_by_id[module_id] = valid_entries
+
+    return latest_by_id, lineage_by_id
+
+
+def write_manifest(manifest_path: Path, lineage_by_id: ModuleRegistry, latest_by_id: dict[str, dict[str, Any]]) -> None:
+    header = [
+        "module_id",
+        "name",
+        "version",
+        "status",
+        "supersedes",
+        "source_file",
+        "is_latest",
+    ]
+
+    with manifest_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(header)
+        for module_id, entries in lineage_by_id.items():
+            for entry in entries:
+                writer.writerow(
+                    [
+                        entry["id"],
+                        entry["name"],
+                        entry["version"],
+                        entry["status"],
+                        entry["supersedes"],
+                        entry["source_file"],
+                        "yes" if entry is latest_by_id[module_id] else "no",
+                    ]
+                )
+
+
+def write_validation_report(
+    report_path: Path,
+    parsing_errors: ParsingErrors,
+    missing_required: list[str],
+    registry: ModuleRegistry,
+    latest_by_id: dict[str, dict[str, Any]],
+) -> None:
+    with report_path.open("w", encoding="utf-8") as handle:
+        handle.write("# Validation Report\n\n")
+
+        if parsing_errors:
+            handle.write("## Parsing / Header Errors\n")
+            for path, error in parsing_errors:
+                handle.write(f"- {path}: {error}\n")
+            handle.write("\n")
+
+        if missing_required:
+            handle.write("## Missing Required Modules\n")
+            for module_id in missing_required:
+                handle.write(f"- {module_id}\n")
+            handle.write("\n")
+        else:
+            handle.write("All required modules present: aspects, transits, scoring, narrative.\n\n")
+
+        handle.write("## Module Counts\n")
+        handle.write(f"- Unique module ids found: {len(registry)}\n")
+        handle.write(f"- Latest modules selected: {len(latest_by_id)}\n")
+
+
+def emit_latest_modules(overrides_dir: Path, latest_by_id: dict[str, dict[str, Any]], ts_file: str) -> list[str]:
+    emitted: list[str] = []
+
+    for module_id, entry in sorted(latest_by_id.items()):
+        body = entry["body"]
+        body["id"] = entry["id"]
+        if entry["name"] is not None:
+            body["name"] = entry["name"]
+        body["version"] = entry["version"]
+        body["status"] = entry["status"]
+        if entry["supersedes"] is not None:
+            body["supersedes"] = entry["supersedes"]
+
+        target = overrides_dir / f"{module_id}__v{ts_file}.yaml"
+        with target.open("w", encoding="utf-8") as handle:
+            yaml.safe_dump(body, handle, sort_keys=False, allow_unicode=True)
+        emitted.append(str(target))
+
+    return emitted
+
+
+def emit_combined_ruleset(destination: Path, latest_by_id: dict[str, dict[str, Any]]) -> None:
+    stitched = {"modules": {}}
+    for module_id, entry in latest_by_id.items():
+        stitched["modules"][module_id] = entry["body"]
+
+    with destination.open("w", encoding="utf-8") as handle:
+        yaml.safe_dump(stitched, handle, sort_keys=False, allow_unicode=True)
+
+
+def write_changelog(
+    changelog_path: Path,
+    generated_at: datetime.datetime,
+    overrides_dir: Path,
+    lineage_by_id: ModuleRegistry,
+    latest_by_id: dict[str, dict[str, Any]],
+) -> None:
+    with changelog_path.open("w", encoding="utf-8") as handle:
+        handle.write("# Ruleset Change Log (Consolidation)\n\n")
+        handle.write(f"- Consolidation time (UTC): {generated_at.isoformat(timespec='seconds')}Z\n")
+        handle.write(f"- Output (overrides): {overrides_dir}\n\n")
+
+        for module_id, entries in sorted(lineage_by_id.items()):
+            handle.write(f"## {module_id}\n")
+            for entry in entries:
+                suffix = " (latest)" if entry is latest_by_id[module_id] else ""
+                name = entry.get("name") or ""
+                handle.write(f"- {entry['version']} — {name} [{entry['status']}]{suffix}\n")
+            handle.write("\n")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Rebuild consolidated astrology ruleset from all iterations (append-only)."
+    )
+    parser.add_argument(
+        "--in",
+        dest="in_dir",
+        required=True,
+        help="Folder containing ALL past iterations (yaml/json)",
+    )
+    parser.add_argument(
+        "--out",
+        dest="out_dir",
+        default="./rulesets",
+        help="Output folder (default ./rulesets)",
+    )
+    parser.add_argument(
+        "--single",
+        dest="emit_single",
+        action="store_true",
+        help="Emit combined ruleset.main.yaml",
+    )
+    return parser.parse_args(argv)
+
+
+def run(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
 
     in_dir = Path(args.in_dir)
     out_root = Path(args.out_dir)
@@ -77,131 +294,55 @@ def main():
     overrides_dir = out_root / "overrides"
     report_dir = out_root / "_reports"
 
-    for d in (base_dir, overrides_dir, report_dir):
-        ensure_dir(d)
+    ensure_dirs((base_dir, overrides_dir, report_dir))
 
-    manifest_rows = []
-    registry = {}   # id -> list of entries
-    parsing_errors = []
-    files = sorted([p for p in in_dir.rglob("*") if p.suffix.lower() in (".yaml",".yml",".json")])
-
-    if not files:
+    source_files = discover_source_files(in_dir)
+    if not source_files:
         print("No YAML/JSON files found in input directory.", file=sys.stderr)
-        sys.exit(2)
+        return 2
 
-    for p in files:
-        data, perr = load_any(p)
-        if perr:
-            parsing_errors.append((str(p), perr))
-            continue
-        hdr, herr = extract_header(data, p)
-        if herr:
-            parsing_errors.append((str(p), herr))
-            continue
-        body = data
-        entry = {
-            "id": hdr["id"],
-            "name": hdr["name"],
-            "version": hdr["version"],
-            "status": hdr["status"],
-            "supersedes": hdr["supersedes"],
-            "_version_dt": hdr["_version_dt"],
-            "source_file": hdr["source_file"],
-            "body": body,
-        }
-        registry.setdefault(hdr["id"], []).append(entry)
+    registry, parsing_errors = build_registry(source_files)
+    latest_by_id, lineage_by_id = compute_lineage(registry)
+    missing_required = sorted(module for module in REQUIRED_MODULE_IDS if module not in latest_by_id)
 
-    latest_by_id = {}
-    lineage_by_id = {}
-    for mid, entries in registry.items():
-        entries = [e for e in entries if e["_version_dt"] is not None]
-        entries.sort(key=lambda e: e["_version_dt"])
-        if not entries:
-            continue
-        latest_by_id[mid] = entries[-1]
-        lineage_by_id[mid] = entries
+    generated_at = datetime.datetime.utcnow()
+    timestamp = generated_at.strftime(TS_FMT_FILE)
 
-    missing_required = sorted([m for m in REQUIRED_MODULE_IDS if m not in latest_by_id])
+    manifest_path = report_dir / f"RULESET__MANIFEST_{timestamp}.csv"
+    write_manifest(manifest_path, lineage_by_id, latest_by_id)
 
-    now = datetime.datetime.utcnow()
-    ts_file = now.strftime(TS_FMT_FILE)
-
-    manifest_path = report_dir / f"RULESET__MANIFEST_{ts_file}.csv"
-    with manifest_path.open("w", newline="", encoding="utf-8") as f:
-        w = csv.writer(f)
-        w.writerow(["module_id","name","version","status","supersedes","source_file","is_latest"])
-        for mid, entries in lineage_by_id.items():
-            for e in entries:
-                w.writerow([e["id"], e["name"], e["version"], e["status"], e["supersedes"], e["source_file"], "yes" if e is latest_by_id[mid] else "no"])
-
-    val_path = report_dir / f"RULESET__VALIDATION_{ts_file}.md"
-    with val_path.open("w", encoding="utf-8") as f:
-        f.write("# Validation Report\n\n")
-        if parsing_errors:
-            f.write("## Parsing / Header Errors\n")
-            for p, err in parsing_errors:
-                f.write(f"- {p}: {err}\n")
-            f.write("\n")
-        if missing_required:
-            f.write("## Missing Required Modules\n")
-            for m in missing_required:
-                f.write(f"- {m}\n")
-            f.write("\n")
-        else:
-            f.write("All required modules present: aspects, transits, scoring, narrative.\n\n")
-
-        f.write("## Module Counts\n")
-        f.write(f"- Unique module ids found: {len(registry)}\n")
-        f.write(f"- Latest modules selected: {len(latest_by_id)}\n")
+    validation_path = report_dir / f"RULESET__VALIDATION_{timestamp}.md"
+    write_validation_report(validation_path, parsing_errors, missing_required, registry, latest_by_id)
 
     if missing_required:
         print(f"Missing required modules: {', '.join(missing_required)}", file=sys.stderr)
-        print(f"See validation: {val_path}", file=sys.stderr)
-        sys.exit(3)
+        print(f"See validation: {validation_path}", file=sys.stderr)
+        return 3
 
-    emitted_paths = []
-    for mid, e in sorted(latest_by_id.items()):
-        body = e["body"]
-        body["id"] = e["id"]
-        if e["name"] is not None:
-            body["name"] = e["name"]
-        body["version"] = e["version"]
-        body["status"] = e["status"]
-        if e["supersedes"] is not None:
-            body["supersedes"] = e["supersedes"]
+    emit_latest_modules(overrides_dir, latest_by_id, timestamp)
 
-        tgt = overrides_dir / f"{mid}__v{ts_file}.yaml"
-        with tgt.open("w", encoding="utf-8") as f:
-            yaml.safe_dump(body, f, sort_keys=False, allow_unicode=True)
-        emitted_paths.append(str(tgt))
-
+    stitched_path: Path | None = None
     if args.emit_single:
-        main_path = out_root / f"ruleset.main.yaml"
-        stitched = {"modules": {}}
-        for mid, e in latest_by_id.items():
-            stitched["modules"][mid] = e["body"]
-        with main_path.open("w", encoding="utf-8") as f:
-            yaml.safe_dump(stitched, f, sort_keys=False, allow_unicode=True)
+        stitched_path = out_root / "ruleset.main.yaml"
+        emit_combined_ruleset(stitched_path, latest_by_id)
 
-    changelog_path = report_dir / f"RULESET__CHANGELOG_{ts_file}.md"
-    with changelog_path.open("w", encoding="utf-8") as f:
-        f.write("# Ruleset Change Log (Consolidation)\n\n")
-        f.write(f"- Consolidation time (UTC): {now.isoformat(timespec='seconds')}Z\n")
-        f.write(f"- Output (overrides): {overrides_dir}\n\n")
-        for mid, entries in sorted(lineage_by_id.items()):
-            f.write(f"## {mid}\n")
-            for e in entries:
-                mark = " (latest)" if e is latest_by_id[mid] else ""
-                f.write(f"- {e['version']} — {e.get('name') or ''} [{e['status']}]{mark}\n")
-            f.write("\n")
+    changelog_path = report_dir / f"RULESET__CHANGELOG_{timestamp}.md"
+    write_changelog(changelog_path, generated_at, overrides_dir, lineage_by_id, latest_by_id)
 
     print("Consolidation complete.")
     print(f"- Manifest: {manifest_path}")
-    print(f"- Validation: {val_path}")
+    print(f"- Validation: {validation_path}")
     print(f"- Changelog: {changelog_path}")
-    if args.emit_single:
-        print(f"- Stitched: {out_root / 'ruleset.main.yaml'}")
+    if stitched_path is not None:
+        print(f"- Stitched: {stitched_path}")
     print(f"- Latest modules written to: {overrides_dir}")
+
+    return 0
+
+
+def main() -> None:
+    sys.exit(run())
+
 
 if __name__ == "__main__":
     main()

--- a/Version Consolidation/consolidate_rulesets.py
+++ b/Version Consolidation/consolidate_rulesets.py
@@ -36,20 +36,15 @@ def iso_to_dt(value: object | None) -> datetime.datetime | None:
         return value
 
     text: str | None
-    if isinstance(value, (bytes, bytearray, memoryview)):
-        try:
+    try:
+        if isinstance(value, (bytes, bytearray, memoryview)):
             text = bytes(value).decode("utf-8")
-        except Exception:  # pragma: no cover - defensive guardrails
-            return None
-    elif isinstance(value, str):
-        text = value
-    else:
-        try:
+        else:
             text = str(value)
-        except Exception:  # pragma: no cover - defensive guardrails
-            return None
+    except Exception:  # pragma: no cover - defensive guardrails
+        return None
 
-    if not isinstance(text, str):  # pragma: no cover - extreme edge cases
+    if text is None:
         return None
 
     try:

--- a/Version Consolidation/consolidate_rulesets.py
+++ b/Version Consolidation/consolidate_rulesets.py
@@ -35,19 +35,28 @@ def iso_to_dt(value: object | None) -> datetime.datetime | None:
     if isinstance(value, datetime.datetime):
         return value
 
-    if isinstance(value, bytes):
+    text: str | None
+    if isinstance(value, (bytes, bytearray, memoryview)):
         try:
-            value = value.decode("utf-8")
+            text = bytes(value).decode("utf-8")
+        except Exception:  # pragma: no cover - defensive guardrails
+            return None
+    elif isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = str(value)
         except Exception:  # pragma: no cover - defensive guardrails
             return None
 
-    if not isinstance(value, str):
-        try:
-            value = str(value)
-        except Exception:  # pragma: no cover - defensive guardrails
-            return None
+    if not isinstance(text, str):  # pragma: no cover - extreme edge cases
+        return None
 
-    cleaned = value.strip()
+    try:
+        cleaned = text.strip()
+    except AttributeError:  # pragma: no cover - defensive guardrails
+        return None
+
     if not cleaned:
         return None
     if cleaned.endswith("Z"):

--- a/Version Consolidation/consolidate_rulesets.py
+++ b/Version Consolidation/consolidate_rulesets.py
@@ -26,13 +26,30 @@ ModuleRegistry = dict[str, list[dict[str, Any]]]
 ParsingErrors = list[tuple[str, str]]
 
 
-def iso_to_dt(value: str | None) -> datetime.datetime | None:
+def iso_to_dt(value: object | None) -> datetime.datetime | None:
     """Parse a loose ISO 8601 timestamp to a datetime."""
 
-    if not value:
+    if value is None:
         return None
 
+    if isinstance(value, datetime.datetime):
+        return value
+
+    if isinstance(value, bytes):
+        try:
+            value = value.decode("utf-8")
+        except Exception:  # pragma: no cover - defensive guardrails
+            return None
+
+    if not isinstance(value, str):
+        try:
+            value = str(value)
+        except Exception:  # pragma: no cover - defensive guardrails
+            return None
+
     cleaned = value.strip()
+    if not cleaned:
+        return None
     if cleaned.endswith("Z"):
         cleaned = cleaned[:-1]
 

--- a/tests/test_consolidate_rulesets_utils.py
+++ b/tests/test_consolidate_rulesets_utils.py
@@ -1,0 +1,53 @@
+"""Tests for helper utilities in the ruleset consolidation workflow."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import runpy
+from pathlib import Path
+
+_MODULE_GLOBALS = runpy.run_path(
+    Path(__file__).resolve().parents[1]
+    / "Version Consolidation"
+    / "consolidate_rulesets.py"
+)
+iso_to_dt = _MODULE_GLOBALS["iso_to_dt"]
+
+
+def test_iso_to_dt_parses_iso_strings() -> None:
+    result = iso_to_dt("2025-09-03T22:41Z")
+    assert result == _dt.datetime(2025, 9, 3, 22, 41)
+
+
+def test_iso_to_dt_strips_whitespace() -> None:
+    result = iso_to_dt(" 2025-09-03 ")
+    assert result == _dt.datetime(2025, 9, 3)
+
+
+def test_iso_to_dt_accepts_datetime_instances() -> None:
+    stamp = _dt.datetime(2024, 1, 2, 3, 4, 5)
+    result = iso_to_dt(stamp)
+    assert result is stamp
+
+
+def test_iso_to_dt_handles_byte_like_inputs() -> None:
+    result = iso_to_dt(b"2025-09-03T22:41")
+    assert result == _dt.datetime(2025, 9, 3, 22, 41)
+
+    result = iso_to_dt(memoryview(b"2025-09-03"))
+    assert result == _dt.datetime(2025, 9, 3)
+
+
+def test_iso_to_dt_returns_none_for_non_string_inputs() -> None:
+    assert iso_to_dt(20250903) is None
+
+    class Explosive:
+        def __str__(self) -> str:  # pragma: no cover - exercised via iso_to_dt
+            raise ValueError("boom")
+
+    assert iso_to_dt(Explosive()) is None
+
+
+def test_iso_to_dt_returns_none_for_empty_text() -> None:
+    assert iso_to_dt("") is None
+    assert iso_to_dt("   ") is None

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -1,3 +1,2 @@
-```python
 def test_sanity():
     assert True


### PR DESCRIPTION
## Summary
- refactor the ruleset consolidation utility into smaller helper functions with type hints and documentation to clarify the pipeline
- add reusable routines for manifest generation, validation reporting, change log writing, and stitched ruleset emission while preserving output behaviour
- keep the CLI entry point thin, returning explicit exit codes for integration with conda-based automation

## Testing
- ruff check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ccabd9c414832498b8c361f492e9dc