### PR TITLE
Add environment rebuild helper

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -28,10 +28,10 @@ from .core import (
     natal_domain_factor,
     profile_into_ctx,
 )
-from .infrastructure.environment import (
-    collect_environment_report,
-    main as environment_report_main,
-)
+from .infrastructure.environment import collect_environment_report
+from .infrastructure.environment import main as environment_report_main
+from .infrastructure.rebuild import main as environment_rebuild_main
+from .infrastructure.rebuild import rebuild_virtualenv
 from .modules import (
     DEFAULT_REGISTRY,
     AstroChannel,
@@ -42,7 +42,7 @@ from .modules import (
     bootstrap_default_registry,
 )
 from .modules.vca import serialize_vca_ruleset
-from .profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES
+from .profiles import VCA_DOMAIN_PROFILES, DomainScoringProfile
 from .rulesets import VCA_RULESET, get_vca_aspect, vca_orb_for
 
 __all__ = [
@@ -75,6 +75,8 @@ __all__ = [
     "AstroSubchannel",
     "collect_environment_report",
     "environment_report_main",
+    "rebuild_virtualenv",
+    "environment_rebuild_main",
     "get_vca_aspect",
     "vca_orb_for",
     "VCA_CORE_BODIES",

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import argparse
-from typing import Any, Dict, Optional, Sequence, Tuple
+from collections.abc import Sequence
+from typing import Any
 
 from .api import TransitEvent, TransitScanConfig
 from .config import load_profile_json
@@ -46,8 +47,8 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _initial_context_from_args(args: argparse.Namespace) -> Dict[str, Any]:
-    ctx: Dict[str, Any] = {
+def _initial_context_from_args(args: argparse.Namespace) -> dict[str, Any]:
+    ctx: dict[str, Any] = {
         "emit_domains": args.emit_domains,
     }
     if args.emit_domains:
@@ -57,7 +58,7 @@ def _initial_context_from_args(args: argparse.Namespace) -> Dict[str, Any]:
     return ctx
 
 
-def main(argv: Optional[Sequence[str]] = None) -> Tuple[TransitScanConfig, Dict[str, Any]]:
+def main(argv: Sequence[str] | None = None) -> tuple[TransitScanConfig, dict[str, Any]]:
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/astroengine/core/api.py
+++ b/astroengine/core/api.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
 
 
 @dataclass
 class TransitEvent:
     """Container for a resolved transit event."""
 
-    elements: List[str] = field(default_factory=list)
-    domains: Dict[str, float] = field(default_factory=dict)
-    domain_profile: Optional[str] = None
-    severity: Optional[float] = None
+    elements: list[str] = field(default_factory=list)
+    domains: dict[str, float] = field(default_factory=dict)
+    domain_profile: str | None = None
+    severity: float | None = None
 
 
 @dataclass

--- a/astroengine/core/config.py
+++ b/astroengine/core/config.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 
-def load_profile_json(path: str | Path) -> Dict[str, Any]:
+def load_profile_json(path: str | Path) -> dict[str, Any]:
     """Load a profile JSON document and return a dictionary."""
 
     profile_path = Path(path)
@@ -17,7 +17,7 @@ def load_profile_json(path: str | Path) -> Dict[str, Any]:
     return data
 
 
-def profile_into_ctx(ctx: Dict[str, Any], profile: Dict[str, Any]) -> Dict[str, Any]:
+def profile_into_ctx(ctx: dict[str, Any], profile: dict[str, Any]) -> dict[str, Any]:
     """Merge profile keys into an engine context dictionary."""
 
     ctx = dict(ctx or {})

--- a/astroengine/core/domains.py
+++ b/astroengine/core/domains.py
@@ -9,15 +9,15 @@ risking silent regressions.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Dict, List, Mapping, Optional, Tuple
 
 # Canonical element labels (uppercase; stable public API)
-ELEMENTS: Tuple[str, str, str, str] = ("FIRE", "EARTH", "AIR", "WATER")
-DOMAINS: Tuple[str, str, str] = ("MIND", "BODY", "SPIRIT")
+ELEMENTS: tuple[str, str, str, str] = ("FIRE", "EARTH", "AIR", "WATER")
+DOMAINS: tuple[str, str, str] = ("MIND", "BODY", "SPIRIT")
 
 # Zodiac (0=Aries ... 11=Pisces) → Element
-ZODIAC_ELEMENT_MAP: Tuple[str, ...] = (
+ZODIAC_ELEMENT_MAP: tuple[str, ...] = (
     "FIRE",   # 0 Aries
     "EARTH",  # 1 Taurus
     "AIR",    # 2 Gemini
@@ -69,8 +69,8 @@ DEFAULT_HOUSE_DOMAIN_WEIGHTS: Mapping[int, Mapping[str, float]] = {
 
 @dataclass(frozen=True)
 class DomainResolution:
-    elements: List[str]            # e.g., ["FIRE"] (sign-derived)
-    domains: Dict[str, float]      # merged weights {"MIND": w, ...}
+    elements: list[str]            # e.g., ["FIRE"] (sign-derived)
+    domains: dict[str, float]      # merged weights {"MIND": w, ...}
 
 
 class DomainResolver:
@@ -78,8 +78,8 @@ class DomainResolver:
 
     def __init__(
         self,
-        planet_weights: Optional[Mapping[str, Mapping[str, float]]] = None,
-        house_weights: Optional[Mapping[int, Mapping[str, float]]] = None,
+        planet_weights: Mapping[str, Mapping[str, float]] | None = None,
+        house_weights: Mapping[int, Mapping[str, float]] | None = None,
     ) -> None:
         self._planet = planet_weights or DEFAULT_PLANET_DOMAIN_WEIGHTS
         self._house = house_weights or DEFAULT_HOUSE_DOMAIN_WEIGHTS
@@ -88,8 +88,8 @@ class DomainResolver:
         self,
         sign_index: int,
         planet_key: str,
-        house_index: Optional[int] = None,
-        overrides: Optional[Mapping[str, Mapping]] = None,
+        house_index: int | None = None,
+        overrides: Mapping[str, Mapping] | None = None,
     ) -> DomainResolution:
         if not (0 <= sign_index <= 11):
             raise ValueError("sign_index must be 0..11")
@@ -106,7 +106,7 @@ class DomainResolver:
             if house_over and house_index in house_over:
                 h = dict(house_over[house_index])
 
-        merged: Dict[str, float] = {}
+        merged: dict[str, float] = {}
         for src in (p, h):
             for key, value in src.items():
                 merged[key] = merged.get(key, 0.0) + float(value)
@@ -119,7 +119,7 @@ class DomainResolver:
 def natal_domain_factor(
     sign_index: int,
     planet_key: str,
-    house_index: Optional[int],
+    house_index: int | None,
     multipliers: Mapping[str, float],
     method: str = "weighted",
     temperature: float = 8.0,

--- a/astroengine/core/engine.py
+++ b/astroengine/core/engine.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional
+from collections.abc import Iterable
+from typing import Any
 
 from ..modules.vca.profiles import VCA_DOMAIN_PROFILES
 from .config import profile_into_ctx
@@ -53,7 +54,7 @@ def maybe_attach_domain_fields(event_obj, ctx):
     return event_obj
 
 
-def apply_profile_if_any(ctx: Dict[str, Any], profile_dict: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def apply_profile_if_any(ctx: dict[str, Any], profile_dict: dict[str, Any] | None = None) -> dict[str, Any]:
     """Merge an optional profile into ``ctx`` and return a new dictionary."""
 
     if profile_dict:
@@ -61,7 +62,7 @@ def apply_profile_if_any(ctx: Dict[str, Any], profile_dict: Optional[Dict[str, A
     return ctx
 
 
-def get_active_aspect_angles(ctx: Optional[Dict[str, Any]]) -> Iterable[float]:
+def get_active_aspect_angles(ctx: dict[str, Any] | None) -> Iterable[float]:
     """Return the sorted aspect angles configured in ``ctx``."""
 
     aspects = (ctx or {}).get("aspects", {})
@@ -72,7 +73,7 @@ def get_active_aspect_angles(ctx: Optional[Dict[str, Any]]) -> Iterable[float]:
     return sorted({float(angle) for angle in angles})
 
 
-def get_feature_flag(ctx: Optional[Dict[str, Any]], key: str, default: bool = False) -> bool:
+def get_feature_flag(ctx: dict[str, Any] | None, key: str, default: bool = False) -> bool:
     """Return the boolean feature flag stored under ``key`` in ``ctx``."""
 
     flags = (ctx or {}).get("flags", {})

--- a/astroengine/core/scoring.py
+++ b/astroengine/core/scoring.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from typing import Mapping
+from collections.abc import Mapping
 
 
 def compute_domain_factor(

--- a/astroengine/data/schemas.py
+++ b/astroengine/data/schemas.py
@@ -9,9 +9,9 @@ packing everything into the Python module.
 from __future__ import annotations
 
 import json
-from functools import lru_cache
+from collections.abc import Iterable, Mapping, MutableMapping
+from functools import cache
 from pathlib import Path
-from typing import Dict, Iterable, Mapping, MutableMapping
 
 from . import SCHEMA_DIR
 
@@ -29,7 +29,7 @@ class SchemaNotFoundError(KeyError):
 
 SchemaMetadata = Mapping[str, str]
 
-SCHEMA_REGISTRY: Dict[str, SchemaMetadata] = {
+SCHEMA_REGISTRY: dict[str, SchemaMetadata] = {
     "result_v1": {"filename": "result_schema_v1.json", "kind": "jsonschema"},
     "result_v1_with_domains": {
         "filename": "result_schema_v1_with_domains.json",
@@ -54,7 +54,7 @@ def _schema_path(metadata: Mapping[str, str]) -> Path:
     return SCHEMA_DIR / filename
 
 
-@lru_cache(maxsize=None)
+@cache
 def load_schema_document(key: str) -> MutableMapping[str, object]:
     """Return the JSON payload for the requested schema key.
 

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -3,11 +3,11 @@
 from __future__ import annotations
 
 from .core.domains import (
+    DEFAULT_HOUSE_DOMAIN_WEIGHTS,
+    DEFAULT_PLANET_DOMAIN_WEIGHTS,
     DOMAINS,
     ELEMENTS,
     ZODIAC_ELEMENT_MAP,
-    DEFAULT_HOUSE_DOMAIN_WEIGHTS,
-    DEFAULT_PLANET_DOMAIN_WEIGHTS,
     DomainResolution,
     DomainResolver,
     natal_domain_factor,

--- a/astroengine/infrastructure/__init__.py
+++ b/astroengine/infrastructure/__init__.py
@@ -1,7 +1,17 @@
-"""Infrastructure helpers (environment diagnostics, etc.)."""
+"""Infrastructure helpers (environment diagnostics, rebuild utilities, etc.)."""
 
 from __future__ import annotations
 
-from .environment import EnvironmentReport, collect_environment_report, main as environment_main
+from .environment import EnvironmentReport, collect_environment_report
+from .environment import main as environment_main
+from .rebuild import RebuildStep, rebuild_virtualenv
+from .rebuild import main as rebuild_main
 
-__all__ = ["EnvironmentReport", "collect_environment_report", "environment_main"]
+__all__ = [
+    "EnvironmentReport",
+    "collect_environment_report",
+    "environment_main",
+    "RebuildStep",
+    "rebuild_virtualenv",
+    "rebuild_main",
+]

--- a/astroengine/infrastructure/environment.py
+++ b/astroengine/infrastructure/environment.py
@@ -6,9 +6,9 @@ import argparse
 import json
 import platform
 import sys
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from dataclasses import dataclass
 from importlib import metadata
-from typing import Dict, Iterable, Mapping, MutableMapping, Sequence, Tuple
 
 __all__ = [
     "EnvironmentReport",
@@ -21,7 +21,7 @@ __all__ = [
 class EnvironmentReport:
     """Snapshot of the local Python environment."""
 
-    python_version: Tuple[int, int, int]
+    python_version: tuple[int, int, int]
     executable: str
     platform: str
     packages: Mapping[str, str]
@@ -36,7 +36,7 @@ class EnvironmentReport:
 
 
 def _package_versions(package_names: Iterable[str]) -> MutableMapping[str, str]:
-    versions: Dict[str, str] = {}
+    versions: dict[str, str] = {}
     for name in package_names:
         try:
             versions[name] = metadata.version(name)

--- a/astroengine/infrastructure/rebuild.py
+++ b/astroengine/infrastructure/rebuild.py
@@ -1,0 +1,217 @@
+"""Utilities to rebuild the AstroEngine virtual environment from scratch.
+
+The routines here provide a *safe* wrapper around Python's ``venv`` module
+and ``pip`` so developers can reset their environment without manually
+invoking shell commands.  A dry-run mode is available for inspection and
+tests rely on it to avoid mutating the filesystem during CI runs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+__all__ = [
+    "RebuildStep",
+    "build_rebuild_plan",
+    "execute_plan",
+    "rebuild_virtualenv",
+    "main",
+]
+
+
+Command = Sequence[str]
+
+
+@dataclass(frozen=True)
+class RebuildStep:
+    """Represents a single action in the environment rebuild workflow."""
+
+    description: str
+    command: tuple[str, ...] | None = None
+
+
+def _pip_executable(venv_path: Path) -> Path:
+    """Return the path to the ``pip`` executable inside ``venv_path``."""
+
+    if os.name == "nt":
+        return venv_path / "Scripts" / "pip.exe"
+    return venv_path / "bin" / "pip"
+
+
+def _format_extras(extras: Iterable[str] | None) -> str:
+    if not extras:
+        return "."
+    extras_list = [part.strip() for part in extras if part.strip()]
+    if not extras_list:
+        return "."
+    return f".[{','.join(sorted(extras_list))}]"
+
+
+def build_rebuild_plan(
+    *,
+    venv_path: Path = Path(".venv"),
+    python_executable: str | None = None,
+    extras: Iterable[str] | None = ("dev",),
+    upgrade_pip: bool = True,
+) -> list[RebuildStep]:
+    """Construct a list of steps needed to rebuild ``venv_path``.
+
+    The steps describe what will happen; they do not perform any side effects
+    so the plan can be shown to the user before executing it.
+    """
+
+    python_executable = python_executable or sys.executable
+    plan: list[RebuildStep] = []
+
+    if venv_path.exists():
+        plan.append(RebuildStep(description=f"Remove existing environment at {venv_path}"))
+
+    plan.append(
+        RebuildStep(
+            description=f"Create virtual environment at {venv_path}",
+            command=(python_executable, "-m", "venv", str(venv_path)),
+        )
+    )
+
+    pip_path = _pip_executable(venv_path)
+    if upgrade_pip:
+        plan.append(
+            RebuildStep(
+                description="Upgrade pip inside the virtual environment",
+                command=(str(pip_path), "install", "--upgrade", "pip"),
+            )
+        )
+
+    plan.append(
+        RebuildStep(
+            description="Install AstroEngine into the virtual environment",
+            command=(str(pip_path), "install", "--upgrade", "-e", _format_extras(extras)),
+        )
+    )
+
+    return plan
+
+
+def execute_plan(
+    plan: Sequence[RebuildStep],
+    *,
+    venv_path: Path,
+    upgrade_pip: bool = True,
+    remove_existing: bool = True,
+    runner: Callable[[Command], None] | None = None,
+) -> None:
+    """Execute each command in ``plan`` using ``runner``.
+
+    ``remove_existing`` controls whether an existing directory is deleted.
+    ``upgrade_pip`` mirrors :func:`build_rebuild_plan` so the caller can ensure
+    consistent behaviour when the plan was generated earlier.
+    """
+
+    runner = runner or (lambda cmd: subprocess.run(cmd, check=True))
+
+    if remove_existing and venv_path.exists():
+        shutil.rmtree(venv_path)
+
+    for step in plan:
+        if step.command is None:
+            continue
+        runner(step.command)
+
+
+def rebuild_virtualenv(
+    *,
+    venv_path: Path = Path(".venv"),
+    python_executable: str | None = None,
+    extras: Iterable[str] | None = ("dev",),
+    upgrade_pip: bool = True,
+    dry_run: bool = False,
+    runner: Callable[[Command], None] | None = None,
+) -> list[RebuildStep]:
+    """Recreate a virtual environment and reinstall AstroEngine.
+
+    The function returns the plan that was used.  When ``dry_run`` is true the
+    plan is returned without executing the commands, making it suitable for
+    previews or unit tests.
+    """
+
+    plan = build_rebuild_plan(
+        venv_path=venv_path,
+        python_executable=python_executable,
+        extras=extras,
+        upgrade_pip=upgrade_pip,
+    )
+
+    if not dry_run:
+        execute_plan(
+            plan,
+            venv_path=venv_path,
+            upgrade_pip=upgrade_pip,
+            remove_existing=True,
+            runner=runner,
+        )
+
+    return plan
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="astroengine.environment-rebuild",
+        description="Rebuild the AstroEngine virtual environment.",
+    )
+    parser.add_argument(
+        "--path",
+        default=".venv",
+        help="Target directory for the virtual environment (default: .venv).",
+    )
+    parser.add_argument(
+        "--python",
+        default=None,
+        help="Python executable to use for the virtual environment (default: current interpreter).",
+    )
+    parser.add_argument(
+        "--extras",
+        default="dev",
+        help="Comma separated extras to install (default: dev).  Use an empty string to disable.",
+    )
+    parser.add_argument(
+        "--no-upgrade-pip",
+        action="store_true",
+        help="Skip upgrading pip inside the virtual environment.",
+    )
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Execute the rebuild plan after printing it.",
+    )
+    args = parser.parse_args(argv)
+
+    extras = tuple(filter(None, (part.strip() for part in args.extras.split(","))))
+    upgrade_pip = not args.no_upgrade_pip
+
+    plan = rebuild_virtualenv(
+        venv_path=Path(args.path),
+        python_executable=args.python,
+        extras=extras,
+        upgrade_pip=upgrade_pip,
+        dry_run=not args.run,
+    )
+
+    for step in plan:
+        if step.command is None:
+            print(f"- {step.description}")
+        else:
+            printable = " ".join(step.command)
+            print(f"- {step.description}: $ {printable}")
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/astroengine/modules/registry.py
+++ b/astroengine/modules/registry.py
@@ -11,8 +11,8 @@ existing Python modules, satisfying the ``no module loss`` constraint.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, MutableMapping
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, Mapping, MutableMapping, Optional
 
 __all__ = [
     "AstroRegistry",
@@ -29,12 +29,12 @@ class AstroSubchannel:
 
     name: str
     metadata: MutableMapping[str, object] = field(default_factory=dict)
-    payload: Optional[Mapping[str, object]] = None
+    payload: Mapping[str, object] | None = None
 
     def describe(self) -> Mapping[str, object]:
         """Return a merged view of metadata and payload references."""
 
-        data: Dict[str, object] = dict(self.metadata)
+        data: dict[str, object] = dict(self.metadata)
         if self.payload is not None:
             data.setdefault("payload", self.payload)
         return data
@@ -46,14 +46,14 @@ class AstroChannel:
 
     name: str
     metadata: MutableMapping[str, object] = field(default_factory=dict)
-    subchannels: Dict[str, AstroSubchannel] = field(default_factory=dict)
+    subchannels: dict[str, AstroSubchannel] = field(default_factory=dict)
 
     def register_subchannel(
         self,
         name: str,
         *,
-        metadata: Optional[Mapping[str, object]] = None,
-        payload: Optional[Mapping[str, object]] = None,
+        metadata: Mapping[str, object] | None = None,
+        payload: Mapping[str, object] | None = None,
     ) -> AstroSubchannel:
         if name in self.subchannels:
             sub = self.subchannels[name]
@@ -79,13 +79,13 @@ class AstroSubmodule:
 
     name: str
     metadata: MutableMapping[str, object] = field(default_factory=dict)
-    channels: Dict[str, AstroChannel] = field(default_factory=dict)
+    channels: dict[str, AstroChannel] = field(default_factory=dict)
 
     def register_channel(
         self,
         name: str,
         *,
-        metadata: Optional[Mapping[str, object]] = None,
+        metadata: Mapping[str, object] | None = None,
     ) -> AstroChannel:
         if name in self.channels:
             channel = self.channels[name]
@@ -109,13 +109,13 @@ class AstroModule:
 
     name: str
     metadata: MutableMapping[str, object] = field(default_factory=dict)
-    submodules: Dict[str, AstroSubmodule] = field(default_factory=dict)
+    submodules: dict[str, AstroSubmodule] = field(default_factory=dict)
 
     def register_submodule(
         self,
         name: str,
         *,
-        metadata: Optional[Mapping[str, object]] = None,
+        metadata: Mapping[str, object] | None = None,
     ) -> AstroSubmodule:
         if name in self.submodules:
             submodule = self.submodules[name]
@@ -137,13 +137,13 @@ class AstroRegistry:
     """Mutable registry mapping module names to :class:`AstroModule` objects."""
 
     def __init__(self) -> None:
-        self._modules: Dict[str, AstroModule] = {}
+        self._modules: dict[str, AstroModule] = {}
 
     def register_module(
         self,
         name: str,
         *,
-        metadata: Optional[Mapping[str, object]] = None,
+        metadata: Mapping[str, object] | None = None,
     ) -> AstroModule:
         if name in self._modules:
             module = self._modules[name]
@@ -160,19 +160,19 @@ class AstroRegistry:
     def iter_modules(self) -> Iterable[AstroModule]:
         return self._modules.values()
 
-    def as_dict(self) -> Dict[str, Mapping[str, object]]:
+    def as_dict(self) -> dict[str, Mapping[str, object]]:
         """Return a serialisable snapshot of the registry hierarchy."""
 
-        snapshot: Dict[str, Mapping[str, object]] = {}
+        snapshot: dict[str, Mapping[str, object]] = {}
         for module_name, module in self._modules.items():
-            module_payload: Dict[str, object] = {"metadata": dict(module.metadata), "submodules": {}}
+            module_payload: dict[str, object] = {"metadata": dict(module.metadata), "submodules": {}}
             for submodule_name, submodule in module.submodules.items():
-                submodule_payload: Dict[str, object] = {
+                submodule_payload: dict[str, object] = {
                     "metadata": dict(submodule.metadata),
                     "channels": {},
                 }
                 for channel_name, channel in submodule.channels.items():
-                    channel_payload: Dict[str, object] = {
+                    channel_payload: dict[str, object] = {
                         "metadata": dict(channel.metadata),
                         "subchannels": {},
                     }

--- a/astroengine/modules/vca/__init__.py
+++ b/astroengine/modules/vca/__init__.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Dict
-
 from ..registry import AstroModule, AstroRegistry
 from .catalogs import (
     VCA_CENTAURS,
@@ -18,7 +16,7 @@ from .rulesets import VCA_RULESET
 __all__ = ["register_vca_module", "serialize_vca_ruleset"]
 
 
-def serialize_vca_ruleset() -> Dict[str, object]:
+def serialize_vca_ruleset() -> dict[str, object]:
     """Return a serialisable representation of the bundled VCA ruleset."""
 
     aspects = {

--- a/astroengine/modules/vca/profiles.py
+++ b/astroengine/modules/vca/profiles.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 
 @dataclass(frozen=True)

--- a/astroengine/modules/vca/rulesets.py
+++ b/astroengine/modules/vca/rulesets.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Dict, Mapping, Optional
 
 
 @dataclass(frozen=True)
@@ -14,7 +14,7 @@ class AspectDef:
     default_orb_deg: float
 
 
-_VCA_ASPECTS: Dict[str, AspectDef] = {
+_VCA_ASPECTS: dict[str, AspectDef] = {
     "conjunction": AspectDef("conjunction", 0.0, "major", 10.0),
     "opposition": AspectDef("opposition", 180.0, "major", 10.0),
     "square": AspectDef("square", 90.0, "major", 8.0),
@@ -69,11 +69,11 @@ VCA_RULESET = Ruleset(
 )
 
 
-def get_vca_aspect(name: str) -> Optional[AspectDef]:
+def get_vca_aspect(name: str) -> AspectDef | None:
     return _VCA_ASPECTS.get(name.lower())
 
 
-def vca_orb_for(name: str, *, override: Optional[float] = None) -> float:
+def vca_orb_for(name: str, *, override: float | None = None) -> float:
     if override is not None:
         return float(override)
     aspect = get_vca_aspect(name)

--- a/astroengine/profiles.py
+++ b/astroengine/profiles.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .modules.vca.profiles import DomainScoringProfile, VCA_DOMAIN_PROFILES
+from .modules.vca.profiles import VCA_DOMAIN_PROFILES, DomainScoringProfile
 
 __all__ = ["DomainScoringProfile", "VCA_DOMAIN_PROFILES"]

--- a/astroengine/providers/__init__.py
+++ b/astroengine/providers/__init__.py
@@ -22,10 +22,11 @@ respecting the schema contracts enforced by the engine.
 """
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Mapping, Optional, Protocol, Sequence
+from typing import Protocol
 
 
 class ProviderError(RuntimeError):
@@ -78,7 +79,7 @@ class ProviderMetadata:
     supports_light_time: bool
     cache_layout: Mapping[str, str]
     extras_required: Sequence[str]
-    documentation_url: Optional[str] = None
+    documentation_url: str | None = None
 
 
 @dataclass(frozen=True)
@@ -113,7 +114,7 @@ class EphemerisProvider(Protocol):
 
     metadata: ProviderMetadata
 
-    def configure(self, *, profile_flags: Mapping[str, object], options: Optional[Mapping[str, object]] = None) -> None:
+    def configure(self, *, profile_flags: Mapping[str, object], options: Mapping[str, object] | None = None) -> None:
         """Apply profile-specific configuration.
 
         Implementations MUST be idempotent and only mutate internal caches.

--- a/astroengine/rulesets.py
+++ b/astroengine/rulesets.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from .modules.vca.rulesets import AspectDef, Ruleset, VCA_RULESET, get_vca_aspect, vca_orb_for
+from .modules.vca.rulesets import VCA_RULESET, AspectDef, Ruleset, get_vca_aspect, vca_orb_for
 
 __all__ = ["AspectDef", "Ruleset", "VCA_RULESET", "get_vca_aspect", "vca_orb_for"]

--- a/astroengine/validation/_simple_validator.py
+++ b/astroengine/validation/_simple_validator.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 
 import datetime as _dt
 import re
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Iterator, Tuple
+from typing import Any
 
 __all__ = ["SimpleValidationError", "SimpleValidator"]
 
@@ -20,7 +21,7 @@ __all__ = ["SimpleValidationError", "SimpleValidator"]
 class SimpleValidationError:
     """Represents a validation failure."""
 
-    path: Tuple[Any, ...]
+    path: tuple[Any, ...]
     message: str
 
     @property
@@ -37,7 +38,7 @@ class SimpleValidationError:
 class SimpleValidator:
     """Very small subset of JSON Schema validation."""
 
-    def __init__(self, schema: Dict[str, Any]):
+    def __init__(self, schema: dict[str, Any]):
         self._schema = schema
         self._defs = schema.get("$defs") or schema.get("definitions") or {}
 
@@ -48,7 +49,7 @@ class SimpleValidator:
     # Internal helpers
     # ------------------------------------------------------------------
     def _iter_errors(
-        self, schema: Dict[str, Any], value: Any, path: Tuple[Any, ...]
+        self, schema: dict[str, Any], value: Any, path: tuple[Any, ...]
     ) -> Iterable[SimpleValidationError]:
         if "$ref" in schema:
             target = self._resolve_ref(schema["$ref"], path)
@@ -159,7 +160,7 @@ class SimpleValidator:
     # ------------------------------------------------------------------
     # Utility helpers
     # ------------------------------------------------------------------
-    def _resolve_ref(self, ref: str, path: Tuple[Any, ...]) -> Dict[str, Any] | None:
+    def _resolve_ref(self, ref: str, path: tuple[Any, ...]) -> dict[str, Any] | None:
         if ref.startswith("#/$defs/"):
             key = ref.split("/")[-1]
             return self._defs.get(key)
@@ -186,7 +187,7 @@ class SimpleValidator:
 
 
 def _is_number(value: Any) -> bool:
-    return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, int | float) and not isinstance(value, bool)
 
 
 def _is_datetime(value: str) -> bool:

--- a/astroengine/validation/schema_loader.py
+++ b/astroengine/validation/schema_loader.py
@@ -7,8 +7,8 @@ be swapped without touching the schema contracts.
 
 from __future__ import annotations
 
-from functools import lru_cache
-from typing import Iterable, List
+from collections.abc import Iterable
+from functools import cache
 
 from astroengine.data.schemas import (
     SCHEMA_REGISTRY,
@@ -16,6 +16,7 @@ from astroengine.data.schemas import (
     list_schema_keys,
     load_schema_document,
 )
+
 from ._simple_validator import SimpleValidator
 
 __all__ = [
@@ -30,11 +31,11 @@ class SchemaValidationError(RuntimeError):
     """Raised when a payload fails schema validation."""
 
     def __init__(self, errors: Iterable[str]):
-        self.errors: List[str] = list(errors)
+        self.errors: list[str] = list(errors)
         super().__init__("; ".join(self.errors))
 
 
-@lru_cache(maxsize=None)
+@cache
 def get_validator(schema_key: str) -> SimpleValidator:
     """Return a cached validator instance for ``schema_key``."""
 
@@ -46,7 +47,7 @@ def get_validator(schema_key: str) -> SimpleValidator:
     return SimpleValidator(schema)
 
 
-def available_schema_keys(kind: str | None = None) -> List[str]:
+def available_schema_keys(kind: str | None = None) -> list[str]:
     """List schema keys known to the registry."""
 
     return sorted(list_schema_keys(kind))

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -41,3 +41,18 @@ pip install -e . --upgrade
 
 If you prefer a clean install, remove the ``.venv`` directory and repeat
 steps 1–3.
+
+## 5) Rebuilding the environment
+
+The package ships with a helper that removes the virtual environment, recreates
+it, and reinstalls AstroEngine.  It previews the steps by default:
+
+```bash
+python -m astroengine.infrastructure.rebuild
+python -m astroengine.infrastructure.rebuild --run
+```
+
+The first command only prints the plan.  Add ``--run`` to execute it.  Additional
+flags let you choose a different target directory, interpreter, or extras.  Run
+``python -m astroengine.infrastructure.rebuild --help`` for the complete
+reference.

--- a/tests/test_domain_scoring.py
+++ b/tests/test_domain_scoring.py
@@ -1,6 +1,5 @@
 from astroengine.scoring import compute_domain_factor
 
-
 MULTIPLIERS = {"MIND": 1.25, "BODY": 1.0, "SPIRIT": 1.0}
 
 

--- a/tests/test_domains.py
+++ b/tests/test_domains.py
@@ -1,4 +1,4 @@
-from astroengine.domains import DomainResolver, ZODIAC_ELEMENT_MAP
+from astroengine.domains import ZODIAC_ELEMENT_MAP, DomainResolver
 
 
 def test_elements_triplicity_mapping():

--- a/tests/test_environment_rebuild.py
+++ b/tests/test_environment_rebuild.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from astroengine.infrastructure import rebuild_virtualenv
+from astroengine.infrastructure.rebuild import build_rebuild_plan
+
+
+def _expected_pip_path(venv_path: Path) -> Path:
+    if os.name == "nt":
+        return venv_path / "Scripts" / "pip.exe"
+    return venv_path / "bin" / "pip"
+
+
+def test_build_rebuild_plan_includes_all_steps(tmp_path: Path) -> None:
+    venv_path = tmp_path / "existing"
+    venv_path.mkdir()
+
+    plan = build_rebuild_plan(
+        venv_path=venv_path,
+        python_executable="python3",
+        extras=["dev"],
+        upgrade_pip=True,
+    )
+
+    assert plan[0].description.startswith("Remove existing environment")
+    assert plan[0].command is None
+    assert plan[1].command == ("python3", "-m", "venv", str(venv_path))
+
+    pip_path = str(_expected_pip_path(venv_path))
+    assert plan[2].command == (pip_path, "install", "--upgrade", "pip")
+    assert plan[3].command == (pip_path, "install", "--upgrade", "-e", ".[dev]")
+
+
+def test_rebuild_virtualenv_dry_run(tmp_path: Path) -> None:
+    venv_path = tmp_path / "preview"
+
+    plan = rebuild_virtualenv(
+        venv_path=venv_path,
+        python_executable="python3",
+        extras=["dev", "docs"],
+        dry_run=True,
+    )
+
+    assert not venv_path.exists(), "dry run should not create the environment"
+    assert plan[-1].command[-1] == ".[dev,docs]"
+
+
+def test_rebuild_virtualenv_executes_commands(tmp_path: Path) -> None:
+    venv_path = tmp_path / "actual"
+    recorded: list[tuple[str, ...]] = []
+
+    def runner(cmd: tuple[str, ...]) -> None:
+        recorded.append(tuple(cmd))
+
+    plan = rebuild_virtualenv(
+        venv_path=venv_path,
+        python_executable="python3",
+        extras=["dev"],
+        dry_run=False,
+        runner=runner,
+    )
+
+    assert [step.command for step in plan if step.command] == recorded
+    assert len(recorded) == 3
+    assert recorded[0][0] == "python3"
+


### PR DESCRIPTION
## Summary
- add a rebuild utility that plans and optionally executes recreating the AstroEngine virtual environment
- expose the helper through the public infrastructure package and document how to use it
- cover the planning and execution pathways with new unit tests

## Testing
- `pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68cd4ce2a2d883249f7e886ab3b74209