### PR TITLE
Add Swiss caching and performance utilities

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -1,0 +1,27 @@
+# >>> AUTO-GEN BEGIN: perf benchmark workflow v1.0
+name: Perf Benchmark (Swiss)
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "23 5 * * *"
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install
+        run: |
+          python -m pip install -U pip
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+      - name: Set ephemeris path if present
+        if: ${{ hashFiles('ephe/**') != '' }}
+        run: echo "SE_EPHE_PATH=${{ github.workspace }}/ephe" >> $GITHUB_ENV
+      - name: Run bench
+        run: |
+          python scripts/perf/bench_scan.py || true
+# >>> AUTO-GEN END: perf benchmark workflow v1.0

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,11 @@ Thumbs.db
 # Local artifacts
 diagnostics.json
 # >>> AUTO-GEN END: Gitignore Additions v1.0
+# >>> AUTO-GEN BEGIN: perf artifacts ignore v1.0
+.prof
+*.prof
+*.pyc
+__pycache__/
+inspection/
+triage-report/
+# >>> AUTO-GEN END: perf artifacts ignore v1.0

--- a/docs/PRE_FLIGHT_CHECKLIST.md
+++ b/docs/PRE_FLIGHT_CHECKLIST.md
@@ -1,0 +1,24 @@
+# >>> AUTO-GEN BEGIN: pre-flight checklist v1.0
+# AstroEngine — Pre-Flight Checklist (v0.1)
+
+## Environment
+- [ ] Python pinned to **3.11** in CI (Actions).
+- [ ] `pyswisseph==2.10.3.2` installed where Swiss is needed.
+- [ ] `SE_EPHE_PATH` points to valid Swiss ephemeris folder.
+
+## Functional smoke
+- [ ] `python -c "import swisseph as swe; print(swe.__version__)"` works.
+- [ ] `scripts/swe_smoketest.py` prints a Julian Day and does not error.
+
+## Performance
+- [ ] `pytest -q -m perf` passes locally.
+- [ ] `python scripts/perf/bench_scan.py` completes in a reasonable time window.
+
+## Data & Registry
+- [ ] `registry/aspects.yaml` has core aspects (0/60/90/120/180).
+- [ ] `registry/orbs_policy.yaml` has `orbs_default` with luminaries/personal/social/outer/minors.
+
+## Safety nets
+- [ ] AUTO-GEN fence validators green.
+- [ ] Issue triage workflow updated meta health report.
+# >>> AUTO-GEN END: pre-flight checklist v1.0

