### PR TITLE
Implement experimental lunation and station detectors

### DIFF
--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -9,6 +9,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
+from .detectors import find_lunations, find_stations, solar_lunar_returns  # type: ignore
+from .detectors.common import UNIX_EPOCH_JD
 from .engine import events_to_dicts, scan_contacts
 from .exporters import ParquetExporter, SQLiteExporter
 from .providers import list_providers
@@ -93,9 +95,47 @@ def cmd_validate(args: argparse.Namespace) -> int:
     return 0
 
 
+def _iso_to_jd(iso_ts: str) -> float:
+    dt = datetime.fromisoformat(iso_ts.replace('Z', '+00:00')).astimezone(timezone.utc)
+    return (dt.timestamp() / 86400.0) + UNIX_EPOCH_JD
+
+
+def run_experimental(args) -> None:
+    # Expect args.start_utc, args.end_utc in ISO-8601, and feature flags
+    if not any([args.lunations, args.stations, args.returns]):
+        return
+    if not args.start_utc or not args.end_utc:
+        print("experimental detectors require --start-utc and --end-utc; skipping")
+        return
+    start_jd = _iso_to_jd(args.start_utc)
+    end_jd = _iso_to_jd(args.end_utc)
+    if args.lunations:
+        ev = find_lunations(start_jd, end_jd)
+        print(f"lunations: {len(ev)} events")
+    if args.stations:
+        ev = find_stations(start_jd, end_jd, None)
+        print(f"stations: {len(ev)} events")
+    if args.returns:
+        # need args.natal_utc and args.return_kind
+        if not getattr(args, 'natal_utc', None):
+            print("returns: missing --natal-utc; skipping")
+        else:
+            natal_jd = _iso_to_jd(args.natal_utc)
+            which = getattr(args, 'return_kind', 'solar')
+            ev = solar_lunar_returns(natal_jd, start_jd, end_jd, which)
+            print(f"{which}-returns: {len(ev)} events")
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="astroengine", description="AstroEngine CLI")
-    sub = parser.add_subparsers(dest="command", required=True)
+    parser.add_argument("--start-utc", help="Start timestamp (ISO-8601) for experimental detectors")  # ENSURE-LINE
+    parser.add_argument("--end-utc", help="End timestamp (ISO-8601) for experimental detectors")  # ENSURE-LINE
+    parser.add_argument("--natal-utc", help="Natal timestamp (ISO-8601) for return calculations")  # ENSURE-LINE
+    parser.add_argument("--return-kind", default="solar", help="Return kind: solar or lunar")  # ENSURE-LINE
+    parser.add_argument("--lunations", action="store_true", help="Run lunation detector")
+    parser.add_argument("--stations", action="store_true", help="Run planetary station detector")
+    parser.add_argument("--returns", action="store_true", help="Run solar/lunar return detector")
+    sub = parser.add_subparsers(dest="command")
 
     env_parser = sub.add_parser("env", help="List registered providers")
     env_parser.set_defaults(func=cmd_env)
@@ -127,7 +167,13 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Iterable[str] | None = None) -> int:
     parser = build_parser()
     namespace = parser.parse_args(list(argv) if argv is not None else None)
-    return namespace.func(namespace)
+    run_experimental(namespace)
+    func = getattr(namespace, "func", None)
+    if func is not None:
+        return func(namespace)
+    if not any((namespace.lunations, namespace.stations, namespace.returns)):
+        parser.print_help()
+    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/astroengine/detectors/__init__.py
+++ b/astroengine/detectors/__init__.py
@@ -3,20 +3,33 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, List
 
