### PR TITLE
Add astroengine runtime shims and registry loader

### DIFF
--- a/astroengine/registry/__init__.py
+++ b/astroengine/registry/__init__.py
@@ -1,0 +1,69 @@
+# >>> AUTO-GEN BEGIN: RegistryLoader v1.0
+"""Lightweight registry loader that can read from either
+- packaged path: `astroengine/registry/`
+- repo root path: `./registry/`
+
+This avoids a hard move of files while consolidating runtime onto `astroengine`.
+"""
+from __future__ import annotations
+from pathlib import Path
+from typing import Any
+
+try:
+    # Python ≥3.9 importlib.resources.files API
+    from importlib.resources import files as _files  # type: ignore
+except Exception:  # pragma: no cover
+    _files = None  # type: ignore
+
+
+def _candidate_dirs() -> list[Path]:
+    roots: list[Path] = []
+    # 1) packaged registry directory
+    if _files is not None:  # pragma: no branch
+        try:
+            pkg_root = Path(_files(__package__))
+            roots.append(pkg_root)
+        except Exception:
+            pass
+    # 2) project root `registry/` (dev installs, editable mode)
+    here = Path(__file__).resolve()
+    for up in (here.parents[1], Path.cwd()):
+        cand = up / "registry"
+        if cand.exists():
+            roots.append(cand)
+    # De-dup while preserving order
+    seen: set[Path] = set()
+    uniq: list[Path] = []
+    for r in roots:
+        if r not in seen:
+            uniq.append(r)
+            seen.add(r)
+    return uniq
+
+
+def load_yaml(name: str) -> Any:
+    """Load a registry YAML by file name (e.g., "aspects.yaml").
+    Searches packaged `astroengine/registry/` first, then `./registry/`.
+    """
+    if not name.lower().endswith(".yaml"):
+        raise ValueError("registry files must end with .yaml")
+    data = None
+    last_err: Exception | None = None
+    for root in _candidate_dirs():
+        fp = root / name
+        if fp.exists():
+            try:
+                import yaml  # lazy import to avoid hard dep during installs
+                with fp.open("r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f)
+                return data
+            except Exception as e:  # pragma: no cover
+                last_err = e
+                break
+    if last_err:
+        raise last_err
+    raise FileNotFoundError(f"Registry file not found: {name}; looked in: {', '.join(map(str, _candidate_dirs()))}")
+
+
+__all__ = ["load_yaml"]
+# >>> AUTO-GEN END: RegistryLoader v1.0

--- a/generated/__init__.py
+++ b/generated/__init__.py
@@ -1,0 +1,54 @@
+# >>> AUTO-GEN BEGIN: GeneratedShim v1.0
+"""
+Deprecation shim for the legacy "generated" package.
+This module re-exports from `astroengine` and maps `generated.astroengine`
+imports to the real `astroengine` package. Safe to keep for one minor release.
+"""
+from __future__ import annotations
+import warnings as _warnings
+import sys as _sys
+import types as _types
+
+# Single deprecation nudge on import
+_warnings.warn(
+    "The 'generated' package is deprecated; use 'astroengine' directly.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+# Map submodule path so `import generated.astroengine` resolves to `astroengine`.
+try:
+    import astroengine as _ae  # noqa: F401
+    _sys.modules.setdefault("generated.astroengine", _ae)
+except Exception:  # pragma: no cover — leave import errors to normal flow
+    pass
+
+# Re-export common public API symbols if available (best-effort, no hard deps)
+try:  # noqa: SIM105
+    from astroengine import TransitEngine as TransitEngine  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover
+    pass
+try:
+    from astroengine import TransitScanConfig as TransitScanConfig  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover
+    pass
+try:
+    from astroengine import TransitEvent as TransitEvent  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover
+    pass
+
+# Dynamic attribute forwarding for anything else under astroengine
+def __getattr__(name: str):  # pragma: no cover — simple passthrough
+    import importlib
+
+    _ae = importlib.import_module("astroengine")
+    return getattr(_ae, name)
+
+
+try:
+    import astroengine as _ae_for_all
+
+    __all__ = getattr(_ae_for_all, "__all__", [])  # type: ignore[assignment]
+except Exception:  # pragma: no cover
+    __all__ = []
+# >>> AUTO-GEN END: GeneratedShim v1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,33 @@ from __future__ import annotations
 
 import importlib
 import sys
+import types
+import warnings
 from pathlib import Path
+
+# >>> AUTO-GEN BEGIN: AliasGeneratedToAstroengine v1.0
+"""Pytest compatibility shim: route any `generated.*` imports to `astroengine`.
+Idempotent and safe to keep during the deprecation window.
+"""
+
+if "generated" not in sys.modules:
+    warnings.warn(
+        "Tests importing 'generated' are deprecated; using 'astroengine' instead.",
+        DeprecationWarning,
+        stacklevel=1,
+    )
+    gen = types.ModuleType("generated")
+    sys.modules["generated"] = gen
+
+# Always ensure the submodule alias exists
+try:
+    import astroengine as _ae  # noqa: F401
+
+    sys.modules.setdefault("generated.astroengine", _ae)
+except Exception:
+    # If astroengine is not importable here, let pytest show the normal error later.
+    pass
+# >>> AUTO-GEN END: AliasGeneratedToAstroengine v1.0
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ROOT_STR = str(PROJECT_ROOT)


### PR DESCRIPTION
## Summary
- add a deprecation shim so imports from the legacy generated package route to astroengine
- ensure pytest sessions auto-alias generated.* imports to astroengine during collection
- provide a registry loader that looks in astroengine/registry/ or the repo-level registry/

## Testing
- pytest -q
- python -c "import generated, astroengine; print('ok')"


------
https://chatgpt.com/codex/tasks/task_e_68cf88d8e9d883248ba1f1c1361eab74