### PR TITLE
Add merge-conflict guards and git hook tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# >>> AUTO-GEN BEGIN: Merge Attributes v1.0
+
+# Normalize line endings and reduce trivial conflicts
+
+* text=auto eol=lf
+
+# Markdown/docs often tolerate union merges better than hard conflicts
+
+*.md merge=union
+
+# >>> AUTO-GEN END: Merge Attributes v1.0

--- a/.github/workflows/conflict-guard.yml
+++ b/.github/workflows/conflict-guard.yml
@@ -1,0 +1,20 @@
+# >>> AUTO-GEN BEGIN: Conflict Guard CI v1.0
+name: Conflict Marker Guard
+on:
+  pull_request:
+    branches: [main, trunk]
+  push:
+    branches: [main]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fail on merge conflict markers
+        shell: bash
+        run: |
+          if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .; then
+            echo "::error::Merge conflict markers found. Resolve before pushing."
+            exit 1
+          fi
+# >>> AUTO-GEN END: Conflict Guard CI v1.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,19 @@
-# >>> AUTO-GEN BEGIN: pre-commit config v1.0
+# >>> AUTO-GEN BEGIN: Pre-commit Hooks v1.0
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.8
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+      - id: check-yaml
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.6.9
     hooks:
       - id: ruff
         args: ["--fix"]
@@ -17,4 +29,4 @@ repos:
         entry: python scripts/validators/validate_registry.py
         language: system
         files: '^registry/'
-# >>> AUTO-GEN END: pre-commit config v1.0
+# >>> AUTO-GEN END: Pre-commit Hooks v1.0

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,17 @@
 # >>> AUTO-GEN BEGIN: Makefile v1.1
-.PHONY: help setup fmt lint test doctor clean fullcheck repair build
+.PHONY: help setup hooks fmt lint lint-code test doctor clean fullcheck repair build
 
 help:
-	@echo "Targets: setup, fmt, lint, test, doctor, clean, fullcheck, repair, build"
+	@echo "Targets: setup, hooks, fmt, lint, lint-code, test, doctor, clean, fullcheck, repair, build"
 
 setup:
 	python -m pip install --upgrade pip
 	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 	@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
-	@which pre-commit >/dev/null 2>&1 && pre-commit install || true
+
+hooks:
+	python -m pip install -U pre-commit
+	python -m pre_commit install-hooks
 
 fmt:
 	ruff check --fix . || true
@@ -16,6 +19,9 @@ fmt:
 	isort --profile=black . || true
 
 lint:
+	python -m pre_commit run --all-files
+
+lint-code:
 	ruff check .
 	black --check .
 	isort --check-only --profile=black .

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -1,0 +1,43 @@
+# >>> AUTO-GEN BEGIN: DEV Bootstrap v1.0
+## Local Git hygiene
+
+- Enable Git to remember conflict resolutions you make once:
+  ```bash
+  git config --global rerere.enabled true
+  ```
+
+- Prefer rebases over merge commits when pulling:
+  ```bash
+  git config --global pull.rebase true
+  git config --global rebase.autoStash true
+  ```
+
+## Pre-commit hooks
+
+Install once per clone:
+
+```bash
+make hooks
+```
+
+This adds a *merge-conflict* check so commits fail if `<<<<<<<`, `=======`, `>>>>>>>` markers exist.
+
+## Repo git hooks
+
+```bash
+bash scripts/setup_git_hooks.sh
+```
+
+This sets Git to use the repo-managed `pre-commit` and `pre-push` hooks automatically.
+
+## Typical update flow
+
+```bash
+# Keep feature branch fresh before committing/pushing
+git fetch origin
+git rebase --rebase-merges origin/main
+# fix if prompted, run tests
+make lint
+```
+
+# >>> AUTO-GEN END: DEV Bootstrap v1.0

--- a/docs/merge-strategy.md
+++ b/docs/merge-strategy.md
@@ -1,0 +1,41 @@
+# >>> AUTO-GEN BEGIN: Merge Strategy Guide v1.0
+
+## Quick rules
+
+1. Rebase your feature branch on `origin/main` *before* you push or open a PR.
+2. If you see conflict blocks, keep only the code you want and delete the markers.
+3. Use built-ins if you want one side entirely:
+
+   * Keep ours: `git checkout --ours path/to/file`
+   * Keep theirs: `git checkout --theirs path/to/file`
+   * Then `git add` + `git commit`.
+4. Train Git to remember: `git config --global rerere.enabled true`.
+
+## Standard flow (developer)
+
+```bash
+git fetch origin
+git rebase --rebase-merges origin/main
+# resolve if asked, run tests
+make lint
+# push safely
+git push --force-with-lease
+```
+
+## When conflicts keep returning
+
+* Prefer smaller PRs; rebase daily.
+* Avoid editing generated files by hand.
+* If two branches touch the same function, agree on one branch to land first; rebase the other.
+
+## FAQ
+
+**Q: I want “theirs” version for a file.**
+
+```bash
+git checkout --theirs path/to/file && git add path/to/file && git commit
+```
+
+**Q: My push is blocked by the hook.** It means you’re behind or have markers. Rebase and/or clean markers, then push.
+
+# >>> AUTO-GEN END: Merge Strategy Guide v1.0

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! python -m pre_commit --version >/dev/null 2>&1; then
+  echo "[pre-commit hook] pre-commit is not installed. Run: make hooks" >&2
+  exit 1
+fi
+
+python -m pre_commit run "$@"

--- a/scripts/githooks/pre-push
+++ b/scripts/githooks/pre-push
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+remote="$1"
+url="${2:-}"
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+# Ensure upstream set
+if ! git rev-parse --abbrev-ref "@{u}" >/dev/null 2>&1; then
+  echo "[pre-push] No upstream set for $branch. Run: git push -u origin $branch"
+  exit 1
+fi
+
+# Block pushing if behind upstream (enforce rebase-first)
+ahead=$(git rev-list --count @{u}..HEAD)
+behind=$(git rev-list --count HEAD..@{u})
+if (( behind > 0 )); then
+  echo "[pre-push] Your branch is behind upstream by $behind commits. Rebase first:"
+  echo "  git fetch origin && git rebase --rebase-merges @{u}"
+  exit 1
+fi
+
+# Block conflict markers anywhere
+if git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- . >/dev/null; then
+  echo "[pre-push] Merge conflict markers found. Resolve them before pushing."
+  git grep -n -E '^(<<<<<<<|=======|>>>>>>>)' -- .
+  exit 1
+fi
+
+exit 0

--- a/scripts/setup_git_hooks.sh
+++ b/scripts/setup_git_hooks.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+mkdir -p scripts/githooks
+chmod +x scripts/githooks/pre-commit
+chmod +x scripts/githooks/pre-push
+
+# Use repo-scoped hooks path so collaborators inherit hooks
+git config core.hooksPath scripts/githooks
+printf "Repo git hooks installed.\n"


### PR DESCRIPTION
## Summary
- expand the pre-commit configuration to include conflict-marker detection, formatting hooks, and keep existing validators
- add developer helpers for installing the hooks, repo-level git hook scripts, and documentation on using them
- introduce CI and git attributes to block conflict markers and smooth merges

## Testing
- make hooks
- python -m pre_commit run

------
https://chatgpt.com/codex/tasks/task_e_68d178a6a6f08324b6362fbdd4558154