### PR TITLE
Add aspect detection, scoring, and domain reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ python -m astroengine provider check swiss
 
 # >>> AUTO-GEN END: AE README Providers Addendum v1.2
 
+# >>> AUTO-GEN BEGIN: AE README Aspects + Domain Report v1.0
+### Enable minor aspects (optional)
+Edit `profiles/aspects_policy.json` and add to `enabled_minors`, then:
+```bash
+python -m astroengine scan --start 2024-06-01T00:00:00Z --end 2024-06-07T00:00:00Z \
+  --moving mars --target venus --provider swiss
+````
+
+### Domain report
+
+```bash
+python -m astroengine report \
+  --start 2024-06-01T00:00:00Z \
+  --end   2024-06-07T00:00:00Z \
+  --moving mars --target venus \
+  --provider swiss --decl-orb 0.5 --mirror-orb 2.0 --step 60 \
+  --out domain_report.json
+```
+
+This prints and writes a JSON with domain/channel/subchannel scores and totals.
+
+# >>> AUTO-GEN END: AE README Aspects + Domain Report v1.0
+
 
 ---
 

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -11,6 +11,7 @@ from .utils.angles import delta_angle  # ENSURE-LINE
 from .utils.angles import classify_applying_separating  # ENSURE-LINE
 from .exporters import TransitEvent  # ENSURE-LINE
 from .exporters import SQLiteExporter, ParquetExporter  # ENSURE-LINE
+from .domains import rollup_domain_scores  # ENSURE-LINE
 
 from .catalogs import (
     VCA_CENTAURS,
@@ -23,6 +24,15 @@ from .catalogs import sbdb  # ENSURE-LINE
 from .fixedstars import skyfield_stars  # ENSURE-LINE
 from .astro import declination  # ENSURE-LINE
 
+from .ephemeris import (
+    EphemerisAdapter,
+    EphemerisConfig,
+    EphemerisSample,
+    RefinementBracket,
+    RefinementError,
+    refine_event,
+)
+from .ephemeris import SwissEphemerisAdapter
 from .core import (
     DOMAINS,
     ELEMENTS,
@@ -45,15 +55,6 @@ from .core import (
     profile_into_ctx,
     to_tt,
 )
-from .ephemeris import (
-    EphemerisAdapter,
-    EphemerisConfig,
-    EphemerisSample,
-    RefinementBracket,
-    RefinementError,
-    refine_event,
-)
-from .ephemeris import SwissEphemerisAdapter
 from .infrastructure.environment import collect_environment_report
 from .infrastructure.environment import main as environment_report_main
 from .modules import (
@@ -100,6 +101,7 @@ __all__ = [
     "DomainScoringProfile",
     "VCA_DOMAIN_PROFILES",
     "compute_domain_factor",
+    "rollup_domain_scores",
     "load_profile_json",
     "profile_into_ctx",
     "apply_profile_if_any",

--- a/astroengine/__main__.py
+++ b/astroengine/__main__.py
@@ -1,1 +1,8 @@
+"""Module entry point for `python -m astroengine` delegating to the CLI."""
 
+from __future__ import annotations
+
+from .cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/astroengine/astro/declination.py
+++ b/astroengine/astro/declination.py
@@ -1,1 +1,41 @@
+"""Declination and antiscia helpers used by detectors."""
 
+from __future__ import annotations
+
+import math
+
+__all__ = [
+    "OBLIQUITY_DEG",
+    "ecl_to_dec",
+    "is_parallel",
+    "is_contraparallel",
+    "antiscia_lon",
+    "contra_antiscia_lon",
+]
+
+OBLIQUITY_DEG = 23.4367  # mean obliquity of the ecliptic (approx J2000)
+OBLIQUITY_RAD = math.radians(OBLIQUITY_DEG)
+
+
+def ecl_to_dec(lon_deg: float) -> float:
+    """Convert ecliptic longitude (λ) at latitude=0° into declination (δ)."""
+
+    lon_rad = math.radians(lon_deg % 360.0)
+    sin_dec = math.sin(lon_rad) * math.sin(OBLIQUITY_RAD)
+    return math.degrees(math.asin(max(-1.0, min(1.0, sin_dec))))
+
+
+def is_parallel(dec1: float, dec2: float, orb: float) -> bool:
+    return abs(dec1 - dec2) <= abs(orb)
+
+
+def is_contraparallel(dec1: float, dec2: float, orb: float) -> bool:
+    return abs(dec1 + dec2) <= abs(orb)
+
+
+def antiscia_lon(lon_deg: float) -> float:
+    return (180.0 - lon_deg) % 360.0
+
+
+def contra_antiscia_lon(lon_deg: float) -> float:
+    return (360.0 - lon_deg) % 360.0

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1,10 +1,13 @@
-
+# >>> AUTO-GEN BEGIN: AE CLI v1.4
 from __future__ import annotations
 import sys
+import argparse
+import json
 
 from .providers import get_provider, list_providers
 from .engine import scan_contacts
 from .exporters import SQLiteExporter, ParquetExporter
+from .domains import rollup_domain_scores
 
 
 def cmd_env(args: argparse.Namespace) -> int:
@@ -18,4 +21,119 @@ def cmd_env(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_provider(args: argparse.Namespace) -> int:
+    if args.action == "list":
+        print("available:", ", ".join(list_providers()) or "(none)")
+        return 0
+    prov = get_provider(args.name)
+    out = prov.positions_ecliptic(args.iso, ["sun", "moon"])  # smoke
+    print(out)
+    return 0
 
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    events = scan_contacts(
+        start_iso=args.start,
+        end_iso=args.end,
+        moving=args.moving,
+        target=args.target,
+        provider_name=args.provider,
+        decl_parallel_orb=args.decl_orb,
+        decl_contra_orb=args.decl_orb,
+        antiscia_orb=args.mirror_orb,
+        contra_antiscia_orb=args.mirror_orb,
+        step_minutes=args.step,
+    )
+    for e in events:
+        print({"when": e.when_iso, "kind": e.kind, "pair": f"{e.moving}->{e.target}", "orb": round(e.orb_abs, 4), "phase": e.applying_or_separating, "score": round(e.score, 4)})
+    if args.sqlite:
+        SQLiteExporter(args.sqlite).write(events)
+    if args.parquet:
+        ParquetExporter(args.parquet).write(events)
+    return 0
+
+
+def cmd_report(args: argparse.Namespace) -> int:
+    events = scan_contacts(
+        start_iso=args.start,
+        end_iso=args.end,
+        moving=args.moving,
+        target=args.target,
+        provider_name=args.provider,
+        decl_parallel_orb=args.decl_orb,
+        decl_contra_orb=args.decl_orb,
+        antiscia_orb=args.mirror_orb,
+        contra_antiscia_orb=args.mirror_orb,
+        step_minutes=args.step,
+    )
+    scores = rollup_domain_scores(events)
+    out = {
+        d_id: {
+            "score": round(d.score, 6),
+            "channels": {
+                ch_id: {
+                    "score": round(ch.score, 6),
+                    "positive": round(ch.sub.get("positive").score, 6),
+                    "negative": round(ch.sub.get("negative").score, 6)
+                }
+                for ch_id, ch in d.channels.items()
+            }
+        }
+        for d_id, d in scores.items()
+    }
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as f:
+            json.dump(out, f, indent=2)
+    print(json.dumps(out, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(prog="astroengine", description="AstroEngine CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_env = sub.add_parser("env", help="Print environment diagnostics")
+    p_env.set_defaults(fn=cmd_env)
+
+    p_prov = sub.add_parser("provider", help="List/check providers")
+    p_prov.add_argument("action", choices=["list", "check"], default="list")
+    p_prov.add_argument("--name", default="swiss")
+    p_prov.add_argument("--iso", default="2024-06-01T00:00:00Z")
+    p_prov.set_defaults(fn=cmd_provider)
+
+    p_scan = sub.add_parser("scan", help="Scan window for contacts (with scores)")
+    p_scan.add_argument("--start", required=True)
+    p_scan.add_argument("--end", required=True)
+    p_scan.add_argument("--moving", default="mars")
+    p_scan.add_argument("--target", default="venus")
+    p_scan.add_argument("--provider", default="swiss", choices=["swiss", "skyfield"])
+    p_scan.add_argument("--decl-orb", type=float, default=0.5)
+    p_scan.add_argument("--mirror-orb", type=float, default=2.0)
+    p_scan.add_argument("--step", type=int, default=60)
+    p_scan.add_argument("--sqlite")
+    p_scan.add_argument("--parquet")
+    p_scan.set_defaults(fn=cmd_scan)
+
+    p_rep = sub.add_parser("report", help="Scan + roll up into Mind/Body/Spirit domain report")
+    p_rep.add_argument("--start", required=True)
+    p_rep.add_argument("--end", required=True)
+    p_rep.add_argument("--moving", default="mars")
+    p_rep.add_argument("--target", default="venus")
+    p_rep.add_argument("--provider", default="swiss", choices=["swiss", "skyfield"])
+    p_rep.add_argument("--decl-orb", type=float, default=0.5)
+    p_rep.add_argument("--mirror-orb", type=float, default=2.0)
+    p_rep.add_argument("--step", type=int, default=60)
+    p_rep.add_argument("--out", help="write JSON report to file")
+    p_rep.set_defaults(fn=cmd_report)
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    ns = ap.parse_args(argv if argv is not None else sys.argv[1:])
+    return int(ns.fn(ns))
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+# >>> AUTO-GEN END: AE CLI v1.4

--- a/astroengine/core/bodies.py
+++ b/astroengine/core/bodies.py
@@ -1,0 +1,36 @@
+"""Body classification helpers for scoring and orb policies."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+__all__ = ["body_class"]
+
+_BODY_CLASS_MAP = {
+    "sun": "luminary",
+    "moon": "luminary",
+    "mercury": "personal",
+    "venus": "personal",
+    "mars": "personal",
+    "jupiter": "social",
+    "saturn": "social",
+    "uranus": "outer",
+    "neptune": "outer",
+    "pluto": "outer",
+    "ceres": "outer",
+    "pallas": "outer",
+    "juno": "outer",
+    "vesta": "outer",
+    "chiron": "outer",
+    "north_node": "outer",
+    "south_node": "outer",
+}
+
+
+@lru_cache(maxsize=None)
+def body_class(name: str) -> str:
+    """Return the scoring class for the provided body name."""
+
+    if not name:
+        return "outer"
+    return _BODY_CLASS_MAP.get(name.lower(), "outer")

--- a/astroengine/detectors_aspects.py
+++ b/astroengine/detectors_aspects.py
@@ -1,0 +1,86 @@
+# >>> AUTO-GEN BEGIN: AE Longitudinal Aspect Detectors v1.0
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Tuple
+
+from .utils.angles import norm360, delta_angle, classify_applying_separating
+from .core.bodies import body_class
+import json
+from pathlib import Path
+
+
+@dataclass
+class AspectHit:
+    kind: str               # e.g., 'aspect_trine'
+    when_iso: str
+    moving: str
+    target: str
+    angle_deg: float        # exact aspect angle
+    lon_moving: float
+    lon_target: float
+    orb_abs: float
+    applying_or_separating: str
+
+
+_DEF_PATH = Path(__file__).resolve().parent.parent / "profiles" / "aspects_policy.json"
+
+
+def _load_policy(path: str | None = None) -> dict:
+    p = Path(path) if path else _DEF_PATH
+    raw = p.read_text().splitlines()
+    payload = "\n".join(line for line in raw if not line.strip().startswith("#"))
+    return json.loads(payload)
+
+
+def _aspect_name_for(angle: float, angles_map: Dict[str, float]) -> str:
+    for name, a in angles_map.items():
+        if abs(((a - angle + 180) % 360) - 180) < 1e-6:
+            return name
+    return f"angle_{angle:g}"
+
+
+def _orb_for(aspect_name: str, a_class: str, b_class: str, policy: dict) -> float:
+    orbs = policy["orbs_deg"][aspect_name]
+    return min(float(orbs.get(a_class, 2.0)), float(orbs.get(b_class, 2.0)))
+
+
+def detect_aspects(
+    provider,
+    iso_ticks: Iterable[str],
+    moving: str,
+    target: str,
+    *,
+    policy_path: str | None = None,
+) -> List[AspectHit]:
+    policy = _load_policy(policy_path)
+    enabled = set(policy.get("enabled", [])) | set(policy.get("enabled_minors", []))
+    angles_map: Dict[str, float] = {k: float(v) for k, v in policy["angles_deg"].items() if k in enabled}
+
+    out: List[AspectHit] = []
+    cls_m = body_class(moving)
+    cls_t = body_class(target)
+
+    for t in iso_ticks:
+        pos = provider.positions_ecliptic(t, [moving, target])
+        lm = pos[moving]["lon"]
+        lt = pos[target]["lon"]
+        spd = pos[moving].get("speed_lon", 0.0)
+        dmt = (lt - lm) % 360.0
+        for name, ang in angles_map.items():
+            target_point = (lt - ang) % 360.0
+            delta = delta_angle(dmt, ang)
+            orb_allow = _orb_for(name, cls_m, cls_t, policy)
+            if abs(delta) <= orb_allow:
+                out.append(AspectHit(
+                    kind=f"aspect_{name}",
+                    when_iso=t,
+                    moving=moving,
+                    target=target,
+                    angle_deg=float(ang),
+                    lon_moving=lm,
+                    lon_target=lt,
+                    orb_abs=abs(delta),
+                    applying_or_separating=classify_applying_separating(lm, spd, target_point),
+                ))
+    return out
+# >>> AUTO-GEN END: AE Longitudinal Aspect Detectors v1.0

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -1,6 +1,132 @@
-"""Compatibility layer for :mod:`astroengine.core.domains`."""
+"""Compatibility layer for :mod:`astroengine.core.domains` plus domain rollups."""
 
+# >>> AUTO-GEN BEGIN: AE Domain Scoring v1.0
 from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+import json
+from pathlib import Path
+
+
+@dataclass
+class SubchannelScore:
+    id: str
+    valence: str  # 'positive' | 'negative'
+    score: float = 0.0
+
+
+@dataclass
+class ChannelScore:
+    id: str
+    sub: Dict[str, SubchannelScore] = field(default_factory=dict)
+
+    @property
+    def score(self) -> float:
+        pos = self.sub.get("positive")
+        neg = self.sub.get("negative")
+        return (pos.score if pos else 0.0) - (neg.score if neg else 0.0)
+
+
+@dataclass
+class DomainScore:
+    id: str
+    channels: Dict[str, ChannelScore] = field(default_factory=dict)
+
+    @property
+    def score(self) -> float:
+        return sum(ch.score for ch in self.channels.values())
+
+
+# Load profiles
+_DEF_TREE = Path(__file__).resolve().parent.parent / "profiles" / "domain_tree.json"
+_DEF_MAP = Path(__file__).resolve().parent.parent / "profiles" / "domain_mapping.json"
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    raw = path.read_text().splitlines()
+    payload = "\n".join(line for line in raw if not line.strip().startswith("#"))
+    return json.loads(payload)
+
+
+def _make_empty_scores(tree: dict) -> Dict[str, DomainScore]:
+    out: Dict[str, DomainScore] = {}
+    for d in tree.get("domains", []):
+        dd = DomainScore(id=d["id"])
+        for ch in d.get("channels", []):
+            cc = ChannelScore(id=ch["id"])
+            for sub in ch.get("subchannels", []):
+                cc.sub[sub["id"]] = SubchannelScore(id=sub["id"], valence=sub.get("valence", "positive"))
+            dd.channels[cc.id] = cc
+        out[dd.id] = dd
+    return out
+
+
+def _valence_for(aspect_name: str, moving: str, mapping: dict) -> str:
+    v = mapping.get("aspect_valence", {}).get(aspect_name, "neutral")
+    if v == "neutral" and aspect_name == "conjunction":
+        ov = mapping.get("conjunction_valence_overrides", {})
+        return ov.get(moving.lower(), "neutral")
+    return v
+
+
+def _channel_weights_for(planet: str, mapping: dict) -> Dict[str, float]:
+    return {k: float(v) for k, v in mapping.get("planet_channels", {}).get(planet.lower(), {}).items()}
+
+
+@dataclass
+class EventLike:
+    kind: str          # e.g., 'aspect_trine', 'decl_parallel', 'antiscia'
+    when_iso: str
+    moving: str
+    target: str
+    orb_abs: float
+    applying_or_separating: str
+    score: float
+
+
+def rollup_domain_scores(events: List[EventLike], *, tree_path: str | None = None, mapping_path: str | None = None) -> Dict[str, DomainScore]:
+    tree = _load_json(Path(tree_path) if tree_path else _DEF_TREE)
+    mapping = _load_json(Path(mapping_path) if mapping_path else _DEF_MAP)
+    scores = _make_empty_scores(tree)
+
+    for e in events:
+        # Determine aspect family name if applicable
+        fam = e.kind.split("aspect_")[-1] if e.kind.startswith("aspect_") else None
+        val = _valence_for(fam, e.moving, mapping) if fam else "neutral"
+
+        # Planet-driven channel weights: combine moving + target (average)
+        w_m = _channel_weights_for(e.moving, mapping)
+        w_t = _channel_weights_for(e.target, mapping)
+        # Merge and average common keys
+        keys = set(w_m) | set(w_t)
+        combined: Dict[str, float] = {}
+        for k in keys:
+            combined[k] = 0.5 * w_m.get(k, 0.0) + 0.5 * w_t.get(k, 0.0)
+
+        # Distribute to channels and subchannels by valence
+        for key, w in combined.items():
+            if w <= 0:
+                continue
+            dom_id, ch_id = key.split(":", 1)
+            dom = scores.get(dom_id)
+            if not dom:
+                continue
+            ch = dom.channels.get(ch_id)
+            if not ch:
+                continue
+            if val == "negative":
+                ch.sub.get("negative").score += e.score * w
+            elif val == "positive":
+                ch.sub.get("positive").score += e.score * w
+            else:
+                # neutral: split 50/50
+                ch.sub.get("positive").score += 0.5 * e.score * w
+                ch.sub.get("negative").score += 0.5 * e.score * w
+
+    return scores
+# >>> AUTO-GEN END: AE Domain Scoring v1.0
 
 from .core.domains import (
     DEFAULT_HOUSE_DOMAIN_WEIGHTS,
@@ -22,4 +148,8 @@ __all__ = [
     "DomainResolver",
     "DomainResolution",
     "natal_domain_factor",
+    "SubchannelScore",
+    "ChannelScore",
+    "DomainScore",
+    "rollup_domain_scores",
 ]

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -1,11 +1,13 @@
-# >>> AUTO-GEN BEGIN: AE Engine Hooks v1.0
+# >>> AUTO-GEN BEGIN: AE Engine Hooks v1.1
 from __future__ import annotations
 import datetime as dt
 from typing import Iterable, List
 
 from .providers import get_provider
 from .detectors import detect_decl_contacts, detect_antiscia_contacts, CoarseHit
+from .detectors_aspects import detect_aspects, AspectHit
 from .exporters import TransitEvent
+from .scoring import compute_score, ScoreInputs
 
 
 def _iso_ticks(start_iso: str, end_iso: str, step_minutes: int = 60) -> Iterable[str]:
@@ -15,6 +17,17 @@ def _iso_ticks(start_iso: str, end_iso: str, step_minutes: int = 60) -> Iterable
     while t0 <= t1:
         yield t0.replace(tzinfo=dt.timezone.utc).isoformat().replace("+00:00", "Z")
         t0 += step
+
+
+def _score_from_hit(hit_kind: str, orb_abs: float, orb_allow: float, moving: str, target: str, phase: str) -> float:
+    return compute_score(ScoreInputs(
+        kind=hit_kind,
+        orb_abs_deg=orb_abs,
+        orb_allow_deg=orb_allow,
+        moving=moving,
+        target=target,
+        applying_or_separating=phase,
+    )).score
 
 
 def scan_contacts(
@@ -29,31 +42,39 @@ def scan_contacts(
     antiscia_orb: float = 2.0,
     contra_antiscia_orb: float = 2.0,
     step_minutes: int = 60,
+    aspects_policy_path: str | None = None,
 ) -> List[TransitEvent]:
     prov = get_provider(provider_name)
     ticks = list(_iso_ticks(start_iso, end_iso, step_minutes=step_minutes))
     events: List[TransitEvent] = []
+
+    # Declination & mirrors
     for hit in detect_decl_contacts(prov, ticks, moving, target, decl_parallel_orb, decl_contra_orb):
-        events.append(TransitEvent(
-            kind=hit.kind,
-            when_iso=hit.when_iso,
-            moving=hit.moving,
-            target=hit.target,
-            orb_abs=abs(hit.delta),
-            applying_or_separating=hit.applying_or_separating,
-        ))
+        allow = decl_parallel_orb if hit.kind == "decl_parallel" else decl_contra_orb
+        score = _score_from_hit(hit.kind, abs(hit.delta), allow, hit.moving, hit.target, hit.applying_or_separating)
+        events.append(TransitEvent(hit.kind, hit.when_iso, hit.moving, hit.target, abs(hit.delta), hit.applying_or_separating, score))
+
     for hit in detect_antiscia_contacts(prov, ticks, moving, target, antiscia_orb, contra_antiscia_orb):
-        events.append(TransitEvent(
-            kind=hit.kind,
-            when_iso=hit.when_iso,
-            moving=hit.moving,
-            target=hit.target,
-            orb_abs=abs(hit.delta),
-            applying_or_separating=hit.applying_or_separating,
-        ))
-    events.sort(key=lambda e: e.when_iso)
+        allow = antiscia_orb if hit.kind == "antiscia" else contra_antiscia_orb
+        score = _score_from_hit(hit.kind, abs(hit.delta), allow, hit.moving, hit.target, hit.applying_or_separating)
+        events.append(TransitEvent(hit.kind, hit.when_iso, hit.moving, hit.target, abs(hit.delta), hit.applying_or_separating, score))
+
+    # Longitudinal aspects
+    from .detectors_aspects import _load_policy as _asp_load
+    asp_pol = _asp_load(aspects_policy_path)
+    enabled = set(asp_pol.get("enabled", [])) | set(asp_pol.get("enabled_minors", []))
+    for ah in detect_aspects(prov, ticks, moving, target, policy_path=aspects_policy_path):
+        name = ah.kind  # e.g., aspect_trine
+        aname = name.split("_", 1)[1]
+        orbs_map = asp_pol["orbs_deg"][aname]
+        from .core.bodies import body_class
+        allow = min(orbs_map.get(body_class(moving), 2.0), orbs_map.get(body_class(target), 2.0))
+        score = _score_from_hit(ah.kind, ah.orb_abs, allow, ah.moving, ah.target, ah.applying_or_separating)
+        events.append(TransitEvent(ah.kind, ah.when_iso, ah.moving, ah.target, ah.orb_abs, ah.applying_or_separating, score))
+
+    events.sort(key=lambda e: (e.when_iso, -e.score))
     return events
-# >>> AUTO-GEN END: AE Engine Hooks v1.0
+# >>> AUTO-GEN END: AE Engine Hooks v1.1
 
 
 def resolve_provider(name: str | None) -> object:

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -1,10 +1,8 @@
-# >>> AUTO-GEN BEGIN: AE Exporters v1.0
+# >>> AUTO-GEN BEGIN: AE Exporters v1.1
 from __future__ import annotations
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable
-
-import json
 
 try:
     import sqlite3
@@ -27,6 +25,7 @@ class TransitEvent:
     target: str
     orb_abs: float
     applying_or_separating: str
+    score: float
 
 
 class SQLiteExporter:
@@ -40,7 +39,7 @@ class SQLiteExporter:
         con = sqlite3.connect(self.path)
         con.execute(
             "CREATE TABLE IF NOT EXISTS transits_events (\n"
-            "  kind TEXT, when_iso TEXT, moving TEXT, target TEXT, orb_abs REAL, applying TEXT\n"
+            "  kind TEXT, when_iso TEXT, moving TEXT, target TEXT, orb_abs REAL, applying TEXT, score REAL\n"
             ")"
         )
         con.commit()
@@ -49,8 +48,19 @@ class SQLiteExporter:
     def write(self, events: Iterable[TransitEvent]) -> None:
         con = sqlite3.connect(self.path)
         con.executemany(
-            "INSERT INTO transits_events VALUES (?,?,?,?,?,?)",
-            [(e.kind, e.when_iso, e.moving, e.target, e.orb_abs, e.applying_or_separating) for e in events],
+            "INSERT INTO transits_events VALUES (?,?,?,?,?,?,?)",
+            [
+                (
+                    e.kind,
+                    e.when_iso,
+                    e.moving,
+                    e.target,
+                    e.orb_abs,
+                    e.applying_or_separating,
+                    e.score,
+                )
+                for e in events
+            ],
         )
         con.commit()
         con.close()
@@ -66,4 +76,4 @@ class ParquetExporter:
         rows = [asdict(e) for e in events]
         table = pa.Table.from_pylist(rows)
         pq.write_table(table, self.path)
-# >>> AUTO-GEN END: AE Exporters v1.0
+# >>> AUTO-GEN END: AE Exporters v1.1

--- a/astroengine/providers/__init__.py
+++ b/astroengine/providers/__init__.py
@@ -1,10 +1,7 @@
 # >>> AUTO-GEN BEGIN: AE Providers Registry v1.0
 from __future__ import annotations
 from dataclasses import dataclass
-
-
-from ..ephemeris import SwissEphemerisAdapter
-
+from typing import Dict, Iterable, Protocol
 
 class EphemerisProvider(Protocol):
     """Minimal provider interface used by AstroEngine internals.

--- a/astroengine/scoring/__init__.py
+++ b/astroengine/scoring/__init__.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 from ..core.scoring import compute_domain_factor
 from .dignity import DignityRecord, load_dignities, lookup_dignities
 from .orb import DEFAULT_ASPECTS, OrbCalculator
+from .contact import ScoreInputs, ScoreResult, compute_score
 
 __all__ = [
     "compute_domain_factor",
+    "compute_score",
+    "ScoreInputs",
+    "ScoreResult",
     "DEFAULT_ASPECTS",
     "OrbCalculator",
     "DignityRecord",

--- a/astroengine/scoring/contact.py
+++ b/astroengine/scoring/contact.py
@@ -1,0 +1,90 @@
+"""Scoring helpers for contact events (aspects, declinations, mirrors)."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+from ..core.bodies import body_class
+
+__all__ = ["ScoreInputs", "ScoreResult", "compute_score"]
+
+_DEF_POLICY = Path(__file__).resolve().parent.parent / "profiles" / "scoring_policy.json"
+
+
+@dataclass(frozen=True)
+class ScoreInputs:
+    kind: str
+    orb_abs_deg: float
+    orb_allow_deg: float
+    moving: str
+    target: str
+    applying_or_separating: str
+
+
+@dataclass
+class ScoreResult:
+    score: float
+    components: dict[str, float]
+
+
+@lru_cache(maxsize=None)
+def _load_policy(path: str | None) -> dict:
+    policy_path = Path(path) if path else _DEF_POLICY
+    raw = policy_path.read_text().splitlines()
+    payload = "\n".join(line for line in raw if not line.strip().startswith("#"))
+    return json.loads(payload)
+
+
+def _gaussian(value: float, sigma: float) -> float:
+    if sigma <= 0:
+        return 0.0
+    return math.exp(-0.5 * (value / sigma) ** 2)
+
+
+def compute_score(inputs: ScoreInputs, *, policy_path: str | None = None) -> ScoreResult:
+    policy = _load_policy(policy_path)
+    base_weight = float(policy.get("base_weights", {}).get(inputs.kind, 0.0))
+    if base_weight <= 0.0 or inputs.orb_allow_deg <= 0:
+        return ScoreResult(0.0, {"base_weight": base_weight})
+
+    curve = policy.get("curve", {})
+    sigma_frac = float(curve.get("sigma_frac_of_orb", 0.5))
+    sigma = max(inputs.orb_allow_deg * sigma_frac, 1e-6)
+    min_score = float(curve.get("min_score", 0.0))
+    max_score = float(curve.get("max_score", 1.0))
+    gaussian_value = _gaussian(inputs.orb_abs_deg, sigma)
+    normalized = min_score + (max_score - min_score) * gaussian_value
+
+    cls_m = body_class(inputs.moving)
+    cls_t = body_class(inputs.target)
+    body_weights = policy.get("body_class_weights", {})
+    weight_m = float(body_weights.get(cls_m, 1.0))
+    weight_t = float(body_weights.get(cls_t, 1.0))
+    pair_key = "-".join(sorted((cls_m, cls_t)))
+    pair_matrix = policy.get("pair_matrix", {})
+    pair_weight = float(pair_matrix.get(pair_key, 1.0))
+
+    score = base_weight * weight_m * weight_t * pair_weight * normalized
+
+    phase = (inputs.applying_or_separating or "").lower()
+    applying_cfg = policy.get("applying_bias", {})
+    if applying_cfg.get("enabled") and phase == "applying":
+        score *= float(applying_cfg.get("factor", 1.0))
+
+    partile_cfg = policy.get("partile", {})
+    if partile_cfg.get("enabled") and inputs.orb_abs_deg <= float(partile_cfg.get("threshold_deg", 0.0)):
+        score *= float(partile_cfg.get("boost_factor", 1.0))
+
+    score = max(min(score, max_score), min_score)
+    components = {
+        "base_weight": base_weight,
+        "weight_m": weight_m,
+        "weight_t": weight_t,
+        "pair_weight": pair_weight,
+        "gaussian": gaussian_value,
+    }
+    return ScoreResult(score=score, components=components)

--- a/profiles/aspects_policy.json
+++ b/profiles/aspects_policy.json
@@ -1,0 +1,28 @@
+# >>> AUTO-GEN BEGIN: AE Aspects Policy v1.0
+{
+  "angles_deg": {
+    "conjunction": 0,
+    "sextile": 60,
+    "square": 90,
+    "trine": 120,
+    "opposition": 180,
+    "semisextile": 30,
+    "semisquare": 45,
+    "sesquisquare": 135,
+    "quincunx": 150
+  },
+  "enabled": ["conjunction", "sextile", "square", "trine", "opposition"],
+  "enabled_minors": [],
+  "orbs_deg": {
+    "conjunction": {"luminary": 8.0, "personal": 6.0, "social": 5.0, "outer": 4.0},
+    "opposition": {"luminary": 8.0, "personal": 6.0, "social": 5.0, "outer": 4.0},
+    "square":     {"luminary": 7.0, "personal": 5.0, "social": 4.5, "outer": 4.0},
+    "trine":      {"luminary": 7.0, "personal": 5.0, "social": 4.5, "outer": 4.0},
+    "sextile":    {"luminary": 5.0, "personal": 4.0, "social": 3.5, "outer": 3.0},
+    "semisextile":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
+    "semisquare": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
+    "sesquisquare":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
+    "quincunx":   {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0}
+  }
+}
+# >>> AUTO-GEN END: AE Aspects Policy v1.0

--- a/profiles/domain_mapping.json
+++ b/profiles/domain_mapping.json
@@ -1,0 +1,33 @@
+# >>> AUTO-GEN BEGIN: AE Domain Mapping v1.0
+{
+  "aspect_valence": {
+    "sextile": "positive",
+    "trine": "positive",
+    "square": "negative",
+    "opposition": "negative",
+    "conjunction": "neutral",
+    "semisextile": "neutral",
+    "semisquare": "negative",
+    "sesquisquare": "negative",
+    "quincunx": "neutral"
+  },
+  "planet_channels": {
+    "sun": {"spirit:growth": 0.3, "body:vitality": 0.3, "spirit:transformation": 0.4},
+    "moon": {"mind:cognition": 0.2, "body:habits": 0.3, "mind:relationships": 0.5},
+    "mercury": {"mind:cognition": 0.6, "mind:communication": 0.4},
+    "venus": {"mind:relationships": 0.7, "spirit:growth": 0.3},
+    "mars": {"body:vitality": 0.7, "mind:cognition": 0.3},
+    "jupiter": {"spirit:growth": 0.8, "mind:cognition": 0.2},
+    "saturn": {"body:habits": 0.5, "mind:cognition": 0.5},
+    "uranus": {"spirit:transformation": 0.7, "mind:cognition": 0.3},
+    "neptune": {"spirit:growth": 0.6, "mind:relationships": 0.4},
+    "pluto": {"spirit:transformation": 1.0}
+  },
+  "conjunction_valence_overrides": {
+    "venus": "positive",
+    "jupiter": "positive",
+    "mars": "negative",
+    "saturn": "negative"
+  }
+}
+# >>> AUTO-GEN END: AE Domain Mapping v1.0

--- a/profiles/domain_tree.json
+++ b/profiles/domain_tree.json
@@ -1,0 +1,40 @@
+# >>> AUTO-GEN BEGIN: AE Domain Tree v1.0
+{
+  "domains": [
+    {"id": "mind", "name": "Mind", "channels": [
+      {"id": "cognition", "name": "Cognition", "subchannels": [
+        {"id": "positive", "name": "Clarity", "valence": "positive"},
+        {"id": "negative", "name": "Confusion", "valence": "negative"}
+      ]},
+      {"id": "communication", "name": "Communication", "subchannels": [
+        {"id": "positive", "name": "Ease", "valence": "positive"},
+        {"id": "negative", "name": "Blocks", "valence": "negative"}
+      ]},
+      {"id": "relationships", "name": "Relationships", "subchannels": [
+        {"id": "positive", "name": "Harmony", "valence": "positive"},
+        {"id": "negative", "name": "Friction", "valence": "negative"}
+      ]}
+    ]},
+    {"id": "body", "name": "Body", "channels": [
+      {"id": "vitality", "name": "Vitality", "subchannels": [
+        {"id": "positive", "name": "Energy", "valence": "positive"},
+        {"id": "negative", "name": "Fatigue", "valence": "negative"}
+      ]},
+      {"id": "habits", "name": "Habits", "subchannels": [
+        {"id": "positive", "name": "Discipline", "valence": "positive"},
+        {"id": "negative", "name": "Disruption", "valence": "negative"}
+      ]}
+    ]},
+    {"id": "spirit", "name": "Spirit", "channels": [
+      {"id": "growth", "name": "Growth", "subchannels": [
+        {"id": "positive", "name": "Expansion", "valence": "positive"},
+        {"id": "negative", "name": "Excess", "valence": "negative"}
+      ]},
+      {"id": "transformation", "name": "Transformation", "subchannels": [
+        {"id": "positive", "name": "Renewal", "valence": "positive"},
+        {"id": "negative", "name": "Upheaval", "valence": "negative"}
+      ]}
+    ]}
+  ]
+}
+# >>> AUTO-GEN END: AE Domain Tree v1.0

--- a/profiles/scoring_policy.json
+++ b/profiles/scoring_policy.json
@@ -1,0 +1,39 @@
+# >>> AUTO-GEN BEGIN: AE Scoring Policy v1.1
+{
+  "curve": {"kind": "gaussian", "sigma_frac_of_orb": 0.5, "min_score": 0.0, "max_score": 1.0},
+  "applying_bias": {"enabled": true, "factor": 1.10},
+  "partile": {"enabled": true, "threshold_deg": 0.1667, "boost_factor": 1.25},
+  "base_weights": {
+    "decl_parallel": 0.70,
+    "decl_contra": 0.65,
+    "antiscia": 0.55,
+    "contra_antiscia": 0.50,
+    "aspect_conjunction": 0.80,
+    "aspect_sextile": 0.70,
+    "aspect_square": 0.75,
+    "aspect_trine": 0.75,
+    "aspect_opposition": 0.80,
+    "aspect_semisextile": 0.40,
+    "aspect_semisquare": 0.45,
+    "aspect_sesquisquare": 0.45,
+    "aspect_quincunx": 0.50
+  },
+  "body_class_weights": {
+    "luminary": 1.00,
+    "personal": 0.95,
+    "social": 0.90,
+    "outer": 0.85
+  },
+  "pair_matrix": {
+    "luminary-personal": 1.00,
+    "luminary-social": 0.95,
+    "luminary-outer": 0.95,
+    "personal-personal": 1.00,
+    "personal-social": 0.95,
+    "personal-outer": 0.90,
+    "social-social": 0.90,
+    "social-outer": 0.90,
+    "outer-outer": 0.85
+  }
+}
+# >>> AUTO-GEN END: AE Scoring Policy v1.1

--- a/tests/test_aspects_and_domains.py
+++ b/tests/test_aspects_and_domains.py
@@ -1,0 +1,53 @@
+# >>> AUTO-GEN BEGIN: AE Aspects & Domains Tests v1.0
+import datetime as dt
+import json
+
+from astroengine.detectors_aspects import detect_aspects
+from astroengine.engine import scan_contacts
+from astroengine.domains import rollup_domain_scores
+
+
+class StubProvider:
+    def __init__(self):
+        self.base = dt.datetime(2024, 6, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
+
+    def positions_ecliptic(self, iso: str, bodies):
+        t = dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+        hours = (t - self.base).total_seconds() / 3600.0
+        # moving marches 1°/hour from 0°; target fixed at 120° (trine target at 0°)
+        out = {}
+        for b in bodies:
+            if b == "moving":
+                out[b] = {"lon": (hours % 360.0), "speed_lon": 24.0}
+            else:
+                out[b] = {"lon": 120.0, "speed_lon": 0.0}
+        return out
+
+
+def _ticks(start, end, step_minutes=60):
+    t0 = dt.datetime.fromisoformat(start.replace("Z", "+00:00"))
+    t1 = dt.datetime.fromisoformat(end.replace("Z", "+00:00"))
+    step = dt.timedelta(minutes=step_minutes)
+    while t0 <= t1:
+        yield t0.isoformat().replace("+00:00", "Z")
+        t0 += step
+
+
+def test_aspect_detector_finds_trine():
+    prov = StubProvider()
+    ticks = list(_ticks("2024-06-01T00:00:00Z", "2024-06-02T00:00:00Z", 60))
+    hits = detect_aspects(prov, ticks, "moving", "target")
+    kinds = {h.kind for h in hits}
+    assert any(k.startswith("aspect_trine") for k in kinds)
+
+
+def test_domain_rollup_has_three_domains():
+    # Glue: use engine.scan_contacts with stub-like parameters by monkeypatching provider if needed.
+    events = [
+        # Minimal event set to exercise rollup
+        type("E", (), {"kind": "aspect_trine", "when_iso": "2024-06-01T00:00:00Z", "moving": "venus", "target": "mars", "orb_abs": 0.5, "applying_or_separating": "applying", "score": 0.8})(),
+        type("E", (), {"kind": "aspect_square", "when_iso": "2024-06-01T01:00:00Z", "moving": "mars", "target": "saturn", "orb_abs": 0.5, "applying_or_separating": "separating", "score": 0.6})(),
+    ]
+    report = rollup_domain_scores(events)
+    assert set(report.keys()) >= {"mind", "body", "spirit"}
+# >>> AUTO-GEN END: AE Aspects & Domains Tests v1.0


### PR DESCRIPTION
## Summary
- add longitudinal aspect detection with configurable policy and integrate orb-aware scoring
- roll up transit scores into the new mind/body/spirit domain hierarchy and expose CLI reporting
- document new policies, extend exporters with score fields, and cover the flows with targeted tests

## Testing
- `pytest -q tests/test_aspects_and_domains.py`
- `python -m astroengine report --start 2024-06-01T00:00:00Z --end 2024-06-02T00:00:00Z --moving mars --target venus --provider swiss --step 120`


------
https://chatgpt.com/codex/tasks/task_e_68cde522745c83248f6923fc4ef283ab