### PR TITLE
Flip packaging to astroengine module

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+# >>> AUTO-GEN BEGIN: astroengine manifest data v1.0
+recursive-include astroengine/registry *.yaml *.yml *.csv
+recursive-include astroengine/profiles *.yaml *.yml *.json
+recursive-include astroengine/datasets *.csv *.json
+# >>> AUTO-GEN END: astroengine manifest data v1.0

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ python -m astroengine.maint --full --strict --auto-install all --yes
 See `docs/DIAGNOSTICS.md`, `docs/SWISS_EPHEMERIS.md`, and `docs/QUALITY_GATE.md` for details.
 # >>> AUTO-GEN END: README Quick Start v1.1
 
+# >>> AUTO-GEN BEGIN: README Import Snippet v1.0
+### Import the package
+
+```python
+import astroengine
+```
+# >>> AUTO-GEN END: README Import Snippet v1.0
+
 The CI workflow `.github/workflows/ci.yml` covers Python 3.10–3.12 and archives diagnostics output for each run.
 
 The package exposes a registry-based API for discovering datasets and

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -20,9 +20,9 @@ from .core import (  # noqa: F401
     AngleTracker,
     DomainResolution,
     DomainResolver,
-    TransitEngine,
-    TransitEvent,
-    TransitScanConfig,
+    TransitEngine,  # ENSURE-LINE
+    TransitEvent,  # ENSURE-LINE
+    TransitScanConfig,  # ENSURE-LINE
     apply_profile_if_any,
     classify_relative_motion,
     compute_domain_factor,
@@ -81,8 +81,9 @@ from .scoring import (
 __all__ = [
     "__version__",
     "ChartConfig",
-    "TransitEvent",
-    "TransitScanConfig",
+    "TransitEngine",  # ENSURE-LINE
+    "TransitEvent",  # ENSURE-LINE
+    "TransitScanConfig",  # ENSURE-LINE
     "DomainResolver",
     "DomainResolution",
     "ELEMENTS",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# >>> AUTO-GEN BEGIN: packaging config v1.0
+# >>> AUTO-GEN BEGIN: packaging config v1.1
 [build-system]
 requires = ["setuptools>=69", "wheel"]
 build-backend = "setuptools.build_meta"
@@ -15,12 +15,14 @@ dependencies = [
 ]
 
 [tool.setuptools]
-package-dir = {"" = "generated"}
+include-package-data = true
+package-dir = {"" = "."}
 
 [tool.setuptools.packages.find]
-where = ["generated"]
+where = ["."]
 include = ["astroengine*"]
-# >>> AUTO-GEN END: packaging config v1.0
+exclude = ["generated*"]
+# >>> AUTO-GEN END: packaging config v1.1
 
 # >>> AUTO-GEN BEGIN: ruff target py311 v1.1
 [tool.ruff]

--- a/tests/test_pkg_imports.py
+++ b/tests/test_pkg_imports.py
@@ -1,0 +1,15 @@
+"""Packaging smoke tests ensuring astroengine is importable."""
+
+# >>> AUTO-GEN BEGIN: astroengine packaging smoke v1.0
+import importlib
+
+import pytest
+
+
+@pytest.mark.smoke
+def test_import_astroengine_surface():
+    module = importlib.import_module("astroengine")
+    assert hasattr(module, "TransitEngine")
+    assert hasattr(module, "TransitScanConfig")
+    assert hasattr(module, "TransitEvent")
+# >>> AUTO-GEN END: astroengine packaging smoke v1.0


### PR DESCRIPTION
## Summary
- package the astroengine directory directly and ensure registry/profile datasets ship in the wheel
- reinforce public exports for TransitEngine/TransitScanConfig/TransitEvent and document importing the package
- add a smoke test that imports astroengine after installation

## Testing
- pip install -e .
- python -m astroengine --help | head
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf8a1589e88324b8790b9ca25e208d