### PR TITLE
feat: add git access helpers

### DIFF
--- a/.github/workflows/swe-smoketest.yml
+++ b/.github/workflows/swe-smoketest.yml
@@ -1,0 +1,27 @@
+# >>> AUTO-GEN BEGIN: CI Swiss Ephemeris Smoketest v1.0
+name: swe-smoketest
+on:
+  push:
+  pull_request:
+
+jobs:
+  smoketest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Python deps
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+      - name: Install Swiss Ephemeris data (apt)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y swe-data
+          echo "SE_EPHE_PATH=/usr/share/sweph" >> $GITHUB_ENV
+      - name: Run smoketest script
+        run: |
+          python scripts/swe_smoketest.py --utc "2025-09-19T18:10:00Z"
+# >>> AUTO-GEN END: CI Swiss Ephemeris Smoketest v1.0

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,18 @@
+# ENSURE-LINE
+.venv/
+# ENSURE-LINE
+.env
+# ENSURE-LINE
+/__pycache__/
+# ENSURE-LINE
+*.pyc
+# ENSURE-LINE
+/AstroEngine
+
 __pycache__/
 *.py[cod]
 *.egg-info/
-.venv/
 venv/
-.env
 .ipynb_checkpoints/
 .cache/
 dist/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AstroEngine Contribution Guide
+
+## Scope
+These instructions apply to the entire repository unless a more specific `AGENTS.md` is added deeper in the tree.
+
+## Architectural Expectations
+- Preserve the module → submodule → channel → subchannel organization already established under `astroengine/`. Introduce new capabilities by extending this hierarchy instead of replacing or removing existing modules unless explicitly requested by the user.
+- When touching data-backed workflows (CSV, SQLite, or other data stores), ensure every produced value is derived from real sources available to the project. Never substitute placeholder or synthetic astrology results.
+- Keep smoketests and diagnostics deterministic; if you modify a script that emits ephemeris or chart data, ensure it documents the provenance of the data it reports.
+
+## Coding Style
+- Prefer readable, well-documented Python. Follow existing naming patterns in the touched module; avoid introducing broad formatting changes unrelated to the task.
+- Place shared utilities inside the relevant module hierarchy rather than at the project root, and accompany substantive features with docstrings or inline comments summarizing their intent.
+
+## Testing & Verification
+- Run `pytest` after any change that could affect Python code or dependencies. Include the command and its status in the testing section of the final response.
+- If you touch automation under `.github/` or scripts under `scripts/`, exercise the most relevant command (for example, invoking a smoketest) when practical and document the result.
+
+## Documentation
+- Update `README.md`, `docs/`, or module-specific documentation whenever behavior, inputs, or outputs change in a way users should know about.
+- Keep instructions for obtaining external datasets (e.g., Swiss Ephemeris files) accurate and reproducible.
+
+## Git & PR Hygiene
+- Keep the working tree clean before finishing. Do not rewrite existing commits; add new ones as needed.
+- Reference this guide when clarifying contribution expectations in discussions or reviews.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,31 @@ pip install -e .[dev]
 python -m astroengine.infrastructure.environment numpy pandas scipy
 ```
 
+````
+# >>> AUTO-GEN BEGIN: Ephemeris Smoketest How-To v1.0
+## Swiss Ephemeris smoketest (local)
+
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip && pip install -r requirements.txt
+
+# Install Swiss data (either apt or manual files)
+# Ubuntu/Debian:
+sudo apt-get update && sudo apt-get install -y swe-data
+export SE_EPHE_PATH=/usr/share/sweph
+
+# Or manual files into ~/.sweph and set SE_EPHE_PATH accordingly
+# mkdir -p ~/.sweph && (download sepl_18.se1, semo_18.se1, seas_18.se1, seleapsec.txt, sefstars.txt)
+# export SE_EPHE_PATH=~/.sweph
+
+python scripts/swe_smoketest.py --utc "2025-09-19T18:10:00Z"
+```
+
+The CI workflow `.github/workflows/swe-smoketest.yml` runs the same on every push/PR.
+
+# >>> AUTO-GEN END: Ephemeris Smoketest How-To v1.0
+````
+
 The package exposes a registry-based API for discovering datasets and
 rulesets.  See `astroengine/modules` for details.
 
