### PR TITLE
Align packaging and scaffold optional feature toggles

### DIFF
--- a/.github/workflows/optional-extras.yml
+++ b/.github/workflows/optional-extras.yml
@@ -1,0 +1,26 @@
+# >>> AUTO-GEN BEGIN: ci-optional-extras v1.0
+name: optional-extras
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  extras:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install core + selected extras
+        run: |
+          python -m pip install -U pip
+          pip install -e .[skyfield,catalogs,exporters]
+      - name: Run minimal tests
+        run: |
+          pytest -q
+# >>> AUTO-GEN END: ci-optional-extras v1.0

--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -45,6 +45,15 @@ from .ephemeris import (  # noqa: F401
     SwissEphemerisAdapter,
     refine_event,
 )
+from .events import (
+    LunationEvent,
+    EclipseEvent,
+    StationEvent,
+    ReturnEvent,
+    ProgressionEvent,
+    DirectionEvent,
+    ProfectionEvent,
+)
 from .fixedstars import skyfield_stars  # ENSURE-LINE
 from .infrastructure.environment import collect_environment_report
 from .infrastructure.environment import main as environment_report_main
@@ -144,6 +153,13 @@ __all__ = [
     "VALID_HOUSE_SYSTEMS",
     "collect_diagnostics",
     "maint_main",
+    "LunationEvent",
+    "EclipseEvent",
+    "StationEvent",
+    "ReturnEvent",
+    "ProgressionEvent",
+    "DirectionEvent",
+    "ProfectionEvent",
 ]
 
 try:  # pragma: no cover - package metadata not available during tests

--- a/astroengine/api.py
+++ b/astroengine/api.py
@@ -8,5 +8,25 @@ from __future__ import annotations
 
 from .core import TransitEngine
 from .core.api import TransitEvent, TransitScanConfig
+from .events import (
+    LunationEvent,
+    EclipseEvent,
+    StationEvent,
+    ReturnEvent,
+    ProgressionEvent,
+    DirectionEvent,
+    ProfectionEvent,
+)
 
-__all__ = ["TransitEvent", "TransitScanConfig", "TransitEngine"]
+__all__ = [
+    "TransitEvent",
+    "TransitScanConfig",
+    "TransitEngine",
+    "LunationEvent",
+    "EclipseEvent",
+    "StationEvent",
+    "ReturnEvent",
+    "ProgressionEvent",
+    "DirectionEvent",
+    "ProfectionEvent",
+]

--- a/astroengine/api_server.py
+++ b/astroengine/api_server.py
@@ -1,0 +1,27 @@
+# >>> AUTO-GEN BEGIN: api-skeleton v1.0
+from __future__ import annotations
+
+try:
+    from fastapi import FastAPI
+    from pydantic import BaseModel
+except Exception as e:  # pragma: no cover
+    FastAPI = None  # type: ignore
+
+app = FastAPI(title="AstroEngine API") if FastAPI else None
+
+class Health(BaseModel):
+    ok: bool
+
+if app:
+    @app.get("/health", response_model=Health)
+    def health() -> Health:  # pragma: no cover - trivial
+        return Health(ok=True)
+
+
+def run() -> None:
+    """Launch the API server if dependencies are installed."""
+    if app is None:
+        raise RuntimeError("API extra not installed. Use: pip install -e .[api]")
+    import uvicorn  # type: ignore
+    uvicorn.run(app, host="0.0.0.0", port=8099)
+# >>> AUTO-GEN END: api-skeleton v1.0

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from . import engine as engine_module
 from .engine import events_to_dicts, scan_contacts
 from .exporters import ParquetExporter, SQLiteExporter
 from .providers import list_providers
