### PR TITLE
infra: deps (core+optional), dev tooling, docs, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+# >>> AUTO-GEN BEGIN: CI Lint & Test v1.0
+name: ci
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt -r dev-requirements.txt
+      - name: Install optional deps (non-fatal)
+        continue-on-error: true
+        run: |
+          pip install -r requirements-optional.txt
+      - name: Install Swiss data
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y swe-data
+          echo "SE_EPHE_PATH=/usr/share/sweph" >> $GITHUB_ENV
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+          isort --check-only .
+          mypy .
+      - name: Tests
+        run: pytest -q
+# >>> AUTO-GEN END: CI Lint & Test v1.0

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ venv/
 dist/
 build/
 .pytest_cache/
+/pycache/
+*.pyc
+/site/
+.mypy_cache/
+/.ruff_cache/
+/.pytest_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,21 @@
+# >>> AUTO-GEN BEGIN: Pre-commit Hooks v1.0
 repos:
-  - repo: https://github.com/psf/black
-    rev: 24.3.0
-    hooks:
-      - id: black
-        language_version: python3
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.6.9
     hooks:
       - id: ruff
-        args: ["--fix"]
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+      - id: ruff-format
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
     hooks:
-      - id: end-of-file-fixer
-      - id: trailing-whitespace
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        additional_dependencies: ["pydantic>=2"]
+# >>> AUTO-GEN END: Pre-commit Hooks v1.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,12 @@
+# >>> AUTO-GEN BEGIN: Dev & Docs Requirements v1.0
+pytest
+pytest-cov
+hypothesis
+ruff
+black
+isort
+mypy
+pre-commit
+mkdocs-material
+mkdocs-gen-files
+# >>> AUTO-GEN END: Dev & Docs Requirements v1.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# >>> AUTO-GEN BEGIN: Docs Index v1.0
+# AstroEngine
+A modular, research-grade transit engine with VCA scoring and cross-tradition coverage.
+# >>> AUTO-GEN END: Docs Index v1.0

--- a/docs/repos.md
+++ b/docs/repos.md
@@ -1,0 +1,34 @@
+>>> AUTO-GEN BEGIN: Docs Repos Plan v1.0
+
+Companion Repos (create when ready)
+
+1) astroengine-data (public)
+
+Canonical catalogs loaded at runtime.
+
+modules/
+  bodies.yml           # ids, categories, default orbs
+  aspects.yml          # angles, canonical names
+  dignities.yml        # rulership/exaltation/detriment/fall
+  ayanamsa.yml         # named presets
+fixed_stars.csv        # name, RA, Dec, mag, spectral
+correspondences/       # VCA ↔ Tarot/Kabbalah/Chakras mappings
+
+Notes: do not commit Swiss ephemeris binaries. Engine reads from SE_EPHE_PATH.
+
+2) astroengine-profiles (public)
+
+Profiles for orb policy, severity weights, VCA domain weights, versioned.
+
+3) astroengine-docs (public)
+
+Docs site (MkDocs Material). Optionally mirror docs/ here and publish via Pages.
+
+Optional soon
+
+astroengine-examples (CLI/Jupyter demos)
+
+astroengine-registry (JSON index of plugins with semver)
+
+
+>>> AUTO-GEN END: Docs Repos Plan v1.0

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,21 @@
+# >>> AUTO-GEN BEGIN: Docs Setup v1.0
+## Local Setup
+```bash
+python3 -m venv .venv && source .venv/bin/activate
+python -m pip install -U pip
+pip install -r requirements.txt -r dev-requirements.txt
+# Optional features:
+pip install -r requirements-optional.txt
+
+# Swiss Ephemeris data (Ubuntu/Debian):
+sudo apt-get update && sudo apt-get install -y swe-data
+export SE_EPHE_PATH=/usr/share/sweph
+
+Dev Hygiene
+
+pre-commit install
+ruff check .
+pytest -q
+```
+
+>>> AUTO-GEN END: Docs Setup v1.0

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,9 @@
+# >>> AUTO-GEN BEGIN: MkDocs Config v1.0
+site_name: AstroEngine Docs
+theme:
+  name: material
+nav:
+  - Home: index.md
+  - Setup: setup.md
+  - Repos: repos.md
+# >>> AUTO-GEN END: MkDocs Config v1.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,0 +1,15 @@
+# >>> AUTO-GEN BEGIN: Optional Runtime Requirements v1.0
+# Optional providers / services
+skyfield
+# Web API (when you expose a service)
+fastapi
+uvicorn
+# Narrative templating
+jinja2
+# Performance experiments
+numba
+# Calendar export
+ics
+# DataFrame convenience (only if you plan to use pandas)
+pandas
+# >>> AUTO-GEN END: Optional Runtime Requirements v1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# >>> AUTO-GEN BEGIN: Core Runtime Requirements v1.0
+# Core runtime (engine + CLI + export)
+pyswisseph
+numpy
+pydantic>=2
+python-dateutil
+timezonefinder
+tzdata
+pyyaml
+click
+rich
+orjson
+pyarrow
+duckdb
+# >>> AUTO-GEN END: Core Runtime Requirements v1.0


### PR DESCRIPTION
## Summary
- add core, optional, and development requirements files for the AstroEngine runtime
- configure pre-commit hooks and GitHub Actions CI for linting, typing, and tests
- bootstrap MkDocs site with landing, setup, and repo-planning guides, ensuring the setup shell snippet closes its code fence for proper rendering

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cda358d9188324b4444f99fbc7b2a9