-from .astro.declination import (
+from ..astro.declination import (
     antiscia_lon,
     contra_antiscia_lon,
     ecl_to_dec,
     is_contraparallel,
     is_parallel,
 )
-from .utils.angles import (
+from ..utils.angles import (
     classify_applying_separating,
     delta_angle,
     is_within_orb,
 )
+from .common import jd_to_iso  # ENSURE-LINE noqa: F401
+from .common import norm360, delta_deg, refine_zero_secant_bisect  # ENSURE-LINE noqa: F401
 
-__all__ = ["CoarseHit", "detect_decl_contacts", "detect_antiscia_contacts"]
+from .lunations import find_lunations  # noqa: F401
+from .returns import solar_lunar_returns  # noqa: F401
+from .stations import find_stations  # noqa: F401
+
+__all__ = [
+    "CoarseHit",
+    "detect_decl_contacts",
+    "detect_antiscia_contacts",
+    "find_lunations",
+    "find_stations",
+    "solar_lunar_returns",
+]
 
 
 @dataclass

--- a/astroengine/detectors/common.py
+++ b/astroengine/detectors/common.py
@@ -1,0 +1,135 @@
+# >>> AUTO-GEN BEGIN: detector-common v1.0
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Callable
+import math
+from datetime import datetime, timezone, timedelta
+
+# --- Angle helpers -----------------------------------------------------------
+
+def norm360(x: float) -> float:
+    x = math.fmod(x, 360.0)
+    return x + 360.0 if x < 0 else x
+
+
+def delta_deg(a: float, b: float) -> float:
+    """Signed smallest angular difference a-b in degrees in [-180, +180]."""
+    d = norm360(a) - norm360(b)
+    if d > 180.0:
+        d -= 360.0
+    elif d < -180.0:
+        d += 360.0
+    return d
+
+
+# --- Time helpers ------------------------------------------------------------
+UNIX_EPOCH_JD = 2440587.5  # JD at 1970-01-01T00:00:00Z
+
+
+def jd_to_iso(jd_ut: float) -> str:
+    seconds = (jd_ut - UNIX_EPOCH_JD) * 86400.0
+    dt = datetime(1970, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=seconds)
+    return dt.replace(microsecond=0).isoformat().replace('+00:00', 'Z')
+
+
+# --- Swiss Ephemeris access --------------------------------------------------
+@dataclass
+class _SwissCtx:
+    ok: bool
+
+
+_SWISS = _SwissCtx(ok=False)
+
+
+def _ensure_swiss() -> bool:
+    if _SWISS.ok:
+        return True
+    try:
+        import swisseph as swe  # type: ignore
+        from ..ephemeris.utils import get_se_ephe_path  # local helper
+        ephe = get_se_ephe_path(None)
+        if ephe:
+            swe.set_ephe_path(ephe)
+        _SWISS.ok = True
+        return True
+    except Exception:
+        return False
+
+
+def sun_lon(jd_ut: float) -> float:
+    if not _ensure_swiss():
+        raise RuntimeError("pyswisseph unavailable; install extras: astroengine[ephem]")
+    import swisseph as swe  # type: ignore
+    lon, lat, dist, speed_lon = swe.calc_ut(jd_ut, swe.SUN)
+    return float(lon)
+
+
+def moon_lon(jd_ut: float) -> float:
+    if not _ensure_swiss():
+        raise RuntimeError("pyswisseph unavailable; install extras: astroengine[ephem]")
+    import swisseph as swe  # type: ignore
+    lon, lat, dist, speed_lon = swe.calc_ut(jd_ut, swe.MOON)
+    return float(lon)
+
+
+def body_lon(jd_ut: float, body_name: str) -> float:
+    if not _ensure_swiss():
+        raise RuntimeError("pyswisseph unavailable; install extras: astroengine[ephem]")
+    import swisseph as swe  # type: ignore
+    name = body_name.lower()
+    code = {
+        'mercury': swe.MERCURY,
+        'venus': swe.VENUS,
+        'mars': swe.MARS,
+        'jupiter': swe.JUPITER,
+        'saturn': swe.SATURN,
+        'uranus': swe.URANUS,
+        'neptune': swe.NEPTUNE,
+        'pluto': swe.PLUTO,
+    }[name]
+    lon, lat, dist, speed_lon = swe.calc_ut(jd_ut, code)
+    return float(lon)
+
+
+# --- Root finding ------------------------------------------------------------
+
+def refine_zero_secant_bisect(f: Callable[[float], float], a: float, b: float, tol_deg: float = 1e-4, max_iter: int = 24) -> float:
+    """Find t in [a,b] where f(t)=0 in degrees. Angles allowed; uses secant then bisection."""
+    fa, fb = f(a), f(b)
+    # If either endpoint is already close enough
+    if abs(fa) <= tol_deg:
+        return a
+    if abs(fb) <= tol_deg:
+        return b
+    x0, x1 = a, b
+    f0, f1 = fa, fb
+    for _ in range(max_iter):
+        # Secant step
+        if (f1 - f0) == 0:
+            xm = 0.5 * (x0 + x1)
+        else:
+            xm = x1 - f1 * (x1 - x0) / (f1 - f0)
+        fm = f(xm)
+        # Narrow the bracket by sign (wrap-insensitive by numeric sign of fm)
+        if abs(fm) <= tol_deg:
+            return xm
+        # choose subinterval that contains a sign change or smaller abs
+        if (f0 > 0 and fm < 0) or (f0 < 0 and fm > 0):
+            x1, f1 = xm, fm
+        else:
+            x0, f0 = xm, fm
+        # Fallback bisection if secant diverges
+        if not (min(x0, x1) <= xm <= max(x0, x1)):
+            xm = 0.5 * (x0 + x1)
+    # Final bisection
+    for _ in range(32):
+        xm = 0.5 * (x0 + x1)
+        fm = f(xm)
+        if abs(fm) <= tol_deg:
+            return xm
+        if (f0 > 0 and fm < 0) or (f0 < 0 and fm > 0):
+            x1, f1 = xm, fm
+        else:
+            x0, f0 = xm, fm
+    return 0.5 * (x0 + x1)
+# >>> AUTO-GEN END: detector-common v1.0

--- a/astroengine/detectors/lunations.py
+++ b/astroengine/detectors/lunations.py
@@ -1,0 +1,55 @@
+# >>> AUTO-GEN BEGIN: detector-lunations v2.0
+from __future__ import annotations
+from typing import List, Tuple
+from .common import jd_to_iso, delta_deg, norm360, refine_zero_secant_bisect, sun_lon, moon_lon
+
+# Targets for elongation (Moon - Sun)
+_TARGETS: List[Tuple[str, float]] = [
+    ("new", 0.0),
+    ("first_quarter", 90.0),
+    ("full", 180.0),
+    ("last_quarter", 270.0),
+]
+
+
+def _f_elong(target: float):
+    return lambda jd: delta_deg(moon_lon(jd) - sun_lon(jd), target)
+
+
+def find_lunations(start_ut: float, end_ut: float) -> List["LunationEvent"]:
+    from ..events import LunationEvent
+    if start_ut >= end_ut:
+        return []
+    out: List[LunationEvent] = []
+    step = 0.5  # days; safe to bracket quarters (~7.38d spacing)
+    jd = start_ut
+    while jd < end_ut:
+        jd_next = min(jd + step, end_ut)
+        for kind, ang in _TARGETS:
+            f = _f_elong(ang)
+            a, b = jd, jd_next
+            fa, fb = f(a), f(b)
+            # Bracket if sign change or near-zero at either end
+            if (fa == 0.0) or (fb == 0.0) or (fa > 0 and fb < 0) or (fa < 0 and fb > 0) or (abs(fa) < 5.0 and abs(fb) < 5.0 and abs(fa - fb) > 5.0):
+                t = refine_zero_secant_bisect(f, a, b, tol_deg=1e-4)
+                ts = jd_to_iso(t)
+                lon_m = norm360(moon_lon(t))
+                lon_s = norm360(sun_lon(t))
+                out.append(LunationEvent(kind=kind, ts=ts, lon_moon=lon_m, lon_sun=lon_s))
+        jd = jd_next
+    # Sort & de-dup within 3 hours (rare double-detection at boundaries)
+    out.sort(key=lambda e: e.ts)
+    dedup: List[LunationEvent] = []
+    def _parse(ts: str):
+        from datetime import datetime, timezone
+        return datetime.fromisoformat(ts.replace('Z', '+00:00')).replace(tzinfo=timezone.utc)
+    for e in out:
+        if not dedup:
+            dedup.append(e)
+            continue
+        dt_prev = _parse(dedup[-1].ts)
+        dt_cur = _parse(e.ts)
+        if (dt_cur - dt_prev).total_seconds() > 3 * 3600:
+            dedup.append(e)
+    return dedup
+# >>> AUTO-GEN END: detector-lunations v2.0

--- a/astroengine/detectors/returns.py
+++ b/astroengine/detectors/returns.py
@@ -1,0 +1,35 @@
+# >>> AUTO-GEN BEGIN: detector-returns v2.0
+from __future__ import annotations
+from typing import List
+from .common import jd_to_iso, sun_lon, moon_lon, delta_deg, refine_zero_secant_bisect
+
+
+def _lon_fn(which: str):
+    w = which.lower()
+    if w == "solar" or w == "sun":
+        return sun_lon
+    if w == "lunar" or w == "moon":
+        return moon_lon
+    raise ValueError("which must be 'solar' or 'lunar'")
+
+
+def solar_lunar_returns(natal_jd_ut: float, start_ut: float, end_ut: float, which: str = "solar") -> List["ReturnEvent"]:
+    from ..events import ReturnEvent
+    if start_ut >= end_ut:
+        return []
+    lon_fn = _lon_fn(which)
+    target = lon_fn(natal_jd_ut)
+    out: List[ReturnEvent] = []
+    step = 1.0 if which == "solar" else 0.25  # Moon laps monthly
+    jd = start_ut
+    f = lambda t: delta_deg(lon_fn(t), target)
+    while jd < end_ut:
+        jd_next = min(jd + step, end_ut)
+        fa, fb = f(jd), f(jd_next)
+        if (fa == 0.0) or (fb == 0.0) or (fa > 0 and fb < 0) or (fa < 0 and fb > 0):
+            t = refine_zero_secant_bisect(f, jd, jd_next, tol_deg=1e-5)
+            out.append(ReturnEvent(body=which.lower(), ts=jd_to_iso(t)))
+        jd = jd_next
+    out.sort(key=lambda e: e.ts)
+    return out
+# >>> AUTO-GEN END: detector-returns v2.0

--- a/astroengine/detectors/stations.py
+++ b/astroengine/detectors/stations.py
@@ -1,0 +1,38 @@
+# >>> AUTO-GEN BEGIN: detector-stations v2.0
+from __future__ import annotations
+from typing import List
+from .common import jd_to_iso, body_lon, delta_deg, refine_zero_secant_bisect
+
+_DEF_BODIES = ["mercury", "venus", "mars", "jupiter", "saturn", "uranus", "neptune", "pluto"]
+
+
+def _rate(jd: float, body: str, h: float = 0.25) -> float:
+    # central difference degrees/day with wrap handling
+    la = body_lon(jd - h, body)
+    lb = body_lon(jd + h, body)
+    return delta_deg(lb, la) / (2.0 * h)
+
+
+def find_stations(start_ut: float, end_ut: float, bodies: List[str] | None = None) -> List["StationEvent"]:
+    from ..events import StationEvent
+    bodies = bodies or _DEF_BODIES
+    out: List[StationEvent] = []
+    step = 1.0  # days; stations span days, this brackets well
+    for b in bodies:
+        jd = start_ut
+        prev = _rate(jd, b)
+        while jd < end_ut:
+            jd_next = min(jd + step, end_ut)
+            cur = _rate(jd_next, b)
+            if (prev == 0.0) or (cur == 0.0) or (prev > 0 and cur < 0) or (prev < 0 and cur > 0):
+                # refine zero of rate function
+                f = lambda t: _rate(t, b)
+                t = refine_zero_secant_bisect(f, jd, jd_next, tol_deg=1e-6)
+                # Determine kind by inspecting rate epsilon after
+                eps = _rate(t + 0.02, b)
+                kind = "station_rx" if eps < 0 else "station_dx"
+                out.append(StationEvent(body=b.capitalize(), kind=kind, ts=jd_to_iso(t)))
+            jd, prev = jd_next, cur
+    out.sort(key=lambda e: e.ts)
+    return out
+# >>> AUTO-GEN END: detector-stations v2.0

--- a/astroengine/ephemeris/utils.py
+++ b/astroengine/ephemeris/utils.py
@@ -1,0 +1,21 @@
+"""Utility helpers for Swiss ephemeris configuration."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+
+__all__ = ["get_se_ephe_path"]
+
+
+def get_se_ephe_path(default: Optional[str] = None) -> Optional[str]:
+    """Return the configured Swiss ephemeris path if one is available."""
+
+    for env_var in ("SE_EPHE_PATH", "SWE_EPH_PATH", "ASTROENGINE_EPHEMERIS_PATH"):
+        value = os.environ.get(env_var)
+        if value:
+            candidate = Path(value)
+            if candidate.exists():
+                return str(candidate)
+    return default

--- a/astroengine/events.py
+++ b/astroengine/events.py
@@ -1,0 +1,28 @@
+"""Lightweight event containers for experimental detectors."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = ["LunationEvent", "StationEvent", "ReturnEvent"]
+
+
+@dataclass(slots=True)
+class LunationEvent:
+    kind: str
+    ts: str
+    lon_moon: float
+    lon_sun: float
+
+
+@dataclass(slots=True)
+class StationEvent:
+    body: str
+    kind: str
+    ts: str
+
+
+@dataclass(slots=True)
+class ReturnEvent:
+    body: str
+    ts: str

--- a/tests/test_lunations_impl.py
+++ b/tests/test_lunations_impl.py
@@ -1,0 +1,35 @@
+# >>> AUTO-GEN BEGIN: tests-lunations v1.0
+from __future__ import annotations
+import os
+import pytest
+
+try:
+    import swisseph as swe  # type: ignore
+    HAVE_SWISS = True
+except Exception:
+    HAVE_SWISS = False
+
+SE_OK = bool(os.environ.get("SE_EPHE_PATH") or os.environ.get("SWE_EPH_PATH"))
+
+pytestmark = pytest.mark.skipif(not (HAVE_SWISS and SE_OK), reason="Swiss ephemeris not available")
+
+from astroengine.detectors.lunations import find_lunations
+from astroengine.detectors.common import UNIX_EPOCH_JD
+
+
+def iso_to_jd(iso_ts: str) -> float:
+    from datetime import datetime, timezone
+    dt = datetime.fromisoformat(iso_ts.replace('Z', '+00:00')).astimezone(timezone.utc)
+    return (dt.timestamp()/86400.0) + UNIX_EPOCH_JD
+
+
+def test_lunations_count_and_order():
+    # September 2025 window
+    start = iso_to_jd("2025-09-01T00:00:00Z")
+    end = iso_to_jd("2025-10-01T00:00:00Z")
+    ev = find_lunations(start, end)
+    assert len(ev) >= 3
+    # strictly increasing timestamps
+    ts = [e.ts for e in ev]
+    assert ts == sorted(ts)
+# >>> AUTO-GEN END: tests-lunations v1.0

--- a/tests/test_stations_impl.py
+++ b/tests/test_stations_impl.py
@@ -1,0 +1,31 @@
+# >>> AUTO-GEN BEGIN: tests-stations v1.0
+from __future__ import annotations
+import os
+import pytest
+
+try:
+    import swisseph as swe  # type: ignore
+    HAVE_SWISS = True
+except Exception:
+    HAVE_SWISS = False
+
+SE_OK = bool(os.environ.get("SE_EPHE_PATH") or os.environ.get("SWE_EPH_PATH"))
+
+pytestmark = pytest.mark.skipif(not (HAVE_SWISS and SE_OK), reason="Swiss ephemeris not available")
+
+from astroengine.detectors.stations import find_stations
+from astroengine.detectors.common import UNIX_EPOCH_JD
+
+
+def iso_to_jd(iso_ts: str) -> float:
+    from datetime import datetime, timezone
+    dt = datetime.fromisoformat(iso_ts.replace('Z', '+00:00')).astimezone(timezone.utc)
+    return (dt.timestamp()/86400.0) + UNIX_EPOCH_JD
+
+
+def test_stations_basic():
+    start = iso_to_jd("2025-01-01T00:00:00Z")
+    end = iso_to_jd("2025-12-31T00:00:00Z")
+    ev = find_stations(start, end)
+    assert isinstance(ev, list)
+# >>> AUTO-GEN END: tests-stations v1.0


### PR DESCRIPTION
## Summary
- refactor the detectors module into a package with shared helpers and Swiss ephemeris access
- add lunation, planetary station, and solar/lunar return detectors with associated events
- integrate experimental detector flags into the CLI and add skip-aware tests for lunations and stations

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cf8ded88688324a4e8c348ff6e6801