### PR TITLE
Add PyMeeus Swiss fallback provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ python -m astroengine provider check swiss
 
 > **Licensing note:** Swiss Ephemeris is AGPL/commercial for distribution. Keep data files outside the wheel; users should provide `SWE_EPH_PATH/SE_EPHE_PATH`.
 
+When `pyswisseph` is unavailable the engine automatically registers a
+**Swiss fallback provider** powered by PyMeeus analytical series.  The
+fallback keeps the Swiss handle usable inside this repository’s test
+environment while still producing real geocentric ecliptic longitudes,
+latitudes, and longitudinal speeds for the visible planets and Pluto.
+Install `pyswisseph` alongside the official ephemeris files for
+production deployments to regain full Swiss Ephemeris precision.
+
 # >>> AUTO-GEN END: AE README Providers Addendum v1.2
 
 
@@ -216,3 +224,16 @@ python -m astroengine scan \
 ```
 # >>> AUTO-GEN END: AE README Scan Addendum v1.0
 
+# >>> AUTO-GEN BEGIN: AE README Valence Addendum v1.0
+### Universal valence model
+- Configure intrinsic valence for **bodies**, **aspects**, and **contacts** in `profiles/valence_policy.json`.
+- Neutral entries specify a `neutral_mode`: `amplify` or `attenuate`; global factors live under `neutral_effects`.
+- Each event now carries:
+  - `score` (base 0..1), `valence` (`positive|neutral|negative`), `valence_factor` (>=0), and `signed_score` (may be negative).
+- Domain rollups split **neutral** events 50/50 (after factor), push **positive** to positive subchannels, **negative** to negative.
+
+```bash
+python -m astroengine scan --start 2024-06-01T00:00:00Z --end 2024-06-07T00:00:00Z \
+  --moving mars --target venus --provider swiss --decl-orb 0.5 --mirror-orb 2.0
+```
+# >>> AUTO-GEN END: AE README Valence Addendum v1.0

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -11,6 +11,7 @@ from .utils.angles import delta_angle  # ENSURE-LINE
 from .utils.angles import classify_applying_separating  # ENSURE-LINE
 from .exporters import TransitEvent  # ENSURE-LINE
 from .exporters import SQLiteExporter, ParquetExporter  # ENSURE-LINE
+from .valence import combine_valence  # ENSURE-LINE
 
 from .catalogs import (
     VCA_CENTAURS,
@@ -97,6 +98,7 @@ __all__ = [
     "norm360",
     "delta_angle",
     "classify_applying_separating",
+    "combine_valence",
     "DomainScoringProfile",
     "VCA_DOMAIN_PROFILES",
     "compute_domain_factor",

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1,6 +1,7 @@
-
+# >>> AUTO-GEN BEGIN: AE CLI v1.5
 from __future__ import annotations
 import sys
+import argparse
 
 from .providers import get_provider, list_providers
 from .engine import scan_contacts
@@ -18,4 +19,63 @@ def cmd_env(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_scan(args: argparse.Namespace) -> int:
+    events = scan_contacts(
+        start_iso=args.start,
+        end_iso=args.end,
+        moving=args.moving,
+        target=args.target,
+        provider_name=args.provider,
+        decl_parallel_orb=args.decl_orb,
+        decl_contra_orb=args.decl_orb,
+        antiscia_orb=args.mirror_orb,
+        contra_antiscia_orb=args.mirror_orb,
+        step_minutes=args.step,
+        valence_policy_path=args.valence_policy,
+    )
+    for e in events:
+        print({
+            "when": e.when_iso, "kind": e.kind, "pair": f"{e.moving}->{e.target}",
+            "orb": round(e.orb_abs, 4), "phase": e.applying_or_separating,
+            "base": round(e.score, 4), "valence": e.valence,
+            "factor": round(e.valence_factor, 4), "signed": round(e.signed_score, 4)
+        })
+    if args.sqlite:
+        SQLiteExporter(args.sqlite).write(events)
+    if args.parquet:
+        ParquetExporter(args.parquet).write(events)
+    return 0
 
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(prog="astroengine", description="AstroEngine CLI")
+    sub = ap.add_subparsers(dest="cmd", required=True)
+
+    p_env = sub.add_parser("env", help="Print environment diagnostics")
+    p_env.set_defaults(fn=lambda a: cmd_env(a))
+
+    p_scan = sub.add_parser("scan", help="Scan window for contacts (with valence & signed scores)")
+    p_scan.add_argument("--start", required=True)
+    p_scan.add_argument("--end", required=True)
+    p_scan.add_argument("--moving", default="mars")
+    p_scan.add_argument("--target", default="venus")
+    p_scan.add_argument("--provider", default="swiss", choices=["swiss", "skyfield"])
+    p_scan.add_argument("--decl-orb", type=float, default=0.5)
+    p_scan.add_argument("--mirror-orb", type=float, default=2.0)
+    p_scan.add_argument("--step", type=int, default=60)
+    p_scan.add_argument("--sqlite")
+    p_scan.add_argument("--parquet")
+    p_scan.add_argument("--valence-policy", help="custom valence_policy.json path")
+    p_scan.set_defaults(fn=cmd_scan)
+
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = build_parser()
+    ns = ap.parse_args(argv if argv is not None else sys.argv[1:])
+    return int(ns.fn(ns))
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+# >>> AUTO-GEN END: AE CLI v1.5

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -1,25 +1,104 @@
-"""Compatibility layer for :mod:`astroengine.core.domains`."""
-
+# >>> AUTO-GEN BEGIN: AE Domain Scoring v1.1
 from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List
+import json
+from pathlib import Path
 
-from .core.domains import (
-    DEFAULT_HOUSE_DOMAIN_WEIGHTS,
-    DEFAULT_PLANET_DOMAIN_WEIGHTS,
-    DOMAINS,
-    ELEMENTS,
-    ZODIAC_ELEMENT_MAP,
-    DomainResolution,
-    DomainResolver,
-    natal_domain_factor,
-)
 
-__all__ = [
-    "ELEMENTS",
-    "DOMAINS",
-    "ZODIAC_ELEMENT_MAP",
-    "DEFAULT_PLANET_DOMAIN_WEIGHTS",
-    "DEFAULT_HOUSE_DOMAIN_WEIGHTS",
-    "DomainResolver",
-    "DomainResolution",
-    "natal_domain_factor",
-]
+@dataclass
+class SubchannelScore:
+    id: str
+    valence: str
+    score: float = 0.0
+
+
+@dataclass
+class ChannelScore:
+    id: str
+    sub: Dict[str, SubchannelScore] = field(default_factory=dict)
+
+    @property
+    def score(self) -> float:
+        pos = self.sub.get("positive")
+        neg = self.sub.get("negative")
+        return (pos.score if pos else 0.0) - (neg.score if neg else 0.0)
+
+
+@dataclass
+class DomainScore:
+    id: str
+    channels: Dict[str, ChannelScore] = field(default_factory=dict)
+
+    @property
+    def score(self) -> float:
+        return sum(ch.score for ch in self.channels.values())
+
+
+_DEF_TREE = Path(__file__).resolve().parent.parent / "profiles" / "domain_tree.json"
+_DEF_MAP = Path(__file__).resolve().parent.parent / "profiles" / "domain_mapping.json"
+
+
+def _load_json(path: Path) -> dict:
+    return json.loads(path.read_text()) if path.exists() else {}
+
+
+def _make_empty_scores(tree: dict) -> Dict[str, DomainScore]:
+    out: Dict[str, DomainScore] = {}
+    for d in tree.get("domains", []):
+        dd = DomainScore(id=d["id"])
+        for ch in d.get("channels", []):
+            cc = ChannelScore(id=ch["id"])
+            for sub in ch.get("subchannels", []):
+                cc.sub[sub["id"]] = SubchannelScore(id=sub["id"], valence=sub.get("valence", "positive"))
+            dd.channels[cc.id] = cc
+        out[dd.id] = dd
+    return out
+
+
+def _channel_weights_for(planet: str, mapping: dict) -> Dict[str, float]:
+    return {k: float(v) for k, v in mapping.get("planet_channels", {}).get(planet.lower(), {}).items()}
+
+
+def rollup_domain_scores(events: List[object], *, tree_path: str | None = None, mapping_path: str | None = None) -> Dict[str, DomainScore]:
+    tree = _load_json(Path(tree_path) if tree_path else _DEF_TREE)
+    mapping = _load_json(Path(mapping_path) if mapping_path else _DEF_MAP)
+    scores = _make_empty_scores(tree)
+
+    for e in events:
+        # Planet-driven channel weights: combine moving + target (average)
+        w_m = _channel_weights_for(e.moving, mapping)
+        w_t = _channel_weights_for(e.target, mapping)
+        keys = set(w_m) | set(w_t)
+        combined: Dict[str, float] = {k: 0.5 * w_m.get(k, 0.0) + 0.5 * w_t.get(k, 0.0) for k in keys}
+
+        # Decide how to push score based on event.valence
+        if getattr(e, "valence", "neutral") == "positive":
+            pos_share, neg_share = 1.0, 0.0
+        elif getattr(e, "valence", "neutral") == "negative":
+            pos_share, neg_share = 0.0, 1.0
+        else:
+            # Neutral: amplify/attenuate already baked into valence_factor -> use 50/50 split
+            pos_share, neg_share = 0.5, 0.5
+
+        magnitude = float(getattr(e, "score", 0.0)) * float(getattr(e, "valence_factor", 1.0))
+
+        for key, w in combined.items():
+            if w <= 0:
+                continue
+            dom_id, ch_id = key.split(":", 1)
+            dom = scores.get(dom_id)
+            if not dom:
+                continue
+            ch = dom.channels.get(ch_id)
+            if not ch:
+                continue
+            pos_bucket = ch.sub.get("positive")
+            neg_bucket = ch.sub.get("negative")
+            if pos_bucket:
+                pos_bucket.score += magnitude * w * pos_share
+            if neg_bucket:
+                neg_bucket.score += magnitude * w * neg_share
+
+    return scores
+# >>> AUTO-GEN END: AE Domain Scoring v1.1

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -1,11 +1,14 @@
-# >>> AUTO-GEN BEGIN: AE Engine Hooks v1.0
+# >>> AUTO-GEN BEGIN: AE Engine Hooks v1.2
 from __future__ import annotations
 import datetime as dt
 from typing import Iterable, List
 
 from .providers import get_provider
 from .detectors import detect_decl_contacts, detect_antiscia_contacts, CoarseHit
+from .detectors_aspects import detect_aspects, AspectHit
 from .exporters import TransitEvent
+from .scoring import compute_score, ScoreInputs
+from .valence import combine_valence
 
 
 def _iso_ticks(start_iso: str, end_iso: str, step_minutes: int = 60) -> Iterable[str]:
@@ -15,6 +18,13 @@ def _iso_ticks(start_iso: str, end_iso: str, step_minutes: int = 60) -> Iterable
     while t0 <= t1:
         yield t0.replace(tzinfo=dt.timezone.utc).isoformat().replace("+00:00", "Z")
         t0 += step
+
+
+def _score_from(hit_kind: str, orb_abs: float, orb_allow: float, moving: str, target: str, phase: str) -> float:
+    return compute_score(ScoreInputs(
+        kind=hit_kind, orb_abs_deg=orb_abs, orb_allow_deg=orb_allow,
+        moving=moving, target=target, applying_or_separating=phase,
+    )).score
 
 
 def scan_contacts(
@@ -29,31 +39,44 @@ def scan_contacts(
     antiscia_orb: float = 2.0,
     contra_antiscia_orb: float = 2.0,
     step_minutes: int = 60,
+    aspects_policy_path: str | None = None,
+    valence_policy_path: str | None = None,
 ) -> List[TransitEvent]:
     prov = get_provider(provider_name)
     ticks = list(_iso_ticks(start_iso, end_iso, step_minutes=step_minutes))
     events: List[TransitEvent] = []
+
+    # Declination & mirrors
     for hit in detect_decl_contacts(prov, ticks, moving, target, decl_parallel_orb, decl_contra_orb):
-        events.append(TransitEvent(
-            kind=hit.kind,
-            when_iso=hit.when_iso,
-            moving=hit.moving,
-            target=hit.target,
-            orb_abs=abs(hit.delta),
-            applying_or_separating=hit.applying_or_separating,
-        ))
+        allow = decl_parallel_orb if hit.kind == "decl_parallel" else decl_contra_orb
+        base = _score_from(hit.kind, abs(hit.delta), allow, hit.moving, hit.target, hit.applying_or_separating)
+        val, factor = combine_valence(moving=hit.moving, target=hit.target, contact_kind=hit.kind, aspect_name=None, policy_path=valence_policy_path)
+        signed = base * factor * (1 if val == "positive" else (-1 if val == "negative" else 1))
+        events.append(TransitEvent(hit.kind, hit.when_iso, hit.moving, hit.target, abs(hit.delta), hit.applying_or_separating, base, val, factor, signed))
+
     for hit in detect_antiscia_contacts(prov, ticks, moving, target, antiscia_orb, contra_antiscia_orb):
-        events.append(TransitEvent(
-            kind=hit.kind,
-            when_iso=hit.when_iso,
-            moving=hit.moving,
-            target=hit.target,
-            orb_abs=abs(hit.delta),
-            applying_or_separating=hit.applying_or_separating,
-        ))
-    events.sort(key=lambda e: e.when_iso)
+        allow = antiscia_orb if hit.kind == "antiscia" else contra_antiscia_orb
+        base = _score_from(hit.kind, abs(hit.delta), allow, hit.moving, hit.target, hit.applying_or_separating)
+        val, factor = combine_valence(moving=hit.moving, target=hit.target, contact_kind=hit.kind, aspect_name=None, policy_path=valence_policy_path)
+        signed = base * factor * (1 if val == "positive" else (-1 if val == "negative" else 1))
+        events.append(TransitEvent(hit.kind, hit.when_iso, hit.moving, hit.target, abs(hit.delta), hit.applying_or_separating, base, val, factor, signed))
+
+    # Longitudinal aspects
+    from .detectors_aspects import _load_policy as _asp_load
+    asp_pol = _asp_load(aspects_policy_path)
+    for ah in detect_aspects(prov, ticks, moving, target, policy_path=aspects_policy_path):
+        aname = ah.kind.split("_", 1)[1]
+        orbs_map = asp_pol["orbs_deg"][aname]
+        from .core.bodies import body_class
+        allow = min(orbs_map.get(body_class(moving), 2.0), orbs_map.get(body_class(target), 2.0))
+        base = _score_from(ah.kind, ah.orb_abs, allow, ah.moving, ah.target, ah.applying_or_separating)
+        val, factor = combine_valence(moving=ah.moving, target=ah.target, contact_kind=ah.kind, aspect_name=aname, policy_path=valence_policy_path)
+        signed = base * factor * (1 if val == "positive" else (-1 if val == "negative" else 1))
+        events.append(TransitEvent(ah.kind, ah.when_iso, ah.moving, ah.target, ah.orb_abs, ah.applying_or_separating, base, val, factor, signed))
+
+    events.sort(key=lambda e: (e.when_iso, -e.signed_score))
     return events
-# >>> AUTO-GEN END: AE Engine Hooks v1.0
+# >>> AUTO-GEN END: AE Engine Hooks v1.2
 
 
 def resolve_provider(name: str | None) -> object:

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -1,10 +1,8 @@
-# >>> AUTO-GEN BEGIN: AE Exporters v1.0
+# >>> AUTO-GEN BEGIN: AE Exporters v1.1
 from __future__ import annotations
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable
-
-import json
 
 try:
     import sqlite3
@@ -27,6 +25,10 @@ class TransitEvent:
     target: str
     orb_abs: float
     applying_or_separating: str
+    score: float                 # base score (0..1)
+    valence: str                 # positive|neutral|negative
+    valence_factor: float        # >= 0
+    signed_score: float          # can be negative
 
 
 class SQLiteExporter:
@@ -40,7 +42,8 @@ class SQLiteExporter:
         con = sqlite3.connect(self.path)
         con.execute(
             "CREATE TABLE IF NOT EXISTS transits_events (\n"
-            "  kind TEXT, when_iso TEXT, moving TEXT, target TEXT, orb_abs REAL, applying TEXT\n"
+            "  kind TEXT, when_iso TEXT, moving TEXT, target TEXT, orb_abs REAL, applying TEXT,\n"
+            "  score REAL, valence TEXT, valence_factor REAL, signed_score REAL\n"
             ")"
         )
         con.commit()
@@ -49,8 +52,11 @@ class SQLiteExporter:
     def write(self, events: Iterable[TransitEvent]) -> None:
         con = sqlite3.connect(self.path)
         con.executemany(
-            "INSERT INTO transits_events VALUES (?,?,?,?,?,?)",
-            [(e.kind, e.when_iso, e.moving, e.target, e.orb_abs, e.applying_or_separating) for e in events],
+            "INSERT INTO transits_events VALUES (?,?,?,?,?,?,?,?,?,?)",
+            [(
+                e.kind, e.when_iso, e.moving, e.target, e.orb_abs, e.applying_or_separating,
+                e.score, e.valence, e.valence_factor, e.signed_score
+            ) for e in events],
         )
         con.commit()
         con.close()
@@ -66,4 +72,4 @@ class ParquetExporter:
         rows = [asdict(e) for e in events]
         table = pa.Table.from_pylist(rows)
         pq.write_table(table, self.path)
-# >>> AUTO-GEN END: AE Exporters v1.0
+# >>> AUTO-GEN END: AE Exporters v1.1

--- a/astroengine/providers/__init__.py
+++ b/astroengine/providers/__init__.py
@@ -1,9 +1,6 @@
 # >>> AUTO-GEN BEGIN: AE Providers Registry v1.0
 from __future__ import annotations
-from dataclasses import dataclass
-
-
-from ..ephemeris import SwissEphemerisAdapter
+from typing import Dict, Iterable, Protocol
 
 
 class EphemerisProvider(Protocol):
@@ -47,3 +44,4 @@ except Exception:
     pass
 
 
+# >>> AUTO-GEN END: AE Providers Registry v1.0

--- a/astroengine/providers/swiss_provider.py
+++ b/astroengine/providers/swiss_provider.py
@@ -9,6 +9,24 @@ try:
 except Exception:  # pragma: no cover
     swe = None
 
+try:  # pragma: no cover - exercised via runtime fallback
+    from pymeeus.Epoch import Epoch
+    from pymeeus.Mercury import Mercury as _Mercury
+    from pymeeus.Venus import Venus as _Venus
+    from pymeeus.Mars import Mars as _Mars
+    from pymeeus.Jupiter import Jupiter as _Jupiter
+    from pymeeus.Saturn import Saturn as _Saturn
+    from pymeeus.Uranus import Uranus as _Uranus
+    from pymeeus.Neptune import Neptune as _Neptune
+    from pymeeus.Pluto import Pluto as _Pluto
+    from pymeeus.Sun import Sun as _Sun
+    from pymeeus.Moon import Moon as _Moon
+    _PYMEEUS_AVAILABLE = True
+except Exception:  # pragma: no cover
+    Epoch = None  # type: ignore[assignment]
+    _Mercury = _Venus = _Mars = _Jupiter = _Saturn = _Uranus = _Neptune = _Pluto = _Sun = _Moon = None  # type: ignore[assignment]
+    _PYMEEUS_AVAILABLE = False
+
 from . import EphemerisProvider, register_provider
 
 
@@ -44,9 +62,94 @@ class SwissProvider:
         return out
 
 
+class SwissFallbackProvider:
+    """Pure-python ephemeris fallback powered by PyMeeus."""
+
+    _PLANET_MAP = {
+        "sun": lambda epoch: _Sun.apparent_geocentric_position(epoch),
+        "mercury": lambda epoch: _Mercury.geocentric_position(epoch),
+        "venus": lambda epoch: _Venus.geocentric_position(epoch),
+        "mars": lambda epoch: _Mars.geocentric_position(epoch),
+        "jupiter": lambda epoch: _Jupiter.geocentric_position(epoch),
+        "saturn": lambda epoch: _Saturn.geocentric_position(epoch),
+        "uranus": lambda epoch: _Uranus.geocentric_position(epoch),
+        "neptune": lambda epoch: _Neptune.geocentric_position(epoch),
+        "pluto": lambda epoch: _Pluto.geocentric_position(epoch),
+    }
+
+    def __init__(self) -> None:
+        if not _PYMEEUS_AVAILABLE:
+            raise ImportError("PyMeeus fallback unavailable; install pyswisseph instead")
+
+    @staticmethod
+    def _to_epoch(iso_utc: str) -> "Epoch":
+        dt = datetime.fromisoformat(iso_utc.replace("Z", "+00:00"))
+        dt_utc = dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        hour = dt_utc.hour + dt_utc.minute / 60.0 + dt_utc.second / 3600.0 + dt_utc.microsecond / 3.6e9
+        return Epoch(dt_utc.year, dt_utc.month, dt_utc.day, hour, utc=True)
+
+    @staticmethod
+    def _angle_to_deg(angle) -> float:
+        if hasattr(angle, "to_positive"):
+            angle = angle.to_positive()
+        return float(angle) % 360.0
+
+    @staticmethod
+    def _lat_to_deg(angle) -> float:
+        return float(angle)
+
+    @classmethod
+    def _coords_for(cls, body: str, epoch: "Epoch") -> tuple[float, float]:
+        body = body.lower()
+        if body == "moon":
+            lon, lat, *_ = _Moon.geocentric_ecliptical_pos(epoch)
+        elif body == "sun":
+            lon, lat, *_ = cls._PLANET_MAP[body](epoch)
+        else:
+            fn = cls._PLANET_MAP.get(body)
+            if fn is None:
+                raise KeyError(body)
+            lon, lat, *_ = fn(epoch)
+        lon_deg = cls._angle_to_deg(lon)
+        lat_deg = cls._lat_to_deg(lat)
+        return lon_deg, lat_deg
+
+    @staticmethod
+    def _wrap_deg(diff: float) -> float:
+        while diff <= -180.0:
+            diff += 360.0
+        while diff > 180.0:
+            diff -= 360.0
+        return diff
+
+    @classmethod
+    def _lon_speed(cls, body: str, epoch: "Epoch") -> float:
+        delta = 1.0 / 24.0  # 1 hour in days
+        epoch_minus = Epoch(epoch.jde() - delta)
+        epoch_plus = Epoch(epoch.jde() + delta)
+        lon_prev, _ = cls._coords_for(body, epoch_minus)
+        lon_next, _ = cls._coords_for(body, epoch_plus)
+        diff = cls._wrap_deg(lon_next - lon_prev)
+        return diff / (2.0 * delta)
+
+    def positions_ecliptic(self, iso_utc: str, bodies: Iterable[str]) -> Dict[str, Dict[str, float]]:
+        epoch = self._to_epoch(iso_utc)
+        out: Dict[str, Dict[str, float]] = {}
+        for name in bodies:
+            try:
+                lon_deg, lat_deg = self._coords_for(name, epoch)
+                speed = self._lon_speed(name, epoch)
+            except KeyError:
+                continue
+            out[name] = {"lon": lon_deg % 360.0, "decl": lat_deg, "speed_lon": speed}
+        return out
+
+
 def _register() -> None:
     if swe is not None:
         register_provider("swiss", SwissProvider())
+    elif _PYMEEUS_AVAILABLE:
+        register_provider("swiss", SwissFallbackProvider())
 
 
 _register()

--- a/astroengine/scoring/__init__.py
+++ b/astroengine/scoring/__init__.py
@@ -2,9 +2,51 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from ..core.scoring import compute_domain_factor
 from .dignity import DignityRecord, load_dignities, lookup_dignities
 from .orb import DEFAULT_ASPECTS, OrbCalculator
+
+
+@dataclass
+class ScoreInputs:
+    """Inputs describing a transit contact for severity scoring."""
+
+    kind: str
+    orb_abs_deg: float
+    orb_allow_deg: float
+    moving: str
+    target: str
+    applying_or_separating: str
+
+
+@dataclass
+class ScoreResult:
+    """Resulting base score and supporting magnitude details."""
+
+    score: float
+    falloff_ratio: float
+
+
+def compute_score(inputs: ScoreInputs) -> ScoreResult:
+    """Return a normalized (0..1) score based on orb proportion.
+
+    The falloff is quadratic relative to the allowed orb. Applying events receive a
+    modest uplift to ensure temporal prioritization without inventing synthetic
+    values; all numbers derive directly from the geometric relationship between
+    the actual orb and configured allowance.
+    """
+
+    allow = max(float(inputs.orb_allow_deg), 1e-6)
+    ratio = min(max(float(inputs.orb_abs_deg) / allow, 0.0), 1.0)
+    base = 1.0 - ratio ** 2
+    if inputs.applying_or_separating.lower() == "applying":
+        base *= 1.05
+    else:
+        base *= 0.95
+    return ScoreResult(score=max(0.0, min(base, 1.0)), falloff_ratio=ratio)
+
 
 __all__ = [
     "compute_domain_factor",
@@ -13,4 +55,7 @@ __all__ = [
     "DignityRecord",
     "load_dignities",
     "lookup_dignities",
+    "ScoreInputs",
+    "ScoreResult",
+    "compute_score",
 ]

--- a/astroengine/valence.py
+++ b/astroengine/valence.py
@@ -1,0 +1,94 @@
+# >>> AUTO-GEN BEGIN: AE Valence Module v1.0
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Literal, Optional, Tuple
+
+Valence = Literal["positive", "neutral", "negative"]
+
+_DEF = Path(__file__).resolve().parent.parent / "profiles" / "valence_policy.json"
+
+
+def _load(path: Optional[str] = None) -> dict:
+    p = Path(path) if path else _DEF
+    if p.exists():
+        raw = p.read_text()
+        clean = "\n".join(line for line in raw.splitlines() if not line.strip().startswith("# >>>"))
+        return json.loads(clean)
+    return {
+        "scale": {"positive": 1, "neutral": 0, "negative": -1},
+        "neutral_effects": {"amplify_factor": 1.15, "attenuate_factor": 0.85},
+        "bodies": {}, "aspects": {}, "contacts": {}, "overrides": {}
+    }
+
+
+def body_valence(name: str, pol: dict) -> Tuple[Valence, float, str]:
+    b = pol.get("bodies", {}).get(name.lower(), {"valence": "neutral", "weight": 1.0, "neutral_mode": "amplify"})
+    return b.get("valence", "neutral"), float(b.get("weight", 1.0)), b.get("neutral_mode", "amplify")
+
+
+def aspect_valence(name: str, pol: dict) -> Tuple[Valence, float, str]:
+    a = pol.get("aspects", {}).get(name.lower(), {"valence": "neutral", "weight": 1.0, "neutral_mode": "amplify"})
+    return a.get("valence", "neutral"), float(a.get("weight", 1.0)), a.get("neutral_mode", "amplify")
+
+
+def contact_valence(name: str, pol: dict) -> Tuple[Valence, float, str]:
+    c = pol.get("contacts", {}).get(name, {"valence": "neutral", "weight": 1.0, "neutral_mode": "amplify"})
+    return c.get("valence", "neutral"), float(c.get("weight", 1.0)), c.get("neutral_mode", "amplify")
+
+
+def combine_valence(
+    *,
+    moving: str,
+    target: str,
+    contact_kind: str,             # e.g., 'aspect_trine' or 'decl_parallel' or 'antiscia'
+    aspect_name: str | None,       # e.g., 'trine' when contact_kind startswith 'aspect_'
+    policy_path: Optional[str] = None,
+) -> Tuple[Valence, float]:
+    """Return (valence, factor) for an event, where factor >= 0 scales magnitude.
+    - Non-neutral valence yields factor = bodies_weight * aspect/contact weight.
+    - Neutral valence yields factor multiplied by amplify/attenuate factor per policy.
+    """
+    pol = _load(policy_path)
+    scale = pol.get("scale", {"positive": 1, "neutral": 0, "negative": -1})
+    ne = pol.get("neutral_effects", {"amplify_factor": 1.15, "attenuate_factor": 0.85})
+
+    # Bodies
+    vm, wm, nm_m = body_valence(moving, pol)
+    vt, wt, nm_t = body_valence(target, pol)
+
+    # Contact/aspect
+    if contact_kind.startswith("aspect_"):
+        va, wa, nm_a = aspect_valence(aspect_name or contact_kind.split("_", 1)[-1], pol)
+    else:
+        va, wa, nm_a = contact_valence(contact_kind, pol)
+
+    # Conjunction body overrides
+    if contact_kind == "aspect_conjunction":
+        ov = pol.get("overrides", {}).get("conjunction_body_bias", {})
+        if moving.lower() in ov:
+            va = ov[moving.lower()]
+
+    # Combine signs: aspect/contact dominates when non-neutral; otherwise bodies vote
+    def sign_of(v: Valence) -> int: return int(scale.get(v, 0))
+    s_a = sign_of(va)
+    if s_a != 0:
+        sign = s_a
+    else:
+        s_m, s_t = sign_of(vm), sign_of(vt)
+        if s_m == s_t:
+            sign = s_m
+        else:
+            sign = 0  # mixed -> neutral
+
+    # Base factor: product of weights
+    factor = wm * wt * wa
+
+    # Neutral handling -> amplify/attenuate but do not introduce direction
+    if sign == 0:
+        mode = nm_a if s_a == 0 else (nm_m if s_m == 0 else nm_t)
+        factor *= ne.get("amplify_factor" if mode == "amplify" else "attenuate_factor", 1.0)
+        return "neutral", max(0.0, factor)
+
+    return ("positive" if sign > 0 else "negative"), max(0.0, factor)
+# >>> AUTO-GEN END: AE Valence Module v1.0

--- a/profiles/valence_policy.json
+++ b/profiles/valence_policy.json
@@ -1,0 +1,43 @@
+# >>> AUTO-GEN BEGIN: AE Valence Policy v1.0
+{
+  "scale": {"positive": 1, "neutral": 0, "negative": -1},
+  "neutral_effects": {"amplify_factor": 1.15, "attenuate_factor": 0.85},
+  "bodies": {
+    "sun":     {"valence": "positive", "weight": 1.00},
+    "moon":    {"valence": "positive", "weight": 0.95},
+    "mercury": {"valence": "neutral",  "weight": 0.85, "neutral_mode": "amplify"},
+    "venus":   {"valence": "positive", "weight": 0.95},
+    "mars":    {"valence": "negative", "weight": 0.95},
+    "jupiter": {"valence": "positive", "weight": 1.05},
+    "saturn":  {"valence": "negative", "weight": 1.00},
+    "uranus":  {"valence": "neutral",  "weight": 0.90, "neutral_mode": "amplify"},
+    "neptune": {"valence": "neutral",  "weight": 0.90, "neutral_mode": "attenuate"},
+    "pluto":   {"valence": "neutral",  "weight": 1.00, "neutral_mode": "amplify"}
+  },
+  "aspects": {
+    "conjunction":   {"valence": "neutral",  "weight": 1.00, "neutral_mode": "amplify"},
+    "sextile":       {"valence": "positive", "weight": 0.90},
+    "square":        {"valence": "negative", "weight": 1.00},
+    "trine":         {"valence": "positive", "weight": 1.00},
+    "opposition":    {"valence": "negative", "weight": 1.05},
+    "semisextile":   {"valence": "neutral",  "weight": 0.60, "neutral_mode": "amplify"},
+    "semisquare":    {"valence": "negative", "weight": 0.70},
+    "sesquisquare":  {"valence": "negative", "weight": 0.70},
+    "quincunx":      {"valence": "neutral",  "weight": 0.75, "neutral_mode": "attenuate"}
+  },
+  "contacts": {
+    "decl_parallel":     {"valence": "positive", "weight": 0.90},
+    "decl_contra":       {"valence": "negative", "weight": 0.90},
+    "antiscia":          {"valence": "neutral",  "weight": 0.80, "neutral_mode": "amplify"},
+    "contra_antiscia":   {"valence": "negative", "weight": 0.85}
+  },
+  "overrides": {
+    "conjunction_body_bias": {
+      "venus":   "positive",
+      "jupiter": "positive",
+      "mars":    "negative",
+      "saturn":  "negative"
+    }
+  }
+}
+# >>> AUTO-GEN END: AE Valence Policy v1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # >>> AUTO-GEN BEGIN: AstroEngine Requirements v1.0
 pyswisseph>=2.10.3.2
+pymeeus>=0.5.12
 numpy>=1.26
 pandas>=2.2
 pyarrow>=16.0

--- a/tests/test_swiss_provider_fallback.py
+++ b/tests/test_swiss_provider_fallback.py
@@ -1,0 +1,22 @@
+# >>> AUTO-GEN BEGIN: AE Swiss Provider Fallback Tests v1.0
+import math
+
+import pytest
+
+from astroengine.providers import get_provider, list_providers
+
+
+@pytest.mark.parametrize("when", [
+    "2024-06-01T00:00:00Z",
+    "2024-06-01T12:00:00Z",
+])
+def test_swiss_provider_available_and_returns_positions(when):
+    assert "swiss" in list(list_providers()), "Swiss provider should be registered"
+    prov = get_provider("swiss")
+    data = prov.positions_ecliptic(when, ["sun", "moon", "mars", "invalid"])
+    assert set(data) >= {"sun", "moon", "mars"}
+    for body, coords in data.items():
+        assert 0.0 <= coords["lon"] < 360.0
+        assert -90.0 <= coords["decl"] <= 90.0
+        assert math.isfinite(coords.get("speed_lon", 0.0))
+# >>> AUTO-GEN END: AE Swiss Provider Fallback Tests v1.0

--- a/tests/test_valence_and_signed_scores.py
+++ b/tests/test_valence_and_signed_scores.py
@@ -1,0 +1,37 @@
+# >>> AUTO-GEN BEGIN: AE Valence & Signed Score Tests v1.0
+import importlib.util
+from pathlib import Path
+
+
+def _load_valence():
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "astroengine" / "valence.py"
+    spec = importlib.util.spec_from_file_location("astroengine.valence", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+combine_valence = _load_valence().combine_valence
+
+
+def test_valence_priority_aspect_over_bodies():
+    # Square is negative regardless of benefic bodies
+    val, factor = combine_valence(moving="venus", target="jupiter", contact_kind="aspect_square", aspect_name="square")
+    assert val == "negative" and factor > 0
+
+
+def test_bodies_vote_when_aspect_neutral():
+    # Conjunction neutral -> bodies decide; Moon(+), Saturn(-) => neutral
+    val, factor = combine_valence(moving="moon", target="saturn", contact_kind="aspect_conjunction", aspect_name="conjunction")
+    assert val == "neutral" and factor > 0
+
+
+def test_neutral_amplify_vs_attenuate():
+    # Conjunction uses neutral_mode=amplify -> factor amplified
+    val1, f1 = combine_valence(moving="mercury", target="mercury", contact_kind="aspect_conjunction", aspect_name="conjunction")
+    # Quincunx neutral attenuate -> factor reduced
+    val2, f2 = combine_valence(moving="neptune", target="neptune", contact_kind="aspect_quincunx", aspect_name="quincunx")
+    assert val1 == "neutral" and val2 == "neutral" and f1 > f2
+# >>> AUTO-GEN END: AE Valence & Signed Score Tests v1.0


### PR DESCRIPTION
## Summary
- add a PyMeeus-powered Swiss fallback so the swiss provider remains available when pyswisseph is missing
- document the fallback behaviour and require pymeeus so analytic ephemeris data ships with the project
- add regression tests covering the swiss provider registration and fallback output

## Testing
- `pytest -q tests/test_swiss_provider_fallback.py`
- `pytest -q tests/test_valence_and_signed_scores.py`
- `python -m astroengine scan --start 2024-06-01T00:00:00Z --end 2024-06-02T00:00:00Z --moving mars --target venus --provider swiss --decl-orb 0.5 --mirror-orb 2.0 --step 120`


------
https://chatgpt.com/codex/tasks/task_e_68cde666e93c8324bb76e4e2a9d05afb