@@ -20,6 +21,23 @@ from .validation import (
 
 __all__ = ["build_parser", "main", "serialize_events_to_json", "json"]
 
+
+# >>> AUTO-GEN BEGIN: cli-new-detector-flags v1.0
+def _augment_parser_with_features(p: argparse.ArgumentParser) -> None:
+    targets = getattr(p, "_ae_feature_parsers", [p])
+    for target in targets:
+        if getattr(target, "_ae_features_added", False):
+            continue
+        g = target.add_argument_group("Detectors (experimental)")
+        g.add_argument("--lunations", action="store_true", help="Enable lunations detector")
+        g.add_argument("--eclipses", action="store_true", help="Enable eclipses detector")
+        g.add_argument("--stations", action="store_true", help="Enable stations detector")
+        g.add_argument("--progressions", action="store_true", help="Enable secondary progressions")
+        g.add_argument("--directions", action="store_true", help="Enable solar arc directions")
+        g.add_argument("--returns", action="store_true", help="Enable solar/lunar returns")
+        g.add_argument("--profections", action="store_true", help="Enable annual profections")
+        target._ae_features_added = True
+# >>> AUTO-GEN END: cli-new-detector-flags v1.0
 
 def serialize_events_to_json(events: Iterable) -> str:
     """Serialize events into a pretty-printed JSON string."""
@@ -34,6 +52,13 @@ def cmd_env(_: argparse.Namespace) -> int:
 
 
 def cmd_transits(args: argparse.Namespace) -> int:
+    engine_module.FEATURE_LUNATIONS = args.lunations
+    engine_module.FEATURE_ECLIPSES = args.eclipses
+    engine_module.FEATURE_STATIONS = args.stations
+    engine_module.FEATURE_PROGRESSIONS = args.progressions
+    engine_module.FEATURE_DIRECTIONS = args.directions
+    engine_module.FEATURE_RETURNS = args.returns
+    engine_module.FEATURE_PROFECTIONS = args.profections
     events = scan_contacts(
         start_iso=args.start,
         end_iso=args.end,
@@ -101,6 +126,9 @@ def build_parser() -> argparse.ArgumentParser:
     env_parser.set_defaults(func=cmd_env)
 
     transits = sub.add_parser("transits", help="Scan for transit contacts")
+    feature_targets = getattr(parser, "_ae_feature_parsers", [])
+    feature_targets.append(transits)
+    parser._ae_feature_parsers = feature_targets
     transits.add_argument("--start", required=True)
     transits.add_argument("--end", required=True)
     transits.add_argument("--moving", default="sun")
@@ -121,11 +149,13 @@ def build_parser() -> argparse.ArgumentParser:
     validate.add_argument("path")
     validate.set_defaults(func=cmd_validate)
 
+    _augment_parser_with_features(parser)
     return parser
 
 
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
+    _augment_parser_with_features(parser)
     namespace = parser.parse_args(list(argv) if argv is not None else None)
     return namespace.func(namespace)
 

--- a/astroengine/detectors/__init__.py
+++ b/astroengine/detectors/__init__.py
@@ -1,22 +1,31 @@
+"""Transit detectors and experimental modules."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable, List
 
-from .astro.declination import (
+from ..astro.declination import (
     antiscia_lon,
     contra_antiscia_lon,
     ecl_to_dec,
     is_contraparallel,
     is_parallel,
 )
-from .utils.angles import (
+from ..utils.angles import (
     classify_applying_separating,
     delta_angle,
     is_within_orb,
 )
 
-__all__ = ["CoarseHit", "detect_decl_contacts", "detect_antiscia_contacts"]
+from .lunations import find_lunations
+from .eclipses import find_eclipses
+from .stations import find_stations
+from .progressions import secondary_progressions
+from .directions import solar_arc_directions
+from .returns import solar_lunar_returns
+
+__all__ = ["CoarseHit", "detect_decl_contacts", "detect_antiscia_contacts", "find_lunations", "find_eclipses", "find_stations", "secondary_progressions", "solar_arc_directions", "solar_lunar_returns"]
 
 
 @dataclass

--- a/astroengine/detectors/directions.py
+++ b/astroengine/detectors/directions.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: detector-directions v1.0
+from __future__ import annotations
+from typing import List
+from ..events import DirectionEvent
+
+def solar_arc_directions(natal_ts: str, start_ts: str, end_ts: str) -> List[DirectionEvent]:
+    return []
+# >>> AUTO-GEN END: detector-directions v1.0

--- a/astroengine/detectors/eclipses.py
+++ b/astroengine/detectors/eclipses.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: detector-eclipses v1.0
+from __future__ import annotations
+from typing import List
+from ..events import EclipseEvent
+
+def find_eclipses(start_ut: float, end_ut: float) -> List[EclipseEvent]:
+    return []
+# >>> AUTO-GEN END: detector-eclipses v1.0

--- a/astroengine/detectors/lunations.py
+++ b/astroengine/detectors/lunations.py
@@ -1,0 +1,13 @@
+# >>> AUTO-GEN BEGIN: detector-lunations v1.0
+from __future__ import annotations
+from typing import List
+from ..events import LunationEvent
+
+# TODO: refine with elongation root-finding. For now, placeholder no-op.
+
+def find_lunations(start_ut: float, end_ut: float) -> List[LunationEvent]:
+    """Return [] for now; real implementation lands under profile flag.
+    Keeping stub so API/CLI wiring is complete.
+    """
+    return []
+# >>> AUTO-GEN END: detector-lunations v1.0

--- a/astroengine/detectors/progressions.py
+++ b/astroengine/detectors/progressions.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: detector-progressions v1.0
+from __future__ import annotations
+from typing import List
+from ..events import ProgressionEvent
+
+def secondary_progressions(natal_ts: str, start_ts: str, end_ts: str) -> List[ProgressionEvent]:
+    return []
+# >>> AUTO-GEN END: detector-progressions v1.0

--- a/astroengine/detectors/returns.py
+++ b/astroengine/detectors/returns.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: detector-returns v1.0
+from __future__ import annotations
+from typing import List
+from ..events import ReturnEvent
+
+def solar_lunar_returns(natal_ts: str, start_ts: str, end_ts: str, which: str = "solar") -> List[ReturnEvent]:
+    return []
+# >>> AUTO-GEN END: detector-returns v1.0

--- a/astroengine/detectors/stations.py
+++ b/astroengine/detectors/stations.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: detector-stations v1.0
+from __future__ import annotations
+from typing import List
+from ..events import StationEvent
+
+def find_stations(start_ut: float, end_ut: float, bodies: List[str]) -> List[StationEvent]:
+    return []
+# >>> AUTO-GEN END: detector-stations v1.0

--- a/astroengine/engine.py
+++ b/astroengine/engine.py
@@ -12,6 +12,17 @@ from .exporters import TransitEvent
 from .providers import get_provider
 from .scoring import ScoreInputs, compute_score
 
+# >>> AUTO-GEN BEGIN: engine-feature-flags v1.0
+# Feature flags (default OFF to preserve current behavior)
+FEATURE_LUNATIONS = False
+FEATURE_ECLIPSES = False
+FEATURE_STATIONS = False
+FEATURE_PROGRESSIONS = False
+FEATURE_DIRECTIONS = False
+FEATURE_RETURNS = False
+FEATURE_PROFECTIONS = False
+# >>> AUTO-GEN END: engine-feature-flags v1.0
+
 __all__ = ["events_to_dicts", "scan_contacts", "get_active_aspect_angles", "resolve_provider"]
 
 

--- a/astroengine/ephemeris/swisseph_adapter.py
+++ b/astroengine/ephemeris/swisseph_adapter.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from .utils import get_se_ephe_path
 import swisseph as swe
 
 __all__ = ["BodyPosition", "HousePositions", "SwissEphemerisAdapter"]
@@ -80,7 +81,7 @@ class SwissEphemerisAdapter:
             swe.set_ephe_path(str(ephemeris_path))
             return str(ephemeris_path)
 
-        env_path = os.environ.get("SE_EPHE_PATH")
+        env_path = get_se_ephe_path()
         if env_path:
             candidate = Path(env_path)
             if candidate.exists():

--- a/astroengine/ephemeris/utils.py
+++ b/astroengine/ephemeris/utils.py
@@ -1,0 +1,21 @@
+# >>> AUTO-GEN BEGIN: se-ephe-path-utils v1.0
+"""Shared utilities for ephemeris providers."""
+from __future__ import annotations
+import os
+from typing import Optional
+
+CANON_ENV = "SE_EPHE_PATH"
+ALT_ENV = "SWE_EPH_PATH"
+
+
+def get_se_ephe_path(default: Optional[str] = None) -> Optional[str]:
+    """Return ephemeris directory path.
+
+    Order: explicit arg > SE_EPHE_PATH > SWE_EPH_PATH > default.
+    """
+    return (
+        os.environ.get(CANON_ENV)
+        or os.environ.get(ALT_ENV)
+        or default
+    )
+# >>> AUTO-GEN END: se-ephe-path-utils v1.0

--- a/astroengine/events.py
+++ b/astroengine/events.py
@@ -1,0 +1,47 @@
+# >>> AUTO-GEN BEGIN: event-types v1.0
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Optional
+
+@dataclass(frozen=True)
+class LunationEvent:
+    kind: str  # "new", "first_quarter", "full", "last_quarter"
+    ts: str    # ISO-8601 UTC
+    lon_moon: float
+    lon_sun: float
+
+@dataclass(frozen=True)
+class EclipseEvent:
+    kind: str  # "solar" or "lunar"
+    ts: str
+    magnitude: Optional[float] = None
+
+@dataclass(frozen=True)
+class StationEvent:
+    body: str
+    kind: str  # "station_rx" or "station_dx"
+    ts: str
+
+@dataclass(frozen=True)
+class ReturnEvent:
+    body: str  # "Sun" (solar return) or "Moon" (lunar return)
+    ts: str
+
+@dataclass(frozen=True)
+class ProgressionEvent:
+    method: str  # "secondary"
+    body: str
+    ts: str
+
+@dataclass(frozen=True)
+class DirectionEvent:
+    method: str  # "solar_arc"
+    body: str
+    ts: str
+
+@dataclass(frozen=True)
+class ProfectionEvent:
+    level: int
+    start_ts: str
+    end_ts: str
+# >>> AUTO-GEN END: event-types v1.0

--- a/astroengine/exporters.py
+++ b/astroengine/exporters.py
@@ -15,11 +15,13 @@ except Exception:  # pragma: no cover
 try:  # pragma: no cover - optional dependency
     import pyarrow as pa
     import pyarrow.parquet as pq
+    _PARQUET_OK = True
 except Exception:  # pragma: no cover
     pa = None  # type: ignore[assignment]
     pq = None  # type: ignore[assignment]
+    _PARQUET_OK = False
 
-__all__ = ["TransitEvent", "SQLiteExporter", "ParquetExporter"]
+__all__ = ["TransitEvent", "SQLiteExporter", "ParquetExporter", "parquet_available"]
 
 
 @dataclass
@@ -130,3 +132,7 @@ class ParquetExporter:
         assert pa is not None and pq is not None  # for mypy/pyright
         table = pa.Table.from_pylist([event.to_dict() for event in events])
         pq.write_table(table, self.path)
+
+
+def parquet_available() -> bool:
+    return _PARQUET_OK

--- a/astroengine/narrative.py
+++ b/astroengine/narrative.py
@@ -1,0 +1,18 @@
+# >>> AUTO-GEN BEGIN: narrative-skeleton v1.0
+from __future__ import annotations
+from typing import Dict
+
+try:
+    from jinja2 import Template
+except Exception:  # pragma: no cover
+    Template = None  # type: ignore
+
+_DEFAULT = """
+{{ title }}\n\n{% for e in events %}- {{ e }}\n{% endfor %}
+"""
+
+def render_simple(title: str, events: Dict) -> str:
+    if Template is None:
+        raise RuntimeError("Narrative extra not installed. Use: pip install -e .[narrative]")
+    return Template(_DEFAULT).render(title=title, events=events)
+# >>> AUTO-GEN END: narrative-skeleton v1.0

--- a/astroengine/providers/__init__.py
+++ b/astroengine/providers/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, Protocol
 
+from .se_fixedstars import get_star_lonlat
 
 class EphemerisProvider(Protocol):
     """Minimal provider interface used by AstroEngine internals.

--- a/astroengine/providers/se_fixedstars.py
+++ b/astroengine/providers/se_fixedstars.py
@@ -1,1 +1,22 @@
+# >>> AUTO-GEN BEGIN: se-fixedstars-adapter v1.0
+"""Swiss Ephemeris fixed stars adapter (guarded, minimal).
 
+Exposes get_star_lonlat(name, jd_ut). Requires pyswisseph and star names
+supported by Swiss Ephemeris (e.g., "Aldebaran", "Regulus").
+"""
+from __future__ import annotations
+from typing import Tuple
+
+try:
+    import swisseph as swe  # type: ignore
+except Exception as e:  # pragma: no cover
+    swe = None  # type: ignore
+
+
+def get_star_lonlat(name: str, jd_ut: float) -> Tuple[float, float]:
+    if swe is None:
+        raise RuntimeError("pyswisseph not available; install astroengine[ephem]")
+    # Swiss returns ecliptic lon/lat in degrees via fixstar2
+    lon, lat, _dist = swe.fixstar2(name, jd_ut)
+    return float(lon), float(lat)
+# >>> AUTO-GEN END: se-fixedstars-adapter v1.0

--- a/astroengine/providers/skyfield_kernels.py
+++ b/astroengine/providers/skyfield_kernels.py
@@ -1,0 +1,49 @@
+# >>> AUTO-GEN BEGIN: skyfield-kernel-utils v1.0
+from __future__ import annotations
+from pathlib import Path
+from typing import Iterable, Optional
+
+_DEFAULT_NAMES = ("de440s.bsp", "de421.bsp")
+_SEARCH_DIRS: Iterable[Path] = (
+    Path.cwd() / "kernels",
+    Path.home() / ".skyfield",
+    Path.home() / ".astroengine" / "kernels",
+)
+
+
+def find_kernel(preferred: Optional[str] = None) -> Optional[Path]:
+    """Return path to an existing SPK kernel if found, else None."""
+    candidates = []
+    if preferred:
+        candidates.append(Path(preferred))
+    for d in _SEARCH_DIRS:
+        for name in _DEFAULT_NAMES:
+            candidates.append(d / name)
+    for c in candidates:
+        if c.is_file():
+            return c
+    return None
+
+
+def ensure_kernel(download: bool = False) -> Optional[Path]:
+    """Ensure a kernel is available; optionally download via skyfield Loader.
+    No-op if skyfield is not installed or download=False.
+    """
+    p = find_kernel()
+    if p:
+        return p
+    if not download:
+        return None
+    try:
+        from skyfield.api import Loader  # type: ignore
+    except Exception:
+        return None
+    target_dir = Path.home() / ".skyfield"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    load = Loader(str(target_dir))
+    try:
+        eph = load("de440s.bsp")
+        return Path(eph.filename)
+    except Exception:
+        return None
+# >>> AUTO-GEN END: skyfield-kernel-utils v1.0

--- a/astroengine/providers/swiss_provider.py
+++ b/astroengine/providers/swiss_provider.py
@@ -1,9 +1,10 @@
 # >>> AUTO-GEN BEGIN: AE Swiss Provider v1.0
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
 from typing import Dict, Iterable
+
+from astroengine.ephemeris.utils import get_se_ephe_path
 
 try:
     import swisseph as swe  # pyswisseph imports the module name 'swisseph'
@@ -62,7 +63,7 @@ class SwissProvider:
     def __init__(self) -> None:
         if swe is None:
             raise ImportError("pyswisseph is not installed")
-        eph = os.environ.get("SWE_EPH_PATH") or os.environ.get("SE_EPHE_PATH")
+        eph = get_se_ephe_path()
         if eph:
             swe.set_ephe_path(eph)
 

--- a/astroengine/timelords/__init__.py
+++ b/astroengine/timelords/__init__.py
@@ -1,0 +1,7 @@
+"""Timelord techniques such as profections."""
+
+from __future__ import annotations
+
+from .profections import annual_profections
+
+__all__ = ["annual_profections"]

--- a/astroengine/timelords/profections.py
+++ b/astroengine/timelords/profections.py
@@ -1,0 +1,8 @@
+# >>> AUTO-GEN BEGIN: timelords-profections v1.0
+from __future__ import annotations
+from typing import List
+from ..events import ProfectionEvent
+
+def annual_profections(natal_ts: str, years: int) -> List[ProfectionEvent]:
+    return []
+# >>> AUTO-GEN END: timelords-profections v1.0

--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -1,0 +1,9 @@
+# >>> AUTO-GEN BEGIN: docs-env-vars v1.0
+## Ephemeris data paths
+- **SE_EPHE_PATH** (canonical) — directory containing Swiss Ephemeris data files.
+- **SWE_EPH_PATH** (alias) — accepted for compatibility.
+
+## Skyfield kernels
+Searched in: `./kernels`, `~/.skyfield`, `~/.astroengine/kernels`. Use helper
+`astroengine.providers.skyfield_kernels.ensure_kernel(download=True)` to fetch `de440s.bsp`.
+# >>> AUTO-GEN END: docs-env-vars v1.0

--- a/docs/EXTRAS.md
+++ b/docs/EXTRAS.md
@@ -1,0 +1,21 @@
+# >>> AUTO-GEN BEGIN: docs-extras v1.0
+Install with extras:
+
+```bash
+pip install -e .[all]
+# or pick subsets
+pip install -e .[ephem,skyfield]
+```
+
+Extras:
+
+* `ephem` — Swiss ephemeris & pymeeus fallback
+* `skyfield` — Skyfield + JPL kernels
+* `catalogs` — `astroquery` integrations
+* `exporters` — Parquet/ICS
+* `api` — FastAPI server
+* `narrative` — Jinja2 rendering
+* `perf` — Numba acceleration
+* `cli` — Click/Rich/Pluggy polish
+
+# >>> AUTO-GEN END: docs-extras v1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,28 +1,87 @@
-# >>> AUTO-GEN BEGIN: packaging config v1.1
+# >>> AUTO-GEN BEGIN: packaging-and-extras v1.0
 [build-system]
-requires = ["setuptools>=69", "wheel"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "astroengine"
-version = "0.0.0"
-description = "AstroEngine — generated-first transit engine"
-authors = [{ name = "AstroEngine" }]
+version = "0.1.0"
+description = "AstroEngine — modular transit engine and astrology toolkit"
 readme = "README.md"
-requires-python = ">=3.11"
-dependencies = [
-  "pyyaml>=6.0.2",
+requires-python = ">=3.10"
+authors = [{ name = "AstroEngine Maintainers" }]
+license = { text = "MIT" }
+keywords = ["astrology", "ephemeris", "transits", "astronomy"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
 ]
 
-[tool.setuptools]
-include-package-data = true
-package-dir = {"" = "."}
+# Core runtime deps kept lean. Everything else under extras.
+dependencies = [
+  "numpy>=1.24",
+  "pandas>=2.0",
+  "python-dateutil>=2.8",
+  "PyYAML>=6.0",
+  "tzdata>=2023.3",
+]
 
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["astroengine*"]
-exclude = ["generated*"]
-# >>> AUTO-GEN END: packaging config v1.1
+[project.optional-dependencies]
+# Swiss ephemeris stack
+ephem = [
+  "pyswisseph>=2.10",
+  "pymeeus>=0.5.12",
+]
+# Skyfield provider + kernels
+skyfield = [
+  "skyfield>=1.48",
+  "jplephem>=2.21",
+]
+# Catalog lookups
+catalogs = [
+  "astroquery>=0.4",
+]
+# Exporters
+exporters = [
+  "pyarrow>=15",
+  "ics>=0.7",
+]
+# API + narrative
+api = [
+  "fastapi>=0.110",
+  "uvicorn[standard]>=0.23",
+]
+
+narrative = [
+  "jinja2>=3.1",
+]
+# Performance (optional)
+perf = [
+  "numba>=0.58",
+]
+# CLI polish / plugins (optional)
+cli = [
+  "click>=8.1",
+  "rich>=13.7",
+  "pluggy>=1.3",
+]
+# All the things
+all = [
+  "astroengine[ephem,skyfield,catalogs,exporters,api,narrative,perf,cli]",
+]
+
+[project.urls]
+Homepage = "https://github.com/rinward23/AstroEngine"
+
+[project.scripts]
+astroengine = "astroengine.cli:main"
+astroengine-api = "astroengine.api_server:run"  # guarded import; only works with [api]
+
+[tool.setuptools]
+# Install the real package directory (not the generated skeleton only)
+packages = { find = { where = ["."], include = ["astroengine*"] } }
+include-package-data = true
+# >>> AUTO-GEN END: packaging-and-extras v1.0
 
 # >>> AUTO-GEN BEGIN: ruff target py311 v1.1
 [tool.ruff]

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,15 +1,15 @@
-# >>> AUTO-GEN BEGIN: Optional Runtime Requirements v1.0
-# Optional providers / services
-skyfield
-# Web API (when you expose a service)
-fastapi
-uvicorn
-# Narrative templating
-jinja2
-# Performance experiments
-numba
-# Calendar export
-ics
-# DataFrame convenience (only if you plan to use pandas)
-pandas
-# >>> AUTO-GEN END: Optional Runtime Requirements v1.0
+# >>> AUTO-GEN BEGIN: optional-reqs v1.0
+# Mirrors pyproject extras for non-pep517 workflows
+skyfield>=1.48
+jplephem>=2.21
+astroquery>=0.4
+fastapi>=0.110
+uvicorn[standard]>=0.23
+jinja2>=3.1
+pyarrow>=15
+ics>=0.7
+numba>=0.58
+click>=8.1
+rich>=13.7
+pluggy>=1.3
+# >>> AUTO-GEN END: optional-reqs v1.0

--- a/tests/test_exporter_parquet_guard.py
+++ b/tests/test_exporter_parquet_guard.py
@@ -1,0 +1,7 @@
+# >>> AUTO-GEN BEGIN: tests-parquet-guard v1.0
+from __future__ import annotations
+from astroengine.exporters import parquet_available
+
+def test_parquet_guard_imports():
+    assert isinstance(parquet_available(), bool)
+# >>> AUTO-GEN END: tests-parquet-guard v1.0

--- a/tests/test_feature_flags_off.py
+++ b/tests/test_feature_flags_off.py
@@ -1,0 +1,15 @@
+# >>> AUTO-GEN BEGIN: tests-feature-flags v1.0
+from __future__ import annotations
+import importlib
+
+
+def test_experimental_detectors_default_off():
+    eng = importlib.import_module("astroengine.engine")
+    assert getattr(eng, "FEATURE_LUNATIONS", False) is False
+    assert getattr(eng, "FEATURE_ECLIPSES", False) is False
+    assert getattr(eng, "FEATURE_STATIONS", False) is False
+    assert getattr(eng, "FEATURE_PROGRESSIONS", False) is False
+    assert getattr(eng, "FEATURE_DIRECTIONS", False) is False
+    assert getattr(eng, "FEATURE_RETURNS", False) is False
+    assert getattr(eng, "FEATURE_PROFECTIONS", False) is False
+# >>> AUTO-GEN END: tests-feature-flags v1.0


### PR DESCRIPTION
## Summary
- align the pyproject with the real ``astroengine`` package, optional extras, and CLI/API entry points
- add event dataclasses plus detector and timelord stubs wired behind new engine and CLI feature flags
- supply Swiss ephemeris path helpers, Skyfield kernel discovery, API/narrative skeletons, docs, and smoke tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf8cc4178083249662777e23d78366