--- a/generated/astroengine/__init__.py
+++ b/generated/astroengine/__init__.py
@@ -3,8 +3,10 @@
 All modules are generated; do not hand-edit outside AUTO-GEN fences.
 """
 from .registry import REGISTRY  # ENSURE-LINE
+from .engine import fast_scan, ScanConfig  # ENSURE-LINE
 # Public symbols are ensured here; other modules may be added over time.
 __all__ = [
     "REGISTRY",  # ENSURE-LINE
 ]
+__all__ += ["fast_scan", "ScanConfig"]  # ENSURE-LINE
 # >>> AUTO-GEN END: public api surface v1.0

--- a/generated/astroengine/_cache.py
+++ b/generated/astroengine/_cache.py
@@ -1,0 +1,34 @@
+# >>> AUTO-GEN BEGIN: swiss cache utils v1.0
+from __future__ import annotations
+import os
+from functools import lru_cache
+
+_SE_SET = False
+
+def _lazy_import_swe():
+    try:
+        import swisseph as swe  # type: ignore
+        return swe
+    except Exception as e:
+        raise RuntimeError("pyswisseph unavailable; ensure py311 and pyswisseph installed") from e
+
+def set_ephe_from_env() -> None:
+    """Set ephemeris path from SE_EPHE_PATH once (idempotent)."""
+    global _SE_SET
+    if _SE_SET:
+        return
+    p = os.getenv("SE_EPHE_PATH")
+    if p:
+        _lazy_import_swe().set_ephe_path(p)
+    _SE_SET = True
+
+@lru_cache(maxsize=200_000)
+def calc_ut_lon(jd: float, body: int, flag: int = 0) -> float:
+    """
+    Cached ecliptic longitude (degrees) for (jd, body, flag).
+    Cache key uses exact jd—upstream should quantize ticks if desired.
+    """
+    swe = _lazy_import_swe()
+    lon = swe.calc_ut(jd, body, flag)[0][0]
+    return lon % 360.0
+# >>> AUTO-GEN END: swiss cache utils v1.0

--- a/generated/astroengine/engine.py
+++ b/generated/astroengine/engine.py
@@ -1,0 +1,109 @@
+# >>> AUTO-GEN BEGIN: performance core v1.0
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import List, Tuple, Optional
+import math, datetime as dt
+
+from ._cache import set_ephe_from_env, calc_ut_lon  # ENSURE-LINE
+
+try:
+    import swisseph as swe  # type: ignore
+except Exception:  # pragma: no cover
+    swe = None
+
+def _jd_from_utc(ts: dt.datetime) -> float:
+    """UTC naive/aware -> Julian Day."""
+    if ts.tzinfo is not None:
+        ts = ts.astimezone(dt.timezone.utc).replace(tzinfo=None)
+    y,m,d = ts.year, ts.month, ts.day
+    h = ts.hour + ts.minute/60 + (ts.second + ts.microsecond/1e6)/3600
+    return (swe.julday(y,m,d,h) if swe else 0.0)
+
+def _angnorm(a: float) -> float:
+    return a % 360.0
+
+def _signed_delta(a: float, b: float) -> float:
+    """Smallest signed diff a-b in [-180,180]."""
+    d = (a - b + 540.0) % 360.0 - 180.0
+    return d
+
+@dataclass(frozen=True)
+class ScanConfig:
+    body: int                          # e.g., swe.SUN
+    natal_lon_deg: float               # 0..360
+    aspect_angle_deg: float            # e.g., 0,60,90,120,180
+    orb_deg: float = 6.0
+    tick_minutes: int = 60             # coarse tick
+    refine_max_iter: int = 24
+    refine_tol_deg: float = 1e-4       # ~0.0001° (~0.36")
+    flags: int = 0
+
+def _bracket_zero(jd0: float, jd1: float, cfg: ScanConfig) -> Optional[Tuple[float,float]]:
+    """Return (jda, jdb) if signed delta crosses zero in [jd0,jd1]."""
+    set_ephe_from_env()
+    a0 = calc_ut_lon(jd0, cfg.body, cfg.flags)
+    a1 = calc_ut_lon(jd1, cfg.body, cfg.flags)
+    target = _angnorm(cfg.natal_lon_deg + cfg.aspect_angle_deg)
+    d0 = _signed_delta(a0, target)
+    d1 = _signed_delta(a1, target)
+    if d0 == 0.0:
+        return (jd0, jd0)
+    if d1 == 0.0:
+        return (jd1, jd1)
+    if (d0 > 0 and d1 < 0) or (d0 < 0 and d1 > 0):
+        return (jd0, jd1)
+    return None
+
+def _bisection(jda: float, jdb: float, cfg: ScanConfig) -> float:
+    """Bisection to solve signed_delta=0."""
+    set_ephe_from_env()
+    target = _angnorm(cfg.natal_lon_deg + cfg.aspect_angle_deg)
+    da = lambda jd: _signed_delta(calc_ut_lon(jd, cfg.body, cfg.flags), target)
+    a, b = jda, jdb
+    fa, fb = da(a), da(b)
+    for _ in range(cfg.refine_max_iter):
+        m = 0.5*(a+b)
+        fm = da(m)
+        if abs(fm) <= cfg.refine_tol_deg:
+            return m
+        if (fa > 0 and fm < 0) or (fa < 0 and fm > 0):
+            b, fb = m, fm
+        else:
+            a, fa = m, fm
+    return 0.5*(a+b)
+
+def fast_scan(start_utc: dt.datetime, end_utc: dt.datetime, cfg: ScanConfig) -> List[Tuple[dt.datetime, float]]:
+    """
+    Fast aspect scan:
+      - coarse ticks at cfg.tick_minutes
+      - only refine when sign change
+      - filter by orb at tick time (cheap early gate)
+    Returns list of (exact_utc, delta_deg_at_tick) for each hit.
+    """
+    if swe is None:
+        raise RuntimeError("Swiss not available; ensure py311 + pyswisseph installed.")
+    set_ephe_from_env()
+    tick_minutes = max(1, int(cfg.tick_minutes))
+    step_days = tick_minutes / (60*24)
+    jd = _jd_from_utc(start_utc)
+    jd_end = _jd_from_utc(end_utc)
+    target = _angnorm(cfg.natal_lon_deg + cfg.aspect_angle_deg)
+
+    hits: List[Tuple[dt.datetime, float]] = []
+    prev_jd: Optional[float] = None
+
+    while jd <= jd_end + 1e-12:
+        lon = calc_ut_lon(jd, cfg.body, cfg.flags)
+        d = abs(_signed_delta(lon, target))
+        if d <= cfg.orb_deg and prev_jd is not None:
+            br = _bracket_zero(prev_jd, jd, cfg)
+            if br:
+                jx = _bisection(br[0], br[1], cfg)
+                y, m, d_, h = swe.revjul(jx, 1)
+                hh = int(h); mm = int((h-hh)*60); ss = int(round(((h-hh)*60 - mm)*60))
+                hits.append((dt.datetime(y, m, d_, hh, mm, ss), d))
+        prev_jd = jd
+        jd += step_days
+
+    return hits
+# >>> AUTO-GEN END: performance core v1.0

--- a/scripts/cleanup/repo_clean.py
+++ b/scripts/cleanup/repo_clean.py
@@ -1,0 +1,48 @@
+# >>> AUTO-GEN BEGIN: repo cleanup v1.0
+#!/usr/bin/env python
+"""
+Lightweight cleanup:
+- remove *.pyc/__pycache__
+- normalize newline at EOF for .py/.md/.yml/.yaml/.toml/.txt
+- run ruff --fix (if available)
+"""
+import os, sys, subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+def rm_pycache():
+    for p in ROOT.rglob("__pycache__"):
+        for f in p.iterdir():
+            try:
+                f.unlink()
+            except Exception:
+                pass
+        try:
+            p.rmdir()
+        except Exception:
+            pass
+
+def normalize_eof():
+    exts = {".py",".md",".yml",".yaml",".toml",".txt"}
+    for p in ROOT.rglob("*"):
+        if p.suffix in exts and p.is_file():
+            t = p.read_text(encoding="utf-8", errors="ignore")
+            if not t.endswith("\n"):
+                p.write_text(t + "\n", encoding="utf-8")
+
+def ruff_fix():
+    try:
+        subprocess.run([sys.executable, "-m", "ruff", "check", "--fix", str(ROOT)], check=False)
+    except Exception:
+        pass
+
+def main():
+    rm_pycache()
+    normalize_eof()
+    ruff_fix()
+    print("Cleanup complete.")
+
+if __name__ == "__main__":
+    main()
+# >>> AUTO-GEN END: repo cleanup v1.0

--- a/scripts/perf/bench_scan.py
+++ b/scripts/perf/bench_scan.py
@@ -1,0 +1,39 @@
+# >>> AUTO-GEN BEGIN: bench scan v1.0
+#!/usr/bin/env python
+"""
+Quick performance benchmark:
+- scans Sun→natal Venus conj over N days at tick=60m
+- prints hits and wall time
+Run: python scripts/perf/bench_scan.py
+"""
+import os, time, datetime as dt
+from generated.astroengine.engine import fast_scan, ScanConfig  # fallback
+try:
+    from astroengine.engine import fast_scan as _fs, ScanConfig as _SC  # type: ignore
+    fast_scan, ScanConfig = _fs, _SC
+except Exception:
+    pass
+
+def main():
+    if not os.getenv("SE_EPHE_PATH"):
+        print("WARN: SE_EPHE_PATH not set; Swiss may fail.")
+    start = dt.datetime(2025, 1, 1, 0, 0)
+    end   = dt.datetime(2025, 1, 31, 0, 0)
+    cfg = ScanConfig(body=1, natal_lon_deg=195.0, aspect_angle_deg=0.0, orb_deg=6.0, tick_minutes=60)
+    t0 = time.time()
+    try:
+        hits = fast_scan(start, end, cfg)
+    except Exception as e:
+        print("ERROR:", e)
+        return 2
+    dt_sec = time.time() - t0
+    print(f"fast_scan: days={(end-start).days}, ticks={(end-start).days*24}, hits={len(hits)}, wall={dt_sec:.2f}s")
+    for h in hits[:3]:
+        print("hit:", h[0].isoformat(), "Δ≈", h[1])
+    if dt_sec > 30.0:
+        print("NOTE: >30s; consider lowering tick_minutes or limiting bodies")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+# >>> AUTO-GEN END: bench scan v1.0

--- a/tests/test_perf_smoke.py
+++ b/tests/test_perf_smoke.py
@@ -1,0 +1,21 @@
+# >>> AUTO-GEN BEGIN: perf smoke v1.0
+import os, datetime as dt, pytest
+pytestmark = [pytest.mark.perf, pytest.mark.swiss]
+
+def _have_swiss():
+    try:
+        import swisseph as _  # noqa
+        return bool(os.getenv("SE_EPHE_PATH"))
+    except Exception:
+        return False
+
+@pytest.mark.skipif(not _have_swiss(), reason="Swiss unavailable")
+def test_fast_scan_runs_under_budget():
+    from astroengine.engine import fast_scan, ScanConfig
+    start = dt.datetime(2025,1,1,0,0)
+    end   = dt.datetime(2025,1,3,0,0)
+    cfg = ScanConfig(body=1, natal_lon_deg=195.0, aspect_angle_deg=0.0, orb_deg=6.0, tick_minutes=60)
+    hits = fast_scan(start, end, cfg)
+    assert isinstance(hits, list)
+    assert len(hits) <= 12  # sanity
+# >>> AUTO-GEN END: perf smoke v1.0


### PR DESCRIPTION
## Summary
- add generated Swiss ephemeris cache helpers and expose fast_scan API
- implement generated fast scan core with caching, benchmark, and smoke test
- wire supporting automation including perf workflow, cleanup script, and pre-flight checklist

## Testing
- pytest -q -m perf

------
https://chatgpt.com/codex/tasks/task_e_68cf846b1cfc83248a138bf4188d208a