### PR TITLE
Centralize filesystem paths and align module metadata

### DIFF
--- a/astroengine/catalogs/sbdb.py
+++ b/astroengine/catalogs/sbdb.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from typing import Any, Dict
 
-CACHE_DIR = Path(__file__).resolve().parent.parent / "datasets" / "sbdb_cache"
+from ..infrastructure.paths import datasets_dir
+
+CACHE_DIR = datasets_dir() / "sbdb_cache"
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
 try:

--- a/astroengine/data/__init__.py
+++ b/astroengine/data/__init__.py
@@ -11,6 +11,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..infrastructure.paths import package_root as _package_root
+from ..infrastructure.paths import project_root as _project_root
+from ..infrastructure.paths import schemas_dir as _schemas_dir
+
 __all__ = [
     "PACKAGE_ROOT",
     "ASTROENGINE_ROOT",
@@ -21,9 +25,9 @@ __all__ = [
 ]
 
 PACKAGE_ROOT = Path(__file__).resolve().parent
-ASTROENGINE_ROOT = PACKAGE_ROOT.parent
-REPO_ROOT = ASTROENGINE_ROOT.parent
-SCHEMA_DIR = REPO_ROOT / "schemas"
+ASTROENGINE_ROOT = _package_root()
+REPO_ROOT = _project_root()
+SCHEMA_DIR = _schemas_dir()
 
 
 def project_root() -> Path:

--- a/astroengine/detectors_aspects.py
+++ b/astroengine/detectors_aspects.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Dict, Iterable, List
 
 from .core.bodies import body_class
+from .infrastructure.paths import profiles_dir
 from .utils.angles import classify_applying_separating, delta_angle, is_within_orb
 
 __all__ = ["AspectHit", "detect_aspects"]
@@ -29,7 +30,7 @@ class AspectHit:
     applying_or_separating: str
 
 
-_DEF_PATH = Path(__file__).resolve().parents[1] / "profiles" / "aspects_policy.json"
+_DEF_PATH = profiles_dir() / "aspects_policy.json"
 
 
 def _load_policy(path: str | None = None) -> dict:

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -15,6 +15,7 @@ from .core.domains import (
     DomainResolver,
     natal_domain_factor,
 )
+from .infrastructure.paths import profiles_dir
 
 __all__ = [
     "DOMAINS",
@@ -61,8 +62,8 @@ class DomainScore:
         return sum(ch.score for ch in self.channels.values())
 
 
-_DEF_TREE = Path(__file__).resolve().parent.parent / "profiles" / "domain_tree.json"
-_DEF_MAP = Path(__file__).resolve().parent.parent / "profiles" / "domain_mapping.json"
+_DEF_TREE = profiles_dir() / "domain_tree.json"
+_DEF_MAP = profiles_dir() / "domain_mapping.json"
 
 
 def _load_json(path: Path) -> dict:

--- a/astroengine/ephemeris/utils.py
+++ b/astroengine/ephemeris/utils.py
@@ -6,6 +6,8 @@ import os
 from pathlib import Path
 from typing import Iterable, Iterator
 
+from ..infrastructure.paths import datasets_dir
+
 __all__ = [
     "DEFAULT_ENV_KEYS",
     "DEFAULT_SUBDIRS",
@@ -24,8 +26,7 @@ DEFAULT_ENV_KEYS: tuple[str, ...] = (
 DEFAULT_SUBDIRS: tuple[str, ...] = ("ephe", "sefstars")
 """Common Swiss ephemeris sub-directories to validate when probing paths."""
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-_DATASETS_ROOT = _REPO_ROOT / "datasets"
+_DATASETS_ROOT = datasets_dir()
 _STUB_DIR = _DATASETS_ROOT / "swisseph_stub"
 
 _DEFAULT_HINTS: tuple[Path, ...] = (

--- a/astroengine/fixedstars/skyfield_stars.py
+++ b/astroengine/fixedstars/skyfield_stars.py
@@ -2,8 +2,9 @@
 from __future__ import annotations
 
 import csv
-from pathlib import Path
 from typing import Tuple
+
+from ..infrastructure.paths import datasets_dir
 
 try:
     from skyfield.api import Star, load
@@ -11,7 +12,7 @@ except Exception:  # pragma: no cover
     Star = None
     load = None
 
-DATASET = Path(__file__).resolve().parent.parent / "datasets" / "star_names_iau.csv"
+DATASET = datasets_dir() / "star_names_iau.csv"
 
 
 def _load_kernel():

--- a/astroengine/infrastructure/__init__.py
+++ b/astroengine/infrastructure/__init__.py
@@ -5,6 +5,19 @@ from __future__ import annotations
 from .environment import EnvironmentReport, collect_environment_report
 from .environment import main as environment_main
 from .git_access import GitAuth, GitRepository
+from .paths import (
+    AstroPaths,
+    dataset_path,
+    datasets_dir,
+    generated_dir,
+    get_paths,
+    package_root,
+    profiles_dir,
+    project_root,
+    registry_dir,
+    rulesets_dir,
+    schemas_dir,
+)
 
 __all__ = [
     "EnvironmentReport",
@@ -12,4 +25,15 @@ __all__ = [
     "environment_main",
     "GitAuth",
     "GitRepository",
+    "AstroPaths",
+    "get_paths",
+    "package_root",
+    "project_root",
+    "datasets_dir",
+    "dataset_path",
+    "generated_dir",
+    "profiles_dir",
+    "registry_dir",
+    "rulesets_dir",
+    "schemas_dir",
 ]

--- a/astroengine/infrastructure/paths.py
+++ b/astroengine/infrastructure/paths.py
@@ -1,0 +1,113 @@
+"""Centralised filesystem path helpers for AstroEngine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+
+__all__ = [
+    "AstroPaths",
+    "get_paths",
+    "package_root",
+    "project_root",
+    "datasets_dir",
+    "dataset_path",
+    "generated_dir",
+    "profiles_dir",
+    "registry_dir",
+    "rulesets_dir",
+    "schemas_dir",
+]
+
+
+@dataclass(frozen=True)
+class AstroPaths:
+    """Resolved directory layout for the repository and installed package."""
+
+    package_root: Path
+    project_root: Path
+    datasets: Path
+    generated: Path
+    profiles: Path
+    registry: Path
+    rulesets: Path
+    schemas: Path
+
+    def dataset(self, *parts: str | Path) -> Path:
+        """Return a path under the ``datasets`` directory."""
+
+        return self.datasets.joinpath(*parts)
+
+
+@lru_cache(maxsize=1)
+def get_paths() -> AstroPaths:
+    """Return a cached :class:`AstroPaths` descriptor."""
+
+    here = Path(__file__).resolve()
+    package_root = here.parents[1]
+    project_root = here.parents[2]
+    return AstroPaths(
+        package_root=package_root,
+        project_root=project_root,
+        datasets=project_root / "datasets",
+        generated=project_root / "generated",
+        profiles=project_root / "profiles",
+        registry=project_root / "registry",
+        rulesets=project_root / "rulesets",
+        schemas=project_root / "schemas",
+    )
+
+
+def package_root() -> Path:
+    """Return the root directory of the installed :mod:`astroengine` package."""
+
+    return get_paths().package_root
+
+
+def project_root() -> Path:
+    """Return the repository root (editable installs) when available."""
+
+    return get_paths().project_root
+
+
+def datasets_dir() -> Path:
+    """Return the repository ``datasets`` directory."""
+
+    return get_paths().datasets
+
+
+def dataset_path(*parts: str | Path) -> Path:
+    """Return a path within the ``datasets`` directory."""
+
+    return get_paths().dataset(*parts)
+
+
+def generated_dir() -> Path:
+    """Return the repository ``generated`` directory."""
+
+    return get_paths().generated
+
+
+def profiles_dir() -> Path:
+    """Return the repository ``profiles`` directory."""
+
+    return get_paths().profiles
+
+
+def registry_dir() -> Path:
+    """Return the repository ``registry`` directory."""
+
+    return get_paths().registry
+
+
+def rulesets_dir() -> Path:
+    """Return the repository ``rulesets`` directory."""
+
+    return get_paths().rulesets
+
+
+def schemas_dir() -> Path:
+    """Return the repository ``schemas`` directory."""
+
+    return get_paths().schemas

--- a/astroengine/maint.py
+++ b/astroengine/maint.py
@@ -40,7 +40,9 @@ import sys
 from pathlib import Path
 from typing import Iterable, List, Tuple
 
-ROOT = Path(__file__).resolve().parents[1]
+from .infrastructure.paths import project_root
+
+ROOT = project_root()
 REQ_DEV = ROOT / "requirements-dev.txt"
 
 

--- a/astroengine/profiles/profiles.py
+++ b/astroengine/profiles/profiles.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
 from typing import Any, Mapping
 
 import yaml
+
+from ..infrastructure.paths import profiles_dir
 
 __all__ = [
     "load_base_profile",
@@ -40,21 +41,11 @@ class ResonanceWeights:
         weights = self.normalized()
         return {"mind": weights.mind, "body": weights.body, "spirit": weights.spirit}
 
-
-def _repository_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "profiles"
-        if (candidate / "vca_outline.json").is_file():
-            return parent
-    raise FileNotFoundError("Unable to locate repository root containing 'profiles'.")
-
-
 @lru_cache(maxsize=1)
 def load_vca_outline() -> dict[str, Any]:
     """Return the canonical VCA outline JSON payload."""
 
-    outline_path = _repository_root() / "profiles" / "vca_outline.json"
+    outline_path = profiles_dir() / "vca_outline.json"
     with outline_path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
 
@@ -63,7 +54,7 @@ def load_vca_outline() -> dict[str, Any]:
 def load_base_profile() -> dict[str, Any]:
     """Load and parse the baseline AstroEngine profile definition."""
 
-    profile_path = _repository_root() / "profiles" / "base_profile.yaml"
+    profile_path = profiles_dir() / "base_profile.yaml"
     with profile_path.open("r", encoding="utf-8") as handle:
         return yaml.safe_load(handle)
 

--- a/astroengine/registry/__init__.py
+++ b/astroengine/registry/__init__.py
@@ -15,6 +15,8 @@ try:
 except Exception:  # pragma: no cover
     _files = None  # type: ignore
 
+from ..infrastructure.paths import registry_dir
+
 
 def _candidate_dirs() -> list[Path]:
     roots: list[Path] = []
@@ -26,11 +28,12 @@ def _candidate_dirs() -> list[Path]:
         except Exception:
             pass
     # 2) project root `registry/` (dev installs, editable mode)
-    here = Path(__file__).resolve()
-    for up in (here.parents[1], Path.cwd()):
-        cand = up / "registry"
-        if cand.exists():
-            roots.append(cand)
+    repo_registry = registry_dir()
+    if repo_registry.exists():
+        roots.append(repo_registry)
+    cwd_registry = Path.cwd() / "registry"
+    if cwd_registry.exists():
+        roots.append(cwd_registry)
     # De-dup while preserving order
     seen: set[Path] = set()
     uniq: list[Path] = []

--- a/astroengine/scoring/contact.py
+++ b/astroengine/scoring/contact.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import json
-import json
 import math
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
 from typing import Mapping
 
 from ..core.bodies import body_class
+from ..infrastructure.paths import profiles_dir
 from ..refine import fuzzy_membership
 
 __all__ = [
@@ -19,20 +18,7 @@ __all__ = [
     "compute_score",
     "compute_uncertainty_confidence",
 ]
-
-
-def _repository_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "profiles" / "scoring_policy.json"
-        if candidate.exists():
-            return parent
-    raise FileNotFoundError(
-        "Unable to locate 'profiles/scoring_policy.json' in repository parents."
-    )
-
-
-_DEF_POLICY = _repository_root() / "profiles" / "scoring_policy.json"
+_DEF_POLICY = profiles_dir() / "scoring_policy.json"
 
 
 @dataclass(frozen=True)

--- a/astroengine/scoring_legacy/dignity.py
+++ b/astroengine/scoring_legacy/dignity.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import csv
 from dataclasses import dataclass
 from functools import lru_cache
-from pathlib import Path
+
+from ..infrastructure.paths import profiles_dir
 
 __all__ = ["DignityRecord", "load_dignities", "lookup_dignities"]
 
@@ -24,15 +25,6 @@ class DignityRecord:
     source: str
 
 
-def _repository_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        candidate = parent / "profiles"
-        if (candidate / "dignities.csv").is_file():
-            return parent
-    raise FileNotFoundError("Unable to locate repository root containing 'profiles'.")
-
-
 def _parse_float(value: str | None) -> float | None:
     if value is None or value == "":
         return None
@@ -43,7 +35,7 @@ def _parse_float(value: str | None) -> float | None:
 def load_dignities() -> tuple[DignityRecord, ...]:
     """Load the entire dignity table into memory."""
 
-    path = _repository_root() / "profiles" / "dignities.csv"
+    path = profiles_dir() / "dignities.csv"
     with path.open("r", encoding="utf-8") as handle:
         reader = csv.DictReader(handle)
         records = []

--- a/astroengine/scoring_legacy/orb.py
+++ b/astroengine/scoring_legacy/orb.py
@@ -6,7 +6,6 @@ import json
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import cache, lru_cache
-from pathlib import Path
 
 __all__ = ["DEFAULT_ASPECTS", "OrbCalculator", "AspectPolicy"]
 
@@ -42,6 +41,9 @@ _BODY_CLASSIFICATION = {
 }
 
 
+from ..infrastructure.paths import schemas_dir
+
+
 @dataclass(frozen=True)
 class AspectPolicy:
     """In-memory representation of a single aspect entry."""
@@ -52,17 +54,9 @@ class AspectPolicy:
     profile_overrides: Mapping[str, float]
 
 
-def _repository_root() -> Path:
-    here = Path(__file__).resolve()
-    for parent in here.parents:
-        if (parent / "schemas").is_dir():
-            return parent
-    raise FileNotFoundError("Unable to locate repository root containing 'schemas'.")
-
-
 @lru_cache(maxsize=1)
 def _load_policy() -> Mapping[str, object]:
-    path = _repository_root() / "schemas" / "orbs_policy.json"
+    path = schemas_dir() / "orbs_policy.json"
     with path.open("r", encoding="utf-8") as handle:
         return json.load(handle)
 

--- a/astroengine/valence.py
+++ b/astroengine/valence.py
@@ -4,9 +4,11 @@ import json
 from pathlib import Path
 from typing import Literal, Optional, Tuple
 
+from .infrastructure.paths import profiles_dir
+
 Valence = Literal["positive", "neutral", "negative"]
 
-_DEF = Path(__file__).resolve().parent.parent / "profiles" / "valence_policy.json"
+_DEF = profiles_dir() / "valence_policy.json"
 
 
 def _load(path: Optional[str] = None) -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,25 @@ PROJECT_ROOT = Path(__file__).resolve().parents[1]
 PROJECT_ROOT_STR = str(PROJECT_ROOT)
 GENERATED_ROOT = PROJECT_ROOT / "generated"
 GENERATED_STR = str(GENERATED_ROOT)
+DATASETS_ROOT = PROJECT_ROOT / "datasets"
+
+
+def _refresh_paths_from_package() -> None:
+    try:
+        from astroengine.infrastructure.paths import (
+            datasets_dir,
+            generated_dir,
+            project_root as pkg_project_root,
+        )
+    except Exception:
+        return
+
+    global PROJECT_ROOT, PROJECT_ROOT_STR, GENERATED_ROOT, GENERATED_STR, DATASETS_ROOT
+    PROJECT_ROOT = pkg_project_root()
+    PROJECT_ROOT_STR = str(PROJECT_ROOT)
+    GENERATED_ROOT = generated_dir()
+    GENERATED_STR = str(GENERATED_ROOT)
+    DATASETS_ROOT = datasets_dir()
 
 
 def _ensure_repo_package() -> None:
@@ -68,6 +87,8 @@ def _ensure_repo_package() -> None:
         importlib.invalidate_caches()
         importlib.import_module("astroengine")
 
+    _refresh_paths_from_package()
+
 
 _ensure_repo_package()
 
@@ -75,7 +96,7 @@ _ensure_repo_package()
 def _ensure_swiss_stub() -> None:
     if os.getenv("SE_EPHE_PATH"):
         return
-    stub = PROJECT_ROOT / "datasets" / "swisseph_stub"
+    stub = DATASETS_ROOT / "swisseph_stub"
     if stub.is_dir():
         os.environ.setdefault("SE_EPHE_PATH", str(stub))
 


### PR DESCRIPTION
## Summary
- add an `astroengine.infrastructure.paths` helper that exposes cached paths for the package, repo, datasets, profiles, rulesets and schemas
- refactor catalog, ephemeris, profile, scoring and registry modules to consume the shared path helpers while preserving the module→submodule→channel hierarchy metadata
- update pytest bootstrap and maint tooling to use the new helpers without breaking the generated-module compatibility shim

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d17bfcb6588324aff6ae25793dd938