### PR TITLE
Pin Swiss tooling and harden CI

### DIFF
--- a/.github/workflows/ci-guards.yml
+++ b/.github/workflows/ci-guards.yml
@@ -1,5 +1,5 @@
-# >>> AUTO-GEN BEGIN: ci guards v1.0
-name: CI Guards (Generated-Only)
+# >>> AUTO-GEN BEGIN: ci guards v1.1
+name: CI Guards
 on:
   pull_request:
   push:
@@ -9,17 +9,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+
       - name: Install tools
         run: |
           python -m pip install --upgrade pip
           pip install ruff pyyaml
+
+      - name: Export SE_EPHE_PATH if repo ephemeris folder exists
+        if: ${{ hashFiles('ephe/**') != '' }}
+        run: echo "SE_EPHE_PATH=${{ github.workspace }}/ephe" >> $GITHUB_ENV
+
       - name: Validate AUTO-GEN fences
         run: python scripts/validators/validate_fences.py
+
       - name: Validate registry
         run: python scripts/validators/validate_registry.py
-      - name: Lint
-        run: python -m ruff check generated/ registry/ scripts/ || true
-# >>> AUTO-GEN END: ci guards v1.0
+
+      - name: Lint (ruff)
+        run: python -m ruff check src/ generated/ registry/ scripts/ || true
+
+      - name: Duplicate code scan (jscpd)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Run jscpd
+        run: npx jscpd --min-tokens 70 --threshold 2 --reporters consoleFull --silent || true
+# >>> AUTO-GEN END: ci guards v1.1

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,4 +1,4 @@
-# >>> AUTO-GEN BEGIN: issue-triage workflow v1.0
+# >>> AUTO-GEN BEGIN: issue-triage workflow v1.1
 name: Issue Triage & Health Report
 
 on:
@@ -6,7 +6,7 @@ on:
     branches: [ main, master ]
   pull_request:
   schedule:
-    - cron: '17 */6 * * *'  # every 6h
+    - cron: '17 */6 * * *'
   workflow_dispatch:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Setup Python 3.11
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -30,6 +30,10 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           pip install pytest pytest-cov ruff mypy PyGithub pydantic requests
+
+      - name: Export SE_EPHE_PATH if repo ephemeris folder exists
+        if: ${{ hashFiles('ephe/**') != '' }}
+        run: echo "SE_EPHE_PATH=${{ github.workspace }}/ephe" >> $GITHUB_ENV
 
       - name: Run repo scan & healthcheck
         env:
@@ -44,4 +48,4 @@ jobs:
         with:
           name: triage-report
           path: .github/triage/triage_report.md
-# >>> AUTO-GEN END: issue-triage workflow v1.0
+# >>> AUTO-GEN END: issue-triage workflow v1.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,1 @@
-
+pyswisseph==2.10.3.2  # ENSURE-LINE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,81 @@
 from __future__ import annotations
 
+import importlib
 import sys
 from pathlib import Path
 
-# Ensure the repository root is importable so ``astroengine`` can be resolved
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
-if str(PROJECT_ROOT) not in sys.path:
-    sys.path.insert(0, str(PROJECT_ROOT))
+PROJECT_ROOT_STR = str(PROJECT_ROOT)
+GENERATED_ROOT = PROJECT_ROOT / "generated"
+GENERATED_STR = str(GENERATED_ROOT)
+
+
+def _ensure_repo_package() -> None:
+    while PROJECT_ROOT_STR in sys.path:
+        sys.path.remove(PROJECT_ROOT_STR)
+    sys.path.insert(0, PROJECT_ROOT_STR)
+    for candidate in (GENERATED_STR, "generated"):
+        while candidate in sys.path:
+            sys.path.remove(candidate)
+        sys.path.append(candidate)
+
+    module = sys.modules.get("astroengine")
+    if module is not None:
+        module_file = getattr(module, "__file__", "") or ""
+        if module_file and str(GENERATED_ROOT) in module_file:
+            for key in list(sys.modules):
+                if key == "astroengine" or key.startswith("astroengine."):
+                    sys.modules.pop(key, None)
+            module = None
+    if module is None:
+        importlib.invalidate_caches()
+    try:
+        module = importlib.import_module("astroengine")
+    except ModuleNotFoundError:
+        return
+    module_file = getattr(module, "__file__", "") or ""
+    if module_file and str(GENERATED_ROOT) in module_file:
+        for key in list(sys.modules):
+            if key == "astroengine" or key.startswith("astroengine."):
+                sys.modules.pop(key, None)
+        importlib.invalidate_caches()
+        importlib.import_module("astroengine")
+
+
+_ensure_repo_package()
+
+# >>> AUTO-GEN BEGIN: swiss availability gating v1.0
+import os
+import pytest
+
+
+def _have_pyswisseph() -> bool:
+    try:
+        import swisseph as _swe  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _have_ephe_path() -> bool:
+    p = os.getenv("SE_EPHE_PATH")
+    return bool(p and os.path.isdir(p))
+
+
+def pytest_collection_modifyitems(config, items):
+    """Auto-skip tests marked 'swiss' unless pyswisseph + ephemeris path are available."""
+    swiss_missing = not _have_pyswisseph() or not _have_ephe_path()
+    if not swiss_missing:
+        return
+    skip_swiss = pytest.mark.skip(reason="Swiss Ephemeris unavailable (no pyswisseph or SE_EPHE_PATH).")
+    for item in items:
+        if "swiss" in item.keywords:
+            item.add_marker(skip_swiss)
+# >>> AUTO-GEN END: swiss availability gating v1.0
+
+
+@pytest.fixture(autouse=True)
+def _restore_repo_package() -> None:
+    _ensure_repo_package()
+    yield
+    _ensure_repo_package()

--- a/tests/test_swiss_smoke.py
+++ b/tests/test_swiss_smoke.py
@@ -1,0 +1,13 @@
+# >>> AUTO-GEN BEGIN: swiss smoketest (optional) v1.0
+import os
+import pytest
+
+pytestmark = pytest.mark.swiss  # will auto-skip unless Swiss is available
+
+
+def test_swiss_import_and_path():
+    import swisseph as swe
+    p = os.getenv("SE_EPHE_PATH")
+    assert p, "SE_EPHE_PATH must be set for Swiss tests"
+    assert swe is not None
+# >>> AUTO-GEN END: swiss smoketest (optional) v1.0


### PR DESCRIPTION
## Summary
- pin Python 3.11 across triage and guard workflows and export `SE_EPHE_PATH` when ephemeris data exists
- lock pyswisseph to 2.10.3.2 for reproducible Swiss Ephemeris installs
- harden pytest bootstrapping so repo sources win over generated stubs and auto-skip Swiss tests when prerequisites are missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf803b7dc883248424fb2d10d7c3d4