@@ -56,6 +81,15 @@ instead of cloning the entire document into a new append-only record.
 The default registry can be inspected by importing
 `astroengine.DEFAULT_REGISTRY` or calling
 `astroengine.bootstrap_default_registry()`.
+
+### Automating Git operations
+
+`astroengine.infrastructure` now exposes lightweight helpers for
+repositories that require SSH deploy keys.  Use
+`GitRepository.clone(..., auth=GitAuth(key_path=...))` to clone, commit,
+and push while the helper manages ``GIT_SSH_COMMAND`` for you.  The API
+avoids third-party wrappers and operates on real files inside the
+working tree so downstream automation stays deterministic.
 
 ---
 

--- a/astroengine/infrastructure/__init__.py
+++ b/astroengine/infrastructure/__init__.py
@@ -1,8 +1,15 @@
-"""Infrastructure helpers (environment diagnostics, etc.)."""
+"""Infrastructure helpers (environment diagnostics, git utilities, etc.)."""
 
 from __future__ import annotations
 
 from .environment import EnvironmentReport, collect_environment_report
 from .environment import main as environment_main
+from .git_access import GitAuth, GitRepository
 
-__all__ = ["EnvironmentReport", "collect_environment_report", "environment_main"]
+__all__ = [
+    "EnvironmentReport",
+    "collect_environment_report",
+    "environment_main",
+    "GitAuth",
+    "GitRepository",
+]

--- a/astroengine/infrastructure/git_access.py
+++ b/astroengine/infrastructure/git_access.py
@@ -1,0 +1,209 @@
+"""Git repository helpers with SSH key support.
+
+This module keeps the implementation lightweight so the runtime can
+interact with Git repositories without pulling in heavy third-party
+wrappers.  The helper classes expose composable primitives:
+
+* :class:`GitAuth` constructs an ``ssh`` command that points to a
+  dedicated deploy key and optional ``known_hosts`` file.  The command is
+  injected via the ``GIT_SSH_COMMAND`` environment variable, mirroring
+  the approach recommended in Git's own documentation.
+* :class:`GitRepository` executes Git commands in a working tree and
+  provides convenience methods for common read/write flows (clone,
+  commit, push, file reads/writes).
+
+All filesystem interactions operate on real files inside the working
+tree to satisfy the repository's integrity requirements—no synthetic
+outputs are generated.
+"""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, MutableMapping
+
+__all__ = ["GitAuth", "GitRepository"]
+
+
+@dataclass(frozen=True)
+class GitAuth:
+    """SSH configuration for authenticating Git commands.
+
+    Parameters
+    ----------
+    key_path:
+        Filesystem path to the private key used for Git operations.
+    known_hosts_path:
+        Optional override for the ``known_hosts`` file.
+    strict_host_key_checking:
+        When ``True`` (default) the ``ssh`` command enforces host key
+        verification.  When ``False`` it switches to ``accept-new`` so
+        first-time connections do not require manual confirmation.
+    extra_ssh_options:
+        Additional ``-o`` options passed verbatim to ``ssh``.
+    """
+
+    key_path: Path
+    known_hosts_path: Path | None = None
+    strict_host_key_checking: bool = True
+    extra_ssh_options: tuple[str, ...] = ()
+
+    def build_ssh_command(self) -> str:
+        """Return the fully quoted ``ssh`` command."""
+
+        key_path = Path(self.key_path)
+        parts: list[str] = ["ssh", "-i", str(key_path), "-o", "IdentitiesOnly=yes"]
+
+        # Host key policy keeps operations deterministic.  ``accept-new``
+        # is only enabled when explicitly requested.
+        policy = "yes" if self.strict_host_key_checking else "accept-new"
+        parts.extend(["-o", f"StrictHostKeyChecking={policy}"])
+
+        if self.known_hosts_path is not None:
+            parts.extend(["-o", f"UserKnownHostsFile={self.known_hosts_path}"])
+
+        for option in self.extra_ssh_options:
+            parts.extend(["-o", option])
+
+        return shlex.join(parts)
+
+    def apply(self, env: Mapping[str, str] | None = None) -> MutableMapping[str, str]:
+        """Return ``env`` extended with ``GIT_SSH_COMMAND``."""
+
+        merged: dict[str, str] = dict(os.environ if env is None else env)
+        merged["GIT_SSH_COMMAND"] = self.build_ssh_command()
+        return merged
+
+
+@dataclass
+class GitRepository:
+    """Lightweight wrapper around a Git working tree."""
+
+    path: Path
+    auth: GitAuth | None = None
+
+    def __post_init__(self) -> None:
+        self.path = Path(self.path)
+
+    # ------------------------------------------------------------------
+    # Command execution helpers
+    # ------------------------------------------------------------------
+    def _command_env(self) -> MutableMapping[str, str] | None:
+        return self.auth.apply() if self.auth else None
+
+    def run_git(self, *args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+        """Execute ``git`` with ``args`` inside the repository."""
+
+        cmd = ["git", *args]
+        return subprocess.run(
+            cmd,
+            cwd=self.path,
+            env=self._command_env(),
+            capture_output=capture_output,
+            text=True,
+            check=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Repository lifecycle helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def clone(
+        cls,
+        remote: str | os.PathLike[str],
+        target: str | os.PathLike[str],
+        *,
+        auth: GitAuth | None = None,
+        branch: str | None = None,
+    ) -> "GitRepository":
+        """Clone ``remote`` into ``target`` and return the repository wrapper."""
+
+        target_path = Path(target)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+
+        cmd: list[str] = ["git", "clone"]
+        if branch is not None:
+            cmd.extend(["--branch", branch])
+        cmd.extend([str(remote), str(target_path)])
+
+        subprocess.run(
+            cmd,
+            env=auth.apply() if auth else None,
+            check=True,
+            text=True,
+        )
+        return cls(target_path, auth=auth)
+
+    def fetch(self, remote: str = "origin", *refs: str) -> None:
+        args = ["fetch", remote]
+        if refs:
+            args.extend(refs)
+        self.run_git(*args)
+
+    def pull(self, remote: str = "origin", branch: str | None = None) -> None:
+        args = ["pull", remote]
+        if branch is not None:
+            args.append(branch)
+        self.run_git(*args)
+
+    def push(self, remote: str = "origin", refspec: str | None = None) -> None:
+        args = ["push", remote]
+        if refspec is not None:
+            args.append(refspec)
+        self.run_git(*args)
+
+    # ------------------------------------------------------------------
+    # Commit utilities
+    # ------------------------------------------------------------------
+    def commit(self, message: str, *, allow_empty: bool = False) -> None:
+        args = ["commit", "-m", message]
+        if allow_empty:
+            args.insert(1, "--allow-empty")
+        self.run_git(*args)
+
+    def status(self) -> str:
+        result = self.run_git("status", "--short", capture_output=True)
+        return result.stdout
+
+    def current_branch(self) -> str:
+        result = self.run_git("rev-parse", "--abbrev-ref", "HEAD", capture_output=True)
+        return result.stdout.strip()
+
+    # ------------------------------------------------------------------
+    # File convenience methods
+    # ------------------------------------------------------------------
+    def read_text(self, relative_path: str | os.PathLike[str], *, encoding: str = "utf-8") -> str:
+        return (self.path / Path(relative_path)).read_text(encoding=encoding)
+
+    def write_text(
+        self,
+        relative_path: str | os.PathLike[str],
+        content: str,
+        *,
+        encoding: str = "utf-8",
+    ) -> Path:
+        path = self.path / Path(relative_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding=encoding)
+        return path
+
+    def add(self, *paths: str | os.PathLike[str]) -> None:
+        args = ["add", *map(str, paths)]
+        self.run_git(*args)
+
+    # ------------------------------------------------------------------
+    # Misc helpers
+    # ------------------------------------------------------------------
+    def ensure_remote(self, name: str, url: str | os.PathLike[str]) -> None:
+        """Create or update a remote configuration entry."""
+
+        try:
+            # Prefer ``set-url`` to avoid duplicate remotes when updating.
+            self.run_git("remote", "set-url", name, str(url))
+        except subprocess.CalledProcessError:
+            self.run_git("remote", "add", name, str(url))
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+# >>> AUTO-GEN BEGIN: Dev Requirements v1.0
+pyswisseph>=2.10.3
+numpy>=1.26
+python-dateutil
+pytz
+click
+rich
+pytest
+# >>> AUTO-GEN END: Dev Requirements v1.0

--- a/scripts/swe_smoketest.py
+++ b/scripts/swe_smoketest.py
@@ -1,0 +1,147 @@
+# >>> AUTO-GEN BEGIN: Swiss Ephemeris Smoketest v1.0
+#!/usr/bin/env python
+"""
+Swiss Ephemeris smoketest:
+- Prints positions for Sun..Pluto + Node + Chiron
+- Lists major aspect hits (0/60/90/120/180) within default orbs
+- Finds ephemeris via SE_EPHE_PATH or common system dirs
+"""
+import os
+import argparse
+import datetime as dt
+import itertools
+import swisseph as swe
+
+SIGNS = [
+    "Aries",
+    "Taurus",
+    "Gemini",
+    "Cancer",
+    "Leo",
+    "Virgo",
+    "Libra",
+    "Scorpio",
+    "Sagittarius",
+    "Capricorn",
+    "Aquarius",
+    "Pisces",
+]
+
+BODIES = [
+    ("Sun", swe.SUN),
+    ("Moon", swe.MOON),
+    ("Mercury", swe.MERCURY),
+    ("Venus", swe.VENUS),
+    ("Mars", swe.MARS),
+    ("Jupiter", swe.JUPITER),
+    ("Saturn", swe.SATURN),
+    ("Uranus", swe.URANUS),
+    ("Neptune", swe.NEPTUNE),
+    ("Pluto", swe.PLUTO),
+    ("Node", swe.MEAN_NODE),  # use swe.TRUE_NODE if preferred
+    ("Chiron", swe.CHIRON),
+]
+
+MAJORS = [0, 60, 90, 120, 180]
+
+# --- ephemeris path detection ---
+ephe = os.environ.get("SE_EPHE_PATH")
+if not ephe:
+    for p in ("/usr/share/sweph", "/usr/share/libswisseph", os.path.expanduser("~/.sweph")):
+        if os.path.isdir(p):
+            ephe = p
+            break
+if ephe:
+    swe.set_ephe_path(ephe)
+
+def jd_from_iso(s: str) -> float:
+    s = s.replace("Z", "+00:00")
+    t = dt.datetime.fromisoformat(s)
+    if t.tzinfo is None:
+        t = t.replace(tzinfo=dt.timezone.utc)
+    else:
+        t = t.astimezone(dt.timezone.utc)
+    hour = t.hour + t.minute / 60 + t.second / 3600 + t.microsecond / 3.6e9
+    return swe.julday(t.year, t.month, t.day, hour)
+
+def calc_lon_deg(jd: float, body: int) -> float:
+    try:
+        xx, _ = swe.calc_ut(jd, body, swe.FLG_SWIEPH)
+    except Exception:
+        xx, _ = swe.calc_ut(jd, body, swe.FLG_MOSEPH)  # may not cover Node/Chiron
+    return xx[0]  # longitude degrees
+
+def fmt_lon(lon: float) -> str:
+    lon %= 360.0
+    s = int(lon // 30)
+    d = int(lon % 30)
+    m = int((lon - (s * 30 + d)) * 60)
+    return f"{SIGNS[s]} {d:02d}°{m:02d}′"
+
+def circ_delta(a: float, b: float) -> float:
+    return abs((a - b + 180.0) % 360.0 - 180.0)
+
+def nearest_major_aspect(sep: float):
+    best = min(((circ_delta(sep, a), a) for a in MAJORS), key=lambda x: x[0])
+    return best[1], best[0]
+
+def orb_policy(a: str, b: str, angle: int) -> float:
+    def bucket(n):
+        if n in ("Sun", "Moon"):
+            return 8.0
+        if n in ("Mercury", "Venus", "Mars"):
+            return 6.0
+        if n in ("Jupiter", "Saturn"):
+            return 5.0
+        if n in ("Uranus", "Neptune", "Pluto"):
+            return 4.0
+        return 3.0  # Node/Chiron
+
+    return min(bucket(a), bucket(b))
+
+def main():
+    now_utc = dt.datetime.now(dt.timezone.utc).replace(microsecond=0)
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--utc",
+        default=now_utc.isoformat().replace("+00:00", "Z"),
+        help="UTC ISO-8601 (default: now)",
+    )
+    args = ap.parse_args()
+    jd = jd_from_iso(args.utc)
+
+    positions, skipped = {}, []
+    for name, code in BODIES:
+        try:
+            positions[name] = calc_lon_deg(jd, code)
+        except Exception as e:
+            skipped.append((name, str(e)))
+
+    print("UTC:", args.utc)
+    for name in positions:
+        print(f"{name:7s} {fmt_lon(positions[name])}")
+
+    if skipped:
+        print("\nSkipped (no ephemeris available):")
+        for name, msg in skipped:
+            print(f" - {name}: {msg.splitlines()[-1]}")
+
+    print("\nMajor aspect hits (<= orb policy):")
+    hits = []
+    keys = list(positions.keys())
+    for i in range(len(keys)):
+        for j in range(i + 1, len(keys)):
+            a, b = keys[i], keys[j]
+            sep = (positions[b] - positions[a]) % 360.0
+            ang, orb = nearest_major_aspect(sep)
+            if orb <= orb_policy(a, b, ang):
+                hits.append((orb, f"{a:7s} — {b:7s}  {ang:>3}°  orb {orb:>4.2f}°"))
+    if hits:
+        for _, line in sorted(hits):
+            print(line)
+    else:
+        print("(none within default orbs)")
+
+if __name__ == "__main__":
+    main()
+# >>> AUTO-GEN END: Swiss Ephemeris Smoketest v1.0

--- a/tests/test_git_access.py
+++ b/tests/test_git_access.py
@@ -1,0 +1,66 @@
+"""Tests for the lightweight Git access helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from astroengine.infrastructure import GitAuth, GitRepository
+
+
+def test_git_auth_builds_command(tmp_path: Path) -> None:
+    key_path = tmp_path / "id_ed25519"
+    key_path.write_text("dummy-key")
+    known_hosts = tmp_path / "known_hosts"
+    known_hosts.write_text("example.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAA")
+
+    auth = GitAuth(key_path=key_path, known_hosts_path=known_hosts)
+
+    command = auth.build_ssh_command()
+
+    assert "ssh" in command
+    assert str(key_path) in command
+    assert str(known_hosts) in command
+
+    env = auth.apply({})
+    assert env["GIT_SSH_COMMAND"] == command
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_git_auth_strict_policy(strict: bool, tmp_path: Path) -> None:
+    key_path = tmp_path / "id_ed25519"
+    key_path.write_text("dummy-key")
+
+    auth = GitAuth(key_path=key_path, strict_host_key_checking=strict)
+    command = auth.build_ssh_command()
+
+    assert (
+        ("StrictHostKeyChecking=yes" in command)
+        if strict
+        else ("StrictHostKeyChecking=accept-new" in command)
+    )
+
+
+def test_git_repository_clone_commit_push(tmp_path: Path) -> None:
+    remote_dir = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--bare", str(remote_dir)], check=True)
+
+    clone_dir = tmp_path / "clone"
+    repo = GitRepository.clone(remote_dir, clone_dir)
+
+    repo.run_git("config", "user.name", "AstroEngine Test")
+    repo.run_git("config", "user.email", "test@example.com")
+
+    repo.write_text("README.md", "hello from astroengine\n")
+    repo.add("README.md")
+    repo.commit("Add README")
+
+    # Push to the bare remote and verify the contents by cloning again.
+    repo.push()
+
+    second_dir = tmp_path / "second"
+    repo2 = GitRepository.clone(remote_dir, second_dir)
+
+    assert repo2.read_text("README.md") == "hello from astroengine\n"

--- a/tests/test_swe_import.py
+++ b/tests/test_swe_import.py
@@ -1,0 +1,9 @@
+# >>> AUTO-GEN BEGIN: Test Swiss Ephemeris Import v1.0
+
+import swisseph as swe
+
+
+def test_pyswisseph_imports():
+    assert hasattr(swe, "SUN") and hasattr(swe, "calc_ut")
+
+# >>> AUTO-GEN END: Test Swiss Ephemeris Import v1.0


### PR DESCRIPTION
## Summary
- add a Swiss Ephemeris smoketest script with automatic ephemeris discovery and aspect reporting
- configure GitHub Actions to install Swiss Ephemeris data and exercise the smoketest on pushes and PRs
- document the local smoketest workflow, add required dependencies, and cover pyswisseph importability in tests
- add a repository-wide AGENTS guide describing contribution expectations and required checks
- expose Git access helpers wired for deploy-key authentication and document their usage in the README

## Testing
- pip install -r requirements.txt
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd9f2a0d2483249f0d08f9d884120a