### PR TITLE
Harden Swiss ephemeris integration and Streamlit scanner

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -83,7 +83,8 @@ try:
 except ImportError:  # pragma: no cover - optional legacy surface
     LunationEvent = EclipseEvent = StationEvent = ReturnEvent = None  # type: ignore
     ProgressionEvent = DirectionEvent = ProfectionEvent = OutOfBoundsEvent = None  # type: ignore
-from .fixedstars import skyfield_stars  # ENSURE-LINE
+from . import cycles
+from .fixedstars import parans, skyfield_stars  # ENSURE-LINE
 from .infrastructure.environment import collect_environment_report
 from .infrastructure.environment import main as environment_report_main
 from .maint import main as maint_main  # ENSURE-LINE
@@ -231,6 +232,8 @@ __all__ = [
     "VCA_SENSITIVE_POINTS",
     "sbdb",
     "skyfield_stars",
+    "parans",
+    "cycles",
     "declination",
     "VALID_ZODIAC_SYSTEMS",
     "VALID_HOUSE_SYSTEMS",

--- a/astroengine/app_api.py
+++ b/astroengine/app_api.py
@@ -244,7 +244,6 @@ def run_scan_or_raise(
     entrypoints: Optional[Iterable[ScanSpec]] = None,
     return_used_entrypoint: bool = False,
     zodiac: Optional[str] = None,
-    ayanamsha: Optional[str] = None,
 ) -> Union[List[Dict[str, Any]], Tuple[List[Dict[str, Any]], ScanCandidate]]:
     """
     Try known scan entrypoints, call the first that matches a compatible signature,

--- a/astroengine/cycles/__init__.py
+++ b/astroengine/cycles/__init__.py
@@ -1,0 +1,32 @@
+"""Cycles and age analytics namespace for :mod:`astroengine`."""
+
+from __future__ import annotations
+
+from .ages import AgeBoundary, AgeSample, AgeSeries, compute_age_series, derive_age_boundaries
+from .generational import (
+    DEFAULT_OUTER_ASPECTS,
+    DEFAULT_OUTER_BODIES,
+    CyclePairSample,
+    CycleTimeline,
+    WavePoint,
+    WaveSeries,
+    neptune_pluto_wave,
+    outer_cycle_timeline,
+)
+
+__all__ = [
+    "DEFAULT_OUTER_ASPECTS",
+    "DEFAULT_OUTER_BODIES",
+    "CyclePairSample",
+    "CycleTimeline",
+    "WavePoint",
+    "WaveSeries",
+    "AgeSample",
+    "AgeSeries",
+    "AgeBoundary",
+    "outer_cycle_timeline",
+    "neptune_pluto_wave",
+    "compute_age_series",
+    "derive_age_boundaries",
+]
+

--- a/astroengine/cycles/ages.py
+++ b/astroengine/cycles/ages.py
@@ -1,0 +1,200 @@
+"""Astrological Age analytics built from Aries ingress ephemerides."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Iterator, Sequence
+
+try:  # pragma: no cover - optional dependency guard
+    import swisseph as swe
+except Exception:  # pragma: no cover - handled by _ensure_swisseph
+    swe = None  # type: ignore
+
+from ..detectors.common import body_lon, iso_to_jd, jd_to_iso, solve_zero_crossing
+from ..ephemeris import SwissEphemerisAdapter
+from ..ephemeris.sidereal import DEFAULT_SIDEREAL_AYANAMSHA, normalize_ayanamsha_name
+
+ZODIAC_SIGNS: tuple[str, ...] = (
+    "Aries",
+    "Taurus",
+    "Gemini",
+    "Cancer",
+    "Leo",
+    "Virgo",
+    "Libra",
+    "Scorpio",
+    "Sagittarius",
+    "Capricorn",
+    "Aquarius",
+    "Pisces",
+)
+
+__all__ = [
+    "AgeSample",
+    "AgeSeries",
+    "AgeBoundary",
+    "compute_age_series",
+    "derive_age_boundaries",
+]
+
+
+@dataclass(frozen=True)
+class AgeSample:
+    """Computed astrological age metadata for a single Aries ingress."""
+
+    year: int
+    zodiac_sign: str
+    ingress_ts: str
+    ingress_jd: float
+    ayanamsha_degrees: float
+    sidereal_longitude: float
+    ayanamsha_name: str
+
+
+@dataclass(frozen=True)
+class AgeSeries:
+    """Collection of :class:`AgeSample` instances for a year range."""
+
+    ayanamsha_name: str
+    samples: tuple[AgeSample, ...]
+
+
+@dataclass(frozen=True)
+class AgeBoundary:
+    """Boundary marker for the start of a new astrological age."""
+
+    zodiac_sign: str
+    start_year: int
+    ingress_ts: str
+    ingress_jd: float
+    sidereal_longitude: float
+    ayanamsha_name: str
+
+
+def _ensure_swisseph() -> None:
+    if swe is None:  # pragma: no cover - environment dependent
+        raise ImportError("pyswisseph not installed; install astroengine[ephem] to compute ages")
+
+
+def _available_ayanamshas() -> dict[str, int]:
+    _ensure_swisseph()
+    mapping = {key: value for key, value in SwissEphemerisAdapter._AYANAMSHA_MODES.items()}
+    return mapping
+
+
+def _resolve_ayanamsha(ayanamsha: str | None) -> tuple[str, int]:
+    mapping = _available_ayanamshas()
+    base = ayanamsha or SwissEphemerisAdapter._DEFAULT_AYANAMSHA or DEFAULT_SIDEREAL_AYANAMSHA
+    normalized = normalize_ayanamsha_name(base)
+    if normalized not in mapping:
+        options = ", ".join(sorted(mapping))
+        raise ValueError(f"Unsupported ayanamsha '{base}'. Supported options: {options}")
+    return normalized, int(mapping[normalized])
+
+
+def _default_ayanamsha_code() -> int:
+    normalized, code = _resolve_ayanamsha(SwissEphemerisAdapter._DEFAULT_AYANAMSHA)
+    return code
+
+
+@contextmanager
+def _sidereal_mode(code: int) -> Iterator[None]:
+    _ensure_swisseph()
+    restore_code = _default_ayanamsha_code()
+    swe.set_sid_mode(code, 0.0, 0.0)
+    try:
+        yield
+    finally:
+        swe.set_sid_mode(restore_code, 0.0, 0.0)
+
+
+def _sign_index(longitude: float) -> int:
+    return int((longitude % 360.0) // 30.0)
+
+
+def _aries_ingress(year: int, step_hours: float) -> tuple[str, float]:
+    start_jd = iso_to_jd(f"{year}-01-01T00:00:00Z")
+    end_jd = iso_to_jd(f"{year+1}-01-01T00:00:00Z")
+    step_days = max(step_hours, 1.0) / 24.0
+
+    prev_jd = start_jd
+    prev_lon = body_lon(prev_jd, "sun")
+    prev_sign = _sign_index(prev_lon)
+    jd = prev_jd + step_days
+    while jd <= end_jd:
+        lon = body_lon(jd, "sun")
+        sign = _sign_index(lon)
+        if sign != prev_sign:
+            if sign % 12 == 0:  # Aries ingress detected
+
+                def fn(candidate_jd: float) -> float:
+                    lon_candidate = body_lon(candidate_jd, "sun")
+                    delta = (lon_candidate + 180.0) % 360.0 - 180.0
+                    return delta
+
+                refined = solve_zero_crossing(fn, prev_jd, jd, tol=1e-6, tol_deg=1e-5)
+                return jd_to_iso(refined), refined
+            prev_sign = sign
+        prev_jd = jd
+        jd += step_days
+    raise ValueError(f"No Aries ingress found for {year}")
+
+
+def compute_age_series(
+    start_year: int,
+    end_year: int,
+    *,
+    ayanamsha: str | None = None,
+    step_hours: float = 6.0,
+) -> AgeSeries:
+    """Compute astrological age metadata for each year in ``start_year`` → ``end_year``."""
+
+    if start_year > end_year:
+        raise ValueError("start_year must be <= end_year")
+
+    normalized, code = _resolve_ayanamsha(ayanamsha)
+    samples: list[AgeSample] = []
+
+    with _sidereal_mode(code):
+        for year in range(start_year, end_year + 1):
+            ingress_ts, ingress_jd = _aries_ingress(year, step_hours)
+            ayanamsha_value = float(swe.get_ayanamsa_ut(ingress_jd))
+            sidereal_longitude = (360.0 - ayanamsha_value) % 360.0
+            index = int(sidereal_longitude // 30.0) % len(ZODIAC_SIGNS)
+            sign = ZODIAC_SIGNS[index]
+            samples.append(
+                AgeSample(
+                    year=year,
+                    zodiac_sign=sign,
+                    ingress_ts=ingress_ts,
+                    ingress_jd=ingress_jd,
+                    ayanamsha_degrees=ayanamsha_value,
+                    sidereal_longitude=sidereal_longitude,
+                    ayanamsha_name=normalized,
+                )
+            )
+
+    return AgeSeries(ayanamsha_name=normalized, samples=tuple(samples))
+
+
+def derive_age_boundaries(series: AgeSeries) -> Sequence[AgeBoundary]:
+    """Return astrological age boundaries from ``series``."""
+
+    boundaries: list[AgeBoundary] = []
+    current_sign: str | None = None
+    for sample in series.samples:
+        if sample.zodiac_sign != current_sign:
+            boundaries.append(
+                AgeBoundary(
+                    zodiac_sign=sample.zodiac_sign,
+                    start_year=sample.year,
+                    ingress_ts=sample.ingress_ts,
+                    ingress_jd=sample.ingress_jd,
+                    sidereal_longitude=sample.sidereal_longitude,
+                    ayanamsha_name=series.ayanamsha_name,
+                )
+            )
+            current_sign = sample.zodiac_sign
+    return tuple(boundaries)
+

--- a/astroengine/cycles/generational.py
+++ b/astroengine/cycles/generational.py
@@ -1,0 +1,263 @@
+"""Generational and mundane cycle analytics derived from Swiss Ephemeris."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from itertools import combinations
+from typing import Mapping, Sequence
+
+try:  # pragma: no cover - optional dependency guard
+    import swisseph as swe
+except Exception:  # pragma: no cover - handled by _ensure_swisseph
+    swe = None  # type: ignore
+
+from ..detectors.common import jd_to_iso
+from ..ephemeris import SwissEphemerisAdapter
+
+DEFAULT_OUTER_BODIES: Sequence[str] = ("Jupiter", "Saturn", "Uranus", "Neptune", "Pluto")
+
+DEFAULT_OUTER_ASPECTS: Mapping[int, str] = {
+    0: "conjunction",
+    45: "semi-square",
+    60: "sextile",
+    90: "square",
+    120: "trine",
+    135: "sesquiquadrate",
+    150: "quincunx",
+    180: "opposition",
+}
+
+__all__ = [
+    "DEFAULT_OUTER_ASPECTS",
+    "DEFAULT_OUTER_BODIES",
+    "CyclePairSample",
+    "CycleTimeline",
+    "WavePoint",
+    "WaveSeries",
+    "outer_cycle_timeline",
+    "neptune_pluto_wave",
+]
+
+
+@dataclass(frozen=True)
+class CyclePairSample:
+    """Single observation for an outer-planet pair."""
+
+    pair: tuple[str, str]
+    timestamp: str
+    julian_day: float
+    separation: float
+    signed_delta: float
+    phase: str
+    aspect: str | None
+    aspect_orb: float | None
+
+
+@dataclass(frozen=True)
+class CycleTimeline:
+    """Timeline of outer-cycle samples across a date range."""
+
+    start_ts: str
+    end_ts: str
+    step_days: float
+    samples: tuple[CyclePairSample, ...]
+
+
+@dataclass(frozen=True)
+class WavePoint:
+    """Single point in a Neptune–Pluto wave analysis."""
+
+    timestamp: str
+    julian_day: float
+    separation: float
+    signed_delta: float
+    phase: str
+    aspect: str | None
+    aspect_orb: float | None
+    rate_deg_per_year: float | None
+
+
+@dataclass(frozen=True)
+class WaveSeries:
+    """Ordered series of :class:`WavePoint` entries for a planet pair."""
+
+    pair: tuple[str, str]
+    step_days: float
+    samples: tuple[WavePoint, ...]
+
+
+def _ensure_swisseph() -> None:
+    if swe is None:  # pragma: no cover - environment dependent
+        raise ImportError("pyswisseph not installed; install astroengine[ephem] to enable cycles")
+
+
+def _canonical_body(name: str) -> str:
+    return name.strip().title()
+
+
+def _resolve_body_codes(bodies: Sequence[str]) -> dict[str, int]:
+    _ensure_swisseph()
+    codes: dict[str, int] = {}
+    for raw in bodies:
+        canon = _canonical_body(raw)
+        key = canon.lower()
+        mapping = {
+            "jupiter": swe.JUPITER,
+            "saturn": swe.SATURN,
+            "uranus": swe.URANUS,
+            "neptune": swe.NEPTUNE,
+            "pluto": swe.PLUTO,
+        }
+        if key not in mapping:
+            raise ValueError(f"Unsupported outer planet '{raw}'")
+        codes[canon] = int(mapping[key])
+    return codes
+
+
+def _iso(moment: datetime) -> str:
+    return moment.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _signed_delta(a: float, b: float) -> float:
+    delta = (b - a) % 360.0
+    if delta > 180.0:
+        delta -= 360.0
+    return delta
+
+
+def _classify_aspect(
+    separation: float,
+    aspects: Mapping[int, str],
+    orb: float,
+) -> tuple[str | None, float | None]:
+    candidate: str | None = None
+    diff_min: float | None = None
+    for angle, name in aspects.items():
+        diff = abs(separation - float(angle))
+        if diff <= orb and (diff_min is None or diff < diff_min):
+            candidate = name
+            diff_min = diff
+    return candidate, diff_min
+
+
+def outer_cycle_timeline(
+    start_year: int,
+    end_year: int,
+    *,
+    bodies: Sequence[str] | None = None,
+    step_days: float = 30.0,
+    adapter: SwissEphemerisAdapter | None = None,
+    aspect_angles: Mapping[int, str] | None = None,
+    aspect_orb: float = 3.0,
+) -> CycleTimeline:
+    """Generate an outer-planet separation timeline suitable for dashboards."""
+
+    if start_year > end_year:
+        raise ValueError("start_year must be <= end_year")
+    if step_days <= 0:
+        raise ValueError("step_days must be positive")
+
+    bodies = tuple(_canonical_body(name) for name in (bodies or DEFAULT_OUTER_BODIES))
+    body_codes = _resolve_body_codes(bodies)
+    adapter = adapter or SwissEphemerisAdapter()
+    aspects = aspect_angles or DEFAULT_OUTER_ASPECTS
+
+    start_dt = datetime(start_year, 1, 1, tzinfo=UTC)
+    end_dt = datetime(end_year, 12, 31, tzinfo=UTC)
+
+    samples: list[CyclePairSample] = []
+    current = start_dt
+    while current <= end_dt:
+        jd = adapter.julian_day(current)
+        positions = adapter.body_positions(jd, body_codes)
+        timestamp = jd_to_iso(jd)
+        for left, right in combinations(bodies, 2):
+            lon_a = positions[left].longitude
+            lon_b = positions[right].longitude
+            delta_signed = _signed_delta(lon_a, lon_b)
+            separation = abs(delta_signed)
+            phase = "waxing" if delta_signed >= 0 else "waning"
+            aspect_name, diff = _classify_aspect(separation, aspects, aspect_orb)
+            samples.append(
+                CyclePairSample(
+                    pair=(left, right),
+                    timestamp=timestamp,
+                    julian_day=jd,
+                    separation=separation,
+                    signed_delta=delta_signed,
+                    phase=phase,
+                    aspect=aspect_name,
+                    aspect_orb=diff,
+                )
+            )
+        current += timedelta(days=step_days)
+
+    return CycleTimeline(
+        start_ts=_iso(start_dt),
+        end_ts=_iso(end_dt),
+        step_days=float(step_days),
+        samples=tuple(samples),
+    )
+
+
+def _rate_deg_per_year(prev_delta: float, current_delta: float, delta_jd: float) -> float:
+    diff = current_delta - prev_delta
+    while diff > 180.0:
+        diff -= 360.0
+    while diff < -180.0:
+        diff += 360.0
+    years = delta_jd / 365.2425
+    if years == 0:
+        return 0.0
+    return diff / years
+
+
+def neptune_pluto_wave(
+    start_year: int,
+    end_year: int,
+    *,
+    step_days: float = 60.0,
+    adapter: SwissEphemerisAdapter | None = None,
+    aspect_angles: Mapping[int, str] | None = None,
+    aspect_orb: float = 3.0,
+) -> WaveSeries:
+    """Return a Neptune–Pluto wave timeline with derivative metrics."""
+
+    timeline = outer_cycle_timeline(
+        start_year,
+        end_year,
+        bodies=("Neptune", "Pluto"),
+        step_days=step_days,
+        adapter=adapter,
+        aspect_angles=aspect_angles,
+        aspect_orb=aspect_orb,
+    )
+    wave_points: list[WavePoint] = []
+    prev_delta: float | None = None
+    prev_jd: float | None = None
+    for sample in timeline.samples:
+        if sample.pair != ("Neptune", "Pluto"):
+            continue
+        if prev_delta is None:
+            rate = None
+        else:
+            assert prev_jd is not None
+            rate = _rate_deg_per_year(prev_delta, sample.signed_delta, sample.julian_day - prev_jd)
+        wave_points.append(
+            WavePoint(
+                timestamp=sample.timestamp,
+                julian_day=sample.julian_day,
+                separation=sample.separation,
+                signed_delta=sample.signed_delta,
+                phase=sample.phase,
+                aspect=sample.aspect,
+                aspect_orb=sample.aspect_orb,
+                rate_deg_per_year=rate,
+            )
+        )
+        prev_delta = sample.signed_delta
+        prev_jd = sample.julian_day
+
+    return WaveSeries(pair=("Neptune", "Pluto"), step_days=timeline.step_days, samples=tuple(wave_points))
+

--- a/astroengine/detectors/ingress.py
+++ b/astroengine/detectors/ingress.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 from ..events import IngressEvent
-from .common import body_lon, delta_deg, jd_to_iso, norm360, solve_zero_crossing
+from .common import body_lon, body_position, delta_deg, jd_to_iso, norm360, solve_zero_crossing
 
 __all__ = ["find_ingresses"]
 
@@ -40,16 +40,19 @@ def _boundary_for(prev_index: int) -> float:
     return _SIGN_DEGREES[(prev_index + 1) % 12] if prev_index < 11 else 360.0
 
 
-def _to_ingress_event(body_label: str, body_key: str, jd_ut: float, sign_index: int) -> IngressEvent:
-    longitude = norm360(body_lon(jd_ut, body_key))
-    sign_name = _SIGN_NAMES[sign_index]
+def _to_ingress_event(
+    body_label: str, jd_ut: float, from_index: int, to_index: int
+) -> IngressEvent:
+    position = body_position(jd_ut, body_label)
     return IngressEvent(
         ts=jd_to_iso(jd_ut),
         jd=jd_ut,
         body=body_label,
-        sign=sign_name,
-        longitude=longitude,
-        sign_index=sign_index,
+        sign_from=_SIGN_NAMES[from_index],
+        sign_to=_SIGN_NAMES[to_index],
+        longitude=position.longitude,
+        speed_longitude=position.speed_longitude,
+        retrograde=position.speed_longitude < 0.0,
     )
 
 
@@ -96,7 +99,7 @@ def find_ingresses(
                     root = None
 
                 if root is not None and start_jd - _STEP_TOL <= root <= end_jd + _STEP_TOL:
-                    events.append(_to_ingress_event(body_label, body, root, target_sign))
+                    events.append(_to_ingress_event(body_label, root, prev_sign, target_sign))
 
             prev_jd = jd
             prev_lon = curr_lon
@@ -106,9 +109,9 @@ def find_ingresses(
     events.sort(key=lambda item: (item.jd, item.body))
     # Deduplicate in case of floating point jitter
     deduped: list[IngressEvent] = []
-    seen: set[tuple[str, int, int]] = set()
+    seen: set[tuple[str, int, str]] = set()
     for event in events:
-        key = (event.body.lower(), int(round(event.jd * 86400)), event.sign_index)
+        key = (event.body.lower(), int(round(event.jd * 86400)), event.sign_to.lower())
         if key in seen:
             continue
         seen.add(key)

--- a/astroengine/detectors/ingresses.py
+++ b/astroengine/detectors/ingresses.py
@@ -1,23 +1,3 @@
-
-"""Sign ingress detectors backed by Swiss Ephemeris longitudes."""
-
-from __future__ import annotations
-
-from typing import Iterable, Sequence
-
-try:  # pragma: no cover - exercised through swiss-marked tests
-    import swisseph as swe  # type: ignore
-except Exception:  # pragma: no cover
-    swe = None  # type: ignore
-
-from ..events import IngressEvent
-from .common import delta_deg, jd_to_iso, solve_zero_crossing
-
-__all__ = ["find_sign_ingresses"]
-
-
-_SIGN_NAMES: Sequence[str] = (
-
 """Sign ingress detection utilities built on Swiss Ephemeris longitudes."""
 
 from __future__ import annotations
@@ -25,6 +5,11 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 from typing import Iterable, Sequence
+
+try:  # pragma: no cover - exercised through Swiss-dependent tests
+    import swisseph as swe  # type: ignore
+except Exception:  # pragma: no cover
+    swe = None  # type: ignore
 
 from ..events import IngressEvent
 from .common import body_lon, jd_to_iso, norm360, solve_zero_crossing
@@ -36,9 +21,7 @@ __all__ = [
     "find_sign_ingresses",
 ]
 
-
 ZODIAC_SIGNS: Sequence[str] = (
-
     "Aries",
     "Taurus",
     "Gemini",
@@ -52,7 +35,6 @@ ZODIAC_SIGNS: Sequence[str] = (
     "Aquarius",
     "Pisces",
 )
-
 
 _BODY_CODES = {
     "sun": lambda: swe.SUN,
@@ -88,26 +70,6 @@ def _longitude_and_speed(jd_ut: float, code: int) -> tuple[float, float]:
     return longitude, speed
 
 
-def _sign_index(longitude: float) -> int:
-    return int((longitude % 360.0) // 30.0)
-
-
-def _sign_name(index: int) -> str:
-    return _SIGN_NAMES[index % len(_SIGN_NAMES)]
-
-_DEFAULT_BODIES: Sequence[str] = (
-    "sun",
-    "mercury",
-    "venus",
-    "mars",
-    "jupiter",
-    "saturn",
-    "uranus",
-    "neptune",
-    "pluto",
-)
-
-
 def sign_index(longitude: float) -> int:
     """Return the zero-based zodiac sign index for ``longitude`` in degrees."""
 
@@ -117,7 +79,7 @@ def sign_index(longitude: float) -> int:
 def sign_name(index: int) -> str:
     """Return the canonical sign name for ``index`` (0 = Aries)."""
 
-    return ZODIAC_SIGNS[index % 12]
+    return ZODIAC_SIGNS[index % len(ZODIAC_SIGNS)]
 
 
 def _wrap_to_target(value: float, target: float) -> float:
@@ -179,7 +141,6 @@ def _refine_ingress(body: str, left: _Sample, right: _Sample, boundary: float) -
     try:
         return solve_zero_crossing(fn, left.jd, right.jd, tol=1e-6, tol_deg=1e-5)
     except ValueError:
-        # Fall back to linear interpolation in the unwrapped space.
         span = right.longitude - left.longitude
         if span == 0:
             return left.jd
@@ -187,99 +148,21 @@ def _refine_ingress(body: str, left: _Sample, right: _Sample, boundary: float) -
         return left.jd + fraction * (right.jd - left.jd)
 
 
-
 def find_sign_ingresses(
     start_jd: float,
     end_jd: float,
-
     bodies: Iterable[str] | None = None,
     *,
-    step_hours: float = 6.0,
-) -> list[IngressEvent]:
-    """Return zodiacal ingress events for ``bodies`` within ``start_jd`` → ``end_jd``."""
-
-    if end_jd <= start_jd:
-        return []
-    if swe is None:
-        raise RuntimeError("Swiss ephemeris not available; install astroengine[ephem]")
-
-    step_days = step_hours / 24.0
-    body_names = list(bodies) if bodies is not None else list(_BODY_CODES)
-
-    events: list[IngressEvent] = []
-    seen: set[tuple[str, int]] = set()
-
-    for name in body_names:
-        code = _body_code(name)
-        if code is None:
-            continue
-
-        prev_jd = start_jd
-        prev_lon, prev_speed = _longitude_and_speed(prev_jd, code)
-        prev_sign = _sign_index(prev_lon)
-
-        jd = start_jd + step_days
-        while jd <= end_jd + step_days:
-            lon, speed = _longitude_and_speed(jd, code)
-            sign = _sign_index(lon)
-
-            if sign != prev_sign:
-                target = (sign * 30.0) % 360.0
-
-                try:
-                    root = solve_zero_crossing(
-                        lambda candidate, c=code, tgt=target: delta_deg(
-                            _longitude_and_speed(candidate, c)[0], tgt
-                        ),
-                        prev_jd,
-                        min(jd, end_jd),
-                        tol=1e-5,
-                        tol_deg=1e-4,
-                    )
-                except ValueError:
-                    root = jd
-
-                if not (start_jd <= root <= end_jd):
-                    prev_jd, prev_lon, prev_speed, prev_sign = jd, lon, speed, sign
-                    jd += step_days
-                    continue
-
-                key = (name, int(round(root * 86400)))
-                if key in seen:
-                    prev_jd, prev_lon, prev_speed, prev_sign = jd, lon, speed, sign
-                    jd += step_days
-                    continue
-
-                final_lon, final_speed = _longitude_and_speed(root, code)
-                events.append(
-                    IngressEvent(
-                        ts=jd_to_iso(root),
-                        jd=root,
-                        body=name.capitalize(),
-                        sign_from=_sign_name(prev_sign),
-                        sign_to=_sign_name(sign),
-                        longitude=final_lon,
-                        speed_longitude=final_speed,
-                        retrograde=final_speed < 0.0,
-                    )
-                )
-                seen.add(key)
-
-            prev_jd, prev_lon, prev_speed, prev_sign = jd, lon, speed, sign
-            jd += step_days
-
-    events.sort(key=lambda event: event.jd)
-
-    *,
-    bodies: Sequence[str] | None = None,
     step_hours: float = 6.0,
 ) -> list[IngressEvent]:
     """Detect sign ingress events between ``start_jd`` and ``end_jd`` inclusive."""
 
     if end_jd <= start_jd:
         return []
+    if swe is None:
+        raise RuntimeError("Swiss ephemeris not available; install astroengine[ephem]")
 
-    body_list = tuple((bodies or _DEFAULT_BODIES))
+    body_list = tuple(bodies or ("sun", "mercury", "venus", "mars", "jupiter", "saturn", "uranus", "neptune", "pluto"))
     step_days = max(step_hours, 1.0) / 24.0
     events: list[IngressEvent] = []
 
@@ -313,28 +196,30 @@ def find_sign_ingresses(
                 if not (start_jd <= jd_root <= end_jd):
                     left_sample = _Sample(jd=jd_root, longitude=boundary)
                     continue
+
                 lon_exact = norm360(body_lon(jd_root, body))
                 speed = _estimate_speed(body, jd_root)
-                motion = "retrograde" if speed < 0 else "direct"
+                retrograde = speed < 0
+
                 if direction >= 0:
                     from_idx = sign_index(boundary - 1e-6)
                     to_idx = sign_index(boundary + 1e-6)
                 else:
                     from_idx = sign_index(boundary + 1e-6)
                     to_idx = sign_index(boundary - 1e-6)
+
                 event = IngressEvent(
                     ts=jd_to_iso(jd_root),
                     jd=jd_root,
                     body=body,
-                    from_sign=sign_name(from_idx),
-                    to_sign=sign_name(to_idx),
+                    sign_from=sign_name(from_idx),
+                    sign_to=sign_name(to_idx),
                     longitude=lon_exact,
-                    motion=motion,
-                    speed_deg_per_day=float(speed),
+                    speed_longitude=float(speed),
+                    retrograde=retrograde,
                 )
                 events.append(event)
                 left_sample = _Sample(jd=jd_root, longitude=boundary)
 
     events.sort(key=lambda item: item.jd)
-
     return events

--- a/astroengine/exporters_ics.py
+++ b/astroengine/exporters_ics.py
@@ -1,4 +1,4 @@
-"""ICS export helpers for canonical transit events."""
+"""ICS export helpers for canonical transit events and templated outputs."""
 
 
 from __future__ import annotations
@@ -7,14 +7,20 @@ import hashlib
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, Sequence
+from typing import Any, Dict, Iterable, Mapping, Sequence
 
-from .canonical import TransitEvent, events_from_any
+from ics.grammar.parse import ContentLine
+
+from .canonical import TransitEvent, event_from_legacy, events_from_any
+from .events import ReturnEvent
 
 __all__ = [
     "canonical_events_to_ics",
     "ics_bytes_from_events",
     "write_ics_canonical",
+    "DEFAULT_DESCRIPTION_TEMPLATE",
+    "DEFAULT_SUMMARY_TEMPLATE",
+    "write_ics",
 ]
 
 _PRODID = "-//AstroEngine//Transit Scanner//EN"
@@ -120,25 +126,11 @@ def write_ics_canonical(
     Path(path).write_text(ics_payload, encoding="utf-8")
     return len(canonical_events)
 
-"""ICS exporter with template-driven summaries for AstroEngine events."""
-
-from __future__ import annotations
-
-import json
-from pathlib import Path
-from typing import Any, Dict, Iterable, Mapping
-
-from .canonical import TransitEvent, event_from_legacy
-from .events import ReturnEvent
-from ics.grammar.parse import ContentLine
-
 DEFAULT_SUMMARY_TEMPLATE = "{label}: {moving} {aspect} {target}"
 DEFAULT_DESCRIPTION_TEMPLATE = (
     "Orb {orb:+.2f}° (|{orb_abs:.2f}°|); "
     "Score {score_label}; Profile {profile_id}; Natal {natal_id}"
 )
-
-__all__ = ["DEFAULT_DESCRIPTION_TEMPLATE", "DEFAULT_SUMMARY_TEMPLATE", "write_ics"]
 
 
 class _TemplateContext(dict):

--- a/astroengine/fixedstars/__init__.py
+++ b/astroengine/fixedstars/__init__.py
@@ -2,6 +2,6 @@
 
 from __future__ import annotations
 
-from . import skyfield_stars
+from . import parans, skyfield_stars
 
-__all__ = ["skyfield_stars"]
+__all__ = ["skyfield_stars", "parans"]

--- a/astroengine/fixedstars/parans.py
+++ b/astroengine/fixedstars/parans.py
@@ -1,0 +1,481 @@
+"""Fixed star paran and heliacal phase analytics backed by Skyfield."""
+
+from __future__ import annotations
+
+import csv
+from dataclasses import dataclass
+from datetime import UTC, date as date_cls, datetime, time, timedelta, timezone
+from pathlib import Path
+from typing import Iterable, Iterator, Mapping, Sequence
+
+from ..chart.natal import ChartLocation
+from ..detectors.common import iso_to_jd
+from ..infrastructure.paths import datasets_dir
+
+try:  # pragma: no cover - optional dependency
+    from skyfield.api import Star, load, wgs84
+except Exception:  # pragma: no cover - handled via HAS_SKYFIELD flag
+    Star = None  # type: ignore
+    load = None  # type: ignore
+    wgs84 = None  # type: ignore
+
+
+DATASET = datasets_dir() / "star_names_iau.csv"
+
+_PLANET_KERNEL_KEYS: Mapping[str, str] = {
+    "sun": "sun",
+    "moon": "moon",
+    "mercury": "mercury",
+    "venus": "venus",
+    "mars": "mars",
+    "jupiter": "jupiter barycenter",
+    "saturn": "saturn barycenter",
+    "uranus": "uranus barycenter",
+    "neptune": "neptune barycenter",
+    "pluto": "pluto barycenter",
+}
+
+_ANGLE_CODES = {
+    "rising": "ASC",
+    "culminating": "MC",
+    "setting": "DESC",
+    "anti_culminating": "IC",
+}
+
+HAS_SKYFIELD = Star is not None and load is not None and wgs84 is not None
+
+__all__ = [
+    "HAS_SKYFIELD",
+    "ParanEvent",
+    "HeliacalPhase",
+    "compute_star_parans",
+    "compute_heliacal_phases",
+]
+
+
+@dataclass(frozen=True)
+class HorizonEvent:
+    """Angular crossing for a target relative to the local horizon."""
+
+    target: str
+    kind: str
+    timestamp: datetime
+    altitude: float
+    azimuth: float
+
+
+@dataclass(frozen=True)
+class ParanEvent:
+    """Moment when a fixed star and planet share simultaneous angularity."""
+
+    star: str
+    body: str
+    star_angle: str
+    body_angle: str
+    midpoint_ts: str
+    julian_day: float
+    delta_minutes: float
+    star_event: HorizonEvent
+    body_event: HorizonEvent
+
+
+@dataclass(frozen=True)
+class HeliacalPhase:
+    """Visibility estimate for a heliacal rising or setting."""
+
+    star: str
+    phase: str
+    timestamp: str
+    julian_day: float
+    star_altitude: float
+    sun_altitude: float
+    sun_star_separation: float
+    metadata: Mapping[str, object]
+
+
+class _ObserverContext:
+    """Reusable Skyfield objects for horizon calculations."""
+
+    def __init__(self, location: ChartLocation) -> None:
+        if not HAS_SKYFIELD:  # pragma: no cover - exercised in ImportError tests
+            raise ImportError("skyfield/jplephem not installed")
+        self.kernel = _load_kernel()
+        self.loader = load
+        self.ts = load.timescale()
+        self.earth = self.kernel["earth"]
+        self.location = location
+        self.observer = self.earth + wgs84.latlon(location.latitude, location.longitude)
+
+    def time_from_datetime(self, moment: datetime):
+        return self.ts.from_datetime(moment)
+
+
+def _normalize_day(moment: datetime | date_cls | str) -> datetime:
+    if isinstance(moment, datetime):
+        dt_utc = moment.astimezone(timezone.utc)
+    elif isinstance(moment, date_cls):
+        dt_utc = datetime.combine(moment, time(0, 0, tzinfo=timezone.utc))
+    else:
+        parsed = datetime.fromisoformat(str(moment).replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        dt_utc = parsed.astimezone(timezone.utc)
+    return dt_utc.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=UTC)
+
+
+def _load_kernel():
+    assert load is not None
+    for name in ("de440s.bsp", "de421.bsp", "de430t.bsp"):
+        path = Path(name)
+        try:
+            return load(str(path))
+        except Exception:
+            continue
+    raise FileNotFoundError("No local JPL kernel found (expected de440s.bsp)")
+
+
+def _lookup_ra_dec(name: str) -> tuple[float, float]:
+    if not DATASET.exists():  # pragma: no cover - dataset guaranteed in repo
+        raise FileNotFoundError(f"Fixed star dataset missing: {DATASET}")
+    needle = name.strip().lower()
+    with open(DATASET, newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            if row["name"].strip().lower() == needle:
+                return float(row["ra_deg"]), float(row["dec_deg"])
+    raise KeyError(f"Star not found in dataset: {name}")
+
+
+def _build_star(name: str) -> Star:
+    if not HAS_SKYFIELD:  # pragma: no cover - exercised in ImportError tests
+        raise ImportError("skyfield/jplephem not installed")
+    ra_deg, dec_deg = _lookup_ra_dec(name)
+    return Star(ra_hours=ra_deg / 15.0, dec_degrees=dec_deg)
+
+
+def _format_iso(moment: datetime) -> str:
+    return moment.replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _sample_range(day_start: datetime, *, minutes: int) -> Iterator[datetime]:
+    step = timedelta(minutes=minutes)
+    current = day_start
+    end = day_start + timedelta(days=1)
+    while current <= end:
+        yield current
+        current += step
+
+
+def _alt_az(ctx: _ObserverContext, target: Star | str, moment: datetime) -> tuple[float, float]:
+    time_obj = ctx.time_from_datetime(moment)
+    if isinstance(target, Star):
+        astrometric = ctx.observer.at(time_obj).observe(target)
+    else:
+        body = ctx.kernel.get(target)
+        if body is None:
+            raise KeyError(f"Kernel body not available: {target}")
+        astrometric = ctx.observer.at(time_obj).observe(body)
+    alt, az, _ = astrometric.apparent().altaz()
+    return float(alt.degrees), float(az.degrees % 360.0)
+
+
+def _generate_samples(
+    ctx: _ObserverContext,
+    target: Star | str,
+    name: str,
+    day_start: datetime,
+    *,
+    minutes: int,
+) -> list[HorizonEvent]:
+    samples: list[tuple[datetime, float, float]] = []
+    for moment in _sample_range(day_start, minutes=minutes):
+        altitude, azimuth = _alt_az(ctx, target, moment)
+        samples.append((moment, altitude, azimuth))
+
+    events: list[HorizonEvent] = []
+    for idx in range(1, len(samples)):
+        prev_t, prev_alt, prev_az = samples[idx - 1]
+        curr_t, curr_alt, curr_az = samples[idx]
+        if prev_alt <= 0.0 < curr_alt:
+            when = _bisect_altitude(ctx, target, prev_t, curr_t)
+            alt, az = _alt_az(ctx, target, when)
+            events.append(HorizonEvent(target=name, kind="rising", timestamp=when, altitude=alt, azimuth=az))
+        elif prev_alt >= 0.0 > curr_alt:
+            when = _bisect_altitude(ctx, target, prev_t, curr_t)
+            alt, az = _alt_az(ctx, target, when)
+            events.append(HorizonEvent(target=name, kind="setting", timestamp=when, altitude=alt, azimuth=az))
+
+    for idx in range(1, len(samples) - 1):
+        prev_t, prev_alt, _ = samples[idx - 1]
+        curr_t, curr_alt, _ = samples[idx]
+        next_t, next_alt, _ = samples[idx + 1]
+        if curr_alt > prev_alt and curr_alt > next_alt:
+            when = _refine_extremum(ctx, target, prev_t, curr_t, next_t)
+            alt, az = _alt_az(ctx, target, when)
+            events.append(
+                HorizonEvent(target=name, kind="culminating", timestamp=when, altitude=alt, azimuth=az)
+            )
+        elif curr_alt < prev_alt and curr_alt < next_alt:
+            when = _refine_extremum(ctx, target, prev_t, curr_t, next_t)
+            alt, az = _alt_az(ctx, target, when)
+            events.append(
+                HorizonEvent(
+                    target=name,
+                    kind="anti_culminating",
+                    timestamp=when,
+                    altitude=alt,
+                    azimuth=az,
+                )
+            )
+
+    events.sort(key=lambda evt: evt.timestamp)
+    return events
+
+
+def _bisect_altitude(
+    ctx: _ObserverContext,
+    target: Star | str,
+    start: datetime,
+    end: datetime,
+    *,
+    max_iter: int = 18,
+) -> datetime:
+    low = start
+    high = end
+    low_alt, _ = _alt_az(ctx, target, low)
+    high_alt, _ = _alt_az(ctx, target, high)
+    for _ in range(max_iter):
+        mid = low + (high - low) / 2
+        mid_alt, _ = _alt_az(ctx, target, mid)
+        if abs(mid_alt) < 1e-4 or (high - low) <= timedelta(seconds=5):
+            return mid
+        if low_alt * mid_alt <= 0:
+            high = mid
+            high_alt = mid_alt
+        else:
+            low = mid
+            low_alt = mid_alt
+    return low + (high - low) / 2
+
+
+def _refine_extremum(
+    ctx: _ObserverContext,
+    target: Star | str,
+    before: datetime,
+    center: datetime,
+    after: datetime,
+) -> datetime:
+    step_seconds = (after - center).total_seconds()
+    if step_seconds == 0:
+        return center
+    alt_before, _ = _alt_az(ctx, target, before)
+    alt_center, _ = _alt_az(ctx, target, center)
+    alt_after, _ = _alt_az(ctx, target, after)
+    denom = (alt_before - 2.0 * alt_center + alt_after)
+    if abs(denom) < 1e-6:
+        return center
+    offset = 0.5 * (alt_before - alt_after) / denom
+    offset = max(min(offset, 1.0), -1.0)
+    delta_seconds = offset * step_seconds
+    moment = center + timedelta(seconds=delta_seconds)
+    return moment
+
+
+def _match_parans(
+    star: str,
+    body: str,
+    star_events: Sequence[HorizonEvent],
+    body_events: Sequence[HorizonEvent],
+    *,
+    threshold_minutes: float,
+) -> list[ParanEvent]:
+    matches: list[ParanEvent] = []
+    for star_evt in star_events:
+        for body_evt in body_events:
+            delta = abs((star_evt.timestamp - body_evt.timestamp).total_seconds()) / 60.0
+            if delta <= threshold_minutes:
+                midpoint = star_evt.timestamp + (body_evt.timestamp - star_evt.timestamp) / 2
+                midpoint_iso = _format_iso(midpoint)
+                matches.append(
+                    ParanEvent(
+                        star=star,
+                        body=body,
+                        star_angle=_ANGLE_CODES.get(star_evt.kind, star_evt.kind),
+                        body_angle=_ANGLE_CODES.get(body_evt.kind, body_evt.kind),
+                        midpoint_ts=midpoint_iso,
+                        julian_day=iso_to_jd(midpoint_iso),
+                        delta_minutes=delta,
+                        star_event=star_evt,
+                        body_event=body_evt,
+                    )
+                )
+    matches.sort(key=lambda evt: evt.delta_minutes)
+    return matches
+
+
+def compute_star_parans(
+    star: str,
+    day: datetime | date_cls | str,
+    location: ChartLocation,
+    *,
+    bodies: Iterable[str] | None = None,
+    step_minutes: int = 4,
+    threshold_minutes: float = 12.0,
+) -> list[ParanEvent]:
+    """Return fixed star parans for ``star`` on ``day`` at ``location``."""
+
+    ctx = _ObserverContext(location)
+    star_obj = _build_star(star)
+    day_start = _normalize_day(day)
+    star_events = _generate_samples(ctx, star_obj, star, day_start, minutes=step_minutes)
+    bodies = tuple(bodies or _PLANET_KERNEL_KEYS.keys())
+    matches: list[ParanEvent] = []
+    for body in bodies:
+        key = _PLANET_KERNEL_KEYS.get(body.lower())
+        if not key:
+            continue
+        body_events = _generate_samples(ctx, key, body, day_start, minutes=step_minutes)
+        matches.extend(_match_parans(star, body, star_events, body_events, threshold_minutes=threshold_minutes))
+    matches.sort(key=lambda evt: (evt.midpoint_ts, evt.delta_minutes))
+    return matches
+
+
+def compute_heliacal_phases(
+    star: str,
+    day: datetime | date_cls | str,
+    location: ChartLocation,
+    *,
+    altitude_threshold: float = 1.5,
+    sun_altitude_limit: float = -8.0,
+    step_minutes: int = 4,
+) -> list[HeliacalPhase]:
+    """Estimate heliacal rising and setting for ``star`` at ``location``."""
+
+    ctx = _ObserverContext(location)
+    star_obj = _build_star(star)
+    day_start = _normalize_day(day)
+    star_events = _generate_samples(ctx, star_obj, star, day_start, minutes=step_minutes)
+    sun_events = _generate_samples(ctx, "sun", "sun", day_start, minutes=step_minutes)
+
+    phases: list[HeliacalPhase] = []
+    for star_evt in star_events:
+        if star_evt.kind == "rising":
+            sunrise = _next_event(sun_events, "rising", star_evt.timestamp)
+            if sunrise is None:
+                continue
+            visibility = _scan_visibility(
+                ctx,
+                star_obj,
+                "sun",
+                start=star_evt.timestamp,
+                end=sunrise.timestamp,
+                altitude_threshold=altitude_threshold,
+                sun_altitude_limit=sun_altitude_limit,
+            )
+            if visibility is None:
+                continue
+            sun_alt, _ = _alt_az(ctx, "sun", visibility)
+            star_alt, star_az = _alt_az(ctx, star_obj, visibility)
+            separation = _separation(ctx, star_obj, "sun", visibility)
+            visibility_iso = _format_iso(visibility)
+            phases.append(
+                HeliacalPhase(
+                    star=star,
+                    phase="heliacal_rising",
+                    timestamp=visibility_iso,
+                    julian_day=iso_to_jd(visibility_iso),
+                    star_altitude=star_alt,
+                    sun_altitude=sun_alt,
+                    sun_star_separation=separation,
+                    metadata={
+                        "sunrise": _format_iso(sunrise.timestamp),
+                        "star_azimuth": star_az,
+                    },
+                )
+            )
+        elif star_evt.kind == "setting":
+            sunset = _previous_event(sun_events, "setting", star_evt.timestamp)
+            if sunset is None:
+                continue
+            visibility = _scan_visibility(
+                ctx,
+                star_obj,
+                "sun",
+                start=sunset.timestamp,
+                end=star_evt.timestamp,
+                altitude_threshold=altitude_threshold,
+                sun_altitude_limit=sun_altitude_limit,
+            )
+            if visibility is None:
+                continue
+            sun_alt, _ = _alt_az(ctx, "sun", visibility)
+            star_alt, star_az = _alt_az(ctx, star_obj, visibility)
+            separation = _separation(ctx, star_obj, "sun", visibility)
+            visibility_iso = _format_iso(visibility)
+            phases.append(
+                HeliacalPhase(
+                    star=star,
+                    phase="heliacal_setting",
+                    timestamp=visibility_iso,
+                    julian_day=iso_to_jd(visibility_iso),
+                    star_altitude=star_alt,
+                    sun_altitude=sun_alt,
+                    sun_star_separation=separation,
+                    metadata={
+                        "sunset": _format_iso(sunset.timestamp),
+                        "star_azimuth": star_az,
+                    },
+                )
+            )
+
+    phases.sort(key=lambda phase: phase.timestamp)
+    return phases
+
+
+def _scan_visibility(
+    ctx: _ObserverContext,
+    star_target: Star,
+    sun_key: str,
+    *,
+    start: datetime,
+    end: datetime,
+    altitude_threshold: float,
+    sun_altitude_limit: float,
+) -> datetime | None:
+    step = timedelta(minutes=1)
+    current = start
+    best: datetime | None = None
+    while current <= end:
+        star_alt, _ = _alt_az(ctx, star_target, current)
+        sun_alt, _ = _alt_az(ctx, sun_key, current)
+        if star_alt >= altitude_threshold and sun_alt <= sun_altitude_limit:
+            best = current
+        current += step
+    return best
+
+
+def _next_event(events: Sequence[HorizonEvent], kind: str, moment: datetime) -> HorizonEvent | None:
+    for event in events:
+        if event.kind == kind and event.timestamp >= moment:
+            return event
+    return None
+
+
+def _previous_event(events: Sequence[HorizonEvent], kind: str, moment: datetime) -> HorizonEvent | None:
+    for event in reversed(events):
+        if event.kind == kind and event.timestamp <= moment:
+            return event
+    return None
+
+
+def _separation(
+    ctx: _ObserverContext,
+    star_target: Star,
+    sun_key: str,
+    moment: datetime,
+) -> float:
+    time_obj = ctx.time_from_datetime(moment)
+    star_position = ctx.earth.at(time_obj).observe(star_target).apparent()
+    sun_position = ctx.earth.at(time_obj).observe(ctx.kernel[sun_key]).apparent()
+    return float(star_position.separation_from(sun_position).degrees)
+

--- a/astroengine/modules/__init__.py
+++ b/astroengine/modules/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from .registry import AstroChannel, AstroModule, AstroRegistry, AstroSubchannel, AstroSubmodule
+from .cycles import register_cycles_module
 from .esoteric import register_esoteric_module
 from .predictive import register_predictive_module
 from .vca import register_vca_module
@@ -25,6 +26,7 @@ def bootstrap_default_registry() -> AstroRegistry:
     register_vca_module(registry)
     register_esoteric_module(registry)
     register_predictive_module(registry)
+    register_cycles_module(registry)
     return registry
 
 

--- a/astroengine/modules/cycles/__init__.py
+++ b/astroengine/modules/cycles/__init__.py
@@ -1,0 +1,116 @@
+"""Registry wiring for generational cycles and astrological ages."""
+
+from __future__ import annotations
+
+from ...ephemeris.sidereal import DEFAULT_SIDEREAL_AYANAMSHA
+from ..registry import AstroRegistry
+
+__all__ = ["register_cycles_module"]
+
+
+def register_cycles_module(registry: AstroRegistry) -> None:
+    """Attach cycle analytics metadata to the shared registry."""
+
+    module = registry.register_module(
+        "cycles",
+        metadata={
+            "description": "Generational outer-planet analytics, fixed-star parans, and astrological age tooling.",
+        },
+    )
+
+    fixedstars = module.register_submodule(
+        "fixedstars",
+        metadata={
+            "description": "Horizon-based star analyses referencing the IAU bright-star dataset.",
+            "datasets": ["star_names_iau.csv"],
+        },
+    )
+
+    parans = fixedstars.register_channel(
+        "parans",
+        metadata={
+            "description": "Simultaneous angularity detection for stars and planets using Skyfield.",
+            "sources": ["IAU Star Names", "JPL DE ephemerides"],
+        },
+    )
+    parans.register_subchannel(
+        "daily_windows",
+        metadata={
+            "description": "Daily parans across ASC/MC/DESC/IC angles with configurable thresholds.",
+            "interfaces": ["astroengine.fixedstars.parans.compute_star_parans"],
+        },
+    )
+
+    heliacal = fixedstars.register_channel(
+        "heliacal",
+        metadata={
+            "description": "Heliacal rising/setting visibility estimates derived from twilight scans.",
+            "sources": ["IAU Star Names", "JPL DE ephemerides"],
+        },
+    )
+    heliacal.register_subchannel(
+        "visibility",
+        metadata={
+            "description": "Sun-altitude gated visibility metrics for dawn/dusk windows.",
+            "interfaces": ["astroengine.fixedstars.parans.compute_heliacal_phases"],
+        },
+    )
+
+    generational = module.register_submodule(
+        "generational_cycles",
+        metadata={
+            "description": "Outer-planet separations and wave diagnostics for mundane dashboards.",
+            "bodies": ["Jupiter", "Saturn", "Uranus", "Neptune", "Pluto"],
+        },
+    )
+    outer_planets = generational.register_channel(
+        "outer_planets",
+        metadata={
+            "description": "Timelines and derivative measures for outer-planet pairs.",
+            "sources": ["Swiss Ephemeris"],
+        },
+    )
+    outer_planets.register_subchannel(
+        "timeline",
+        metadata={
+            "description": "Pairwise separation samples with aspect tagging for dashboard visualisations.",
+            "interfaces": ["astroengine.cycles.outer_cycle_timeline"],
+        },
+    )
+    outer_planets.register_subchannel(
+        "neptune_pluto_wave",
+        metadata={
+            "description": "Neptune–Pluto wave analysis with rate-of-change metrics.",
+            "interfaces": ["astroengine.cycles.neptune_pluto_wave"],
+        },
+    )
+
+    ages = module.register_submodule(
+        "astrological_ages",
+        metadata={
+            "description": "Aries ingress ayanamsha tracking for astrological age research.",
+            "default_ayanamsha": DEFAULT_SIDEREAL_AYANAMSHA,
+        },
+    )
+    sidereal = ages.register_channel(
+        "sidereal_projection",
+        metadata={
+            "description": "Projection of the tropical vernal point into sidereal longitudes.",
+            "sources": ["Swiss Ephemeris"],
+        },
+    )
+    sidereal.register_subchannel(
+        "series",
+        metadata={
+            "description": "Per-year Aries ingress ayanamsha offsets and derived age sign.",
+            "interfaces": ["astroengine.cycles.compute_age_series"],
+        },
+    )
+    sidereal.register_subchannel(
+        "boundaries",
+        metadata={
+            "description": "Astrological age boundaries derived from sidereal ingress data.",
+            "interfaces": ["astroengine.cycles.derive_age_boundaries"],
+        },
+    )
+

--- a/astroengine/mundane/__init__.py
+++ b/astroengine/mundane/__init__.py
@@ -7,10 +7,13 @@ from .ingress import (
     compute_solar_ingress_chart,
     compute_solar_quartet,
 )
+from .ingress_charts import IngressChart, compute_cardinal_ingress_charts
 
 __all__ = [
     "MundaneAspect",
     "SolarIngressChart",
+    "IngressChart",
+    "compute_cardinal_ingress_charts",
     "compute_solar_ingress_chart",
     "compute_solar_quartet",
 ]

--- a/astroengine/mundane/ingress_charts.py
+++ b/astroengine/mundane/ingress_charts.py
@@ -85,7 +85,7 @@ def compute_cardinal_ingress_charts(
             bodies=body_map,
             aspect_angles=angles,
             orb_profile=orb_profile,
-            chart_config=chart_config,
+            config=chart_config,
             adapter=adapter,
         )
         results[sign_key] = IngressChart(sign=match.sign, event=match, chart=natal)

--- a/astroengine/providers/swiss_provider.py
+++ b/astroengine/providers/swiss_provider.py
@@ -1,21 +1,24 @@
-# >>> AUTO-GEN BEGIN: AE Swiss Provider v1.0
+"""Swiss ephemeris-backed provider registration and fallbacks."""
+
 from __future__ import annotations
 
 from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Dict, Iterable
 
-
-
 from astroengine.canonical import BodyPosition
 from astroengine.core.time import TimeConversion, to_tt
-from astroengine.ephemeris import EphemerisAdapter, EphemerisConfig, ObserverLocation, TimeScaleContext
-
+from astroengine.ephemeris import (
+    EphemerisAdapter,
+    EphemerisConfig,
+    ObserverLocation,
+    TimeScaleContext,
+)
 from astroengine.ephemeris.utils import get_se_ephe_path
 
-try:
-    import swisseph as swe  # pyswisseph imports the module name 'swisseph'
-except Exception:  # pragma: no cover
+try:  # pragma: no cover - runtime optional dependency
+    import swisseph as swe  # type: ignore[import]
+except Exception:  # pragma: no cover - fallback path exercised elsewhere
     swe = None
 
 try:  # pragma: no cover - exercised via runtime fallback
@@ -32,7 +35,7 @@ try:  # pragma: no cover - exercised via runtime fallback
     from pymeeus.Venus import Venus as _Venus
 
     _PYMEEUS_AVAILABLE = True
-except Exception:  # pragma: no cover
+except Exception:  # pragma: no cover - fallback unavailable
     Epoch = None  # type: ignore[assignment]
     (
         _Mercury,
@@ -45,9 +48,7 @@ except Exception:  # pragma: no cover
         _Pluto,
         _Sun,
         _Moon,
-    ) = (
-        None,
-    ) * 10  # type: ignore[assignment]
+    ) = (None,) * 10  # type: ignore[assignment]
     _PYMEEUS_AVAILABLE = False
 
 from . import register_provider
@@ -67,14 +68,18 @@ _BODY_IDS = {
 
 
 class SwissProvider:
+    """Ephemeris provider backed by :class:`EphemerisAdapter`."""
+
     def __init__(self) -> None:
         if swe is None:
             raise ImportError("pyswisseph is not installed")
-        eph = get_se_ephe_path()
-        if eph:
-            swe.set_ephe_path(eph)
-        self._config = EphemerisConfig(ephemeris_path=str(eph) if eph else None)
-        self._adapter = EphemerisAdapter(self._config)
+        ephe_path = get_se_ephe_path()
+        config = EphemerisConfig(
+            ephemeris_path=str(ephe_path) if ephe_path else None,
+            time_scale=TimeScaleContext(),
+        )
+        self._config = config
+        self._adapter = EphemerisAdapter(config)
 
     def configure(
         self,
@@ -86,23 +91,20 @@ class SwissProvider:
     ) -> None:
         """Update ephemeris configuration used by the provider."""
 
-        cfg = self._config
         updates: dict[str, object] = {}
         if topocentric is not None:
             updates["topocentric"] = topocentric
-        if observer is not None or (topocentric is False and cfg.observer is not None):
+        if observer is not None or (topocentric is False and self._config.observer is not None):
             updates["observer"] = observer
         if sidereal is not None:
             updates["sidereal"] = sidereal
         if time_scale is not None:
             updates["time_scale"] = time_scale
         if updates:
-            cfg = replace(cfg, **updates)
-            self._config = cfg
-            self._adapter = EphemerisAdapter(cfg)
+            self._config = replace(self._config, **updates)
+            self._adapter = EphemerisAdapter(self._config)
 
-    @staticmethod
-    def _normalize_iso(iso_utc: str) -> datetime:
+    def _normalize_iso(self, iso_utc: str) -> datetime:
         dt = datetime.fromisoformat(iso_utc.replace("Z", "+00:00"))
         return dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
@@ -111,47 +113,31 @@ class SwissProvider:
 
     def _body_id(self, name: str) -> int:
         key = name.lower()
-        if key not in _BODY_IDS:
+        code = _BODY_IDS.get(key)
+        if code is None:
             raise KeyError(key)
-        return _BODY_IDS[key]
+        return code
 
     def positions_ecliptic(
         self, iso_utc: str, bodies: Iterable[str]
     ) -> Dict[str, Dict[str, float]]:
-
-        dt = datetime.fromisoformat(iso_utc.replace("Z", "+00:00"))
-        dt_utc = dt.astimezone(timezone.utc) if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
-
-        adapter = SwissEphemerisAdapter.get_default_adapter()
-        jd_ut = adapter.julian_day(dt_utc)
-
         conversion = self._time_conversion(iso_utc)
-
         out: Dict[str, Dict[str, float]] = {}
         for name in bodies:
             try:
-                body_id = self._body_id(name)
+                sample = self._adapter.sample(self._body_id(name), conversion)
             except KeyError:
                 continue
-
-            ipl = _BODY_IDS[name.lower()]
-            position = adapter.body_position(jd_ut, ipl, body_name=name)
-            out[name] = {
-                "lon": position.longitude,
-                "decl": position.latitude,
-                "speed_lon": position.speed_longitude,
-
-            sample = self._adapter.sample(body_id, conversion)
             out[name] = {
                 "lon": sample.longitude % 360.0,
-                "decl": sample.declination,
+                "decl": sample.latitude,
                 "speed_lon": sample.speed_longitude,
-
             }
         return out
 
     def position(self, body: str, ts_utc: str) -> BodyPosition:
-        sample = self._adapter.sample(self._body_id(body), self._time_conversion(ts_utc))
+        conversion = self._time_conversion(ts_utc)
+        sample = self._adapter.sample(self._body_id(body), conversion)
         return BodyPosition(
             lon=sample.longitude % 360.0,
             lat=sample.latitude,
@@ -267,4 +253,3 @@ def _register() -> None:
 
 
 _register()
-# >>> AUTO-GEN END: AE Swiss Provider v1.0

--- a/astroengine/timelords/__init__.py
+++ b/astroengine/timelords/__init__.py
@@ -2,14 +2,8 @@
 
 from __future__ import annotations
 
-
-from .profections import annual_profections
-from .dashas import vimsottari_dashas
-
-__all__ = ["annual_profections", "vimsottari_dashas"]
-
-
 from .active import TimelordCalculator, active_timelords
+from .dashas import vimsottari_dashas
 from .models import TimelordPeriod, TimelordStack
 from .profections import annual_profections, generate_profection_periods
 from .vimshottari import generate_vimshottari_periods
@@ -20,8 +14,9 @@ __all__ = [
     "generate_profection_periods",
     "generate_vimshottari_periods",
     "generate_zodiacal_releasing",
+    "vimsottari_dashas",
     "active_timelords",
     "TimelordCalculator",
     "TimelordPeriod",
     "TimelordStack",
-
+]

--- a/astroengine/timelords/dashas.py
+++ b/astroengine/timelords/dashas.py
@@ -1,34 +1,21 @@
-
-"""Vimsottari dasha timelines derived from the natal Moon nakshatra."""
-
-from __future__ import annotations
-
-from typing import List
-
-from ..detectors.common import iso_to_jd, jd_to_iso, moon_lon
-from ..events import DashaPeriod
-
-__all__ = ["vimsottari_dashas"]
-
-
-_DASHA_SEQUENCE: tuple[str, ...] = (
-
-"""Vimshottari dasha timelines derived from the Moon's nakshatra."""
+"""Vimśottarī daśā calculators."""
 
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import Sequence
+from typing import Iterable, List, Sequence, Tuple
 
-from ..detectors.common import UNIX_EPOCH_JD
-from ..events import DashaPeriodEvent
+from ..detectors.common import UNIX_EPOCH_JD, iso_to_jd, jd_to_iso, moon_lon
+from ..events import DashaPeriod, DashaPeriodEvent
 from ..utils.angles import norm360
 
+__all__ = ["vimsottari_dashas", "compute_vimshottari_dasha"]
+
 YEAR_IN_DAYS = 365.2425
-NAKSHATRA_SIZE = 360.0 / 27.0
+SIDEREAL_YEAR_DAYS = 365.25636
+NAKSHATRA_DEG = 360.0 / 27.0
 
-_DASHA_ORDER = [
-
+_DASHA_ORDER: Tuple[str, ...] = (
     "Ketu",
     "Venus",
     "Sun",
@@ -38,14 +25,9 @@ _DASHA_ORDER = [
     "Jupiter",
     "Saturn",
     "Mercury",
-
 )
 
-
-]
-
 _DASHA_YEARS = {
-
     "Ketu": 7.0,
     "Venus": 20.0,
     "Sun": 6.0,
@@ -57,23 +39,21 @@ _DASHA_YEARS = {
     "Mercury": 17.0,
 }
 
-_TOTAL_SEQUENCE_YEARS = sum(_DASHA_LENGTH_YEARS.values())
-_NAKSHATRA_DEG = 360.0 / 27.0
-_SIDEREAL_YEAR_DAYS = 365.25636
+_TOTAL_SEQUENCE_YEARS = sum(_DASHA_YEARS.values())
 
 
 def _major_index_and_fraction(natal_jd: float) -> tuple[int, float]:
     moon_longitude = moon_lon(natal_jd) % 360.0
-    nak_index = int(moon_longitude // _NAKSHATRA_DEG)
-    within = moon_longitude - nak_index * _NAKSHATRA_DEG
-    fraction = within / _NAKSHATRA_DEG
-    major_index = nak_index % len(_DASHA_SEQUENCE)
+    nak_index = int(moon_longitude // NAKSHATRA_DEG)
+    within = moon_longitude - nak_index * NAKSHATRA_DEG
+    fraction = within / NAKSHATRA_DEG
+    major_index = nak_index % len(_DASHA_ORDER)
     return major_index, fraction
 
 
 def _major_start_jd(natal_jd: float, major_index: int, fraction: float) -> float:
-    major_lord = _DASHA_SEQUENCE[major_index]
-    major_days = _DASHA_LENGTH_YEARS[major_lord] * _SIDEREAL_YEAR_DAYS
+    major_lord = _DASHA_ORDER[major_index]
+    major_days = _DASHA_YEARS[major_lord] * SIDEREAL_YEAR_DAYS
     elapsed_days = major_days * fraction
     return natal_jd - elapsed_days
 
@@ -83,18 +63,18 @@ def _iterate_major_periods(
     major_index: int,
     start_fraction: float,
     end_jd: float,
-):
+) -> Iterable[tuple[int, str, float, float, float]]:
     current_start = start_jd
     index = major_index
     fraction = start_fraction
     first = True
     while current_start <= end_jd:
-        lord = _DASHA_SEQUENCE[index]
-        length_days = _DASHA_LENGTH_YEARS[lord] * _SIDEREAL_YEAR_DAYS
+        lord = _DASHA_ORDER[index]
+        length_days = _DASHA_YEARS[lord] * SIDEREAL_YEAR_DAYS
         current_end = current_start + length_days
         yield index, lord, current_start, current_end, (fraction if first else 0.0)
         current_start = current_end
-        index = (index + 1) % len(_DASHA_SEQUENCE)
+        index = (index + 1) % len(_DASHA_ORDER)
         fraction = 0.0
         first = False
 
@@ -104,13 +84,13 @@ def _sub_periods(
     major_start: float,
     major_end: float,
     start_fraction: float,
-):
+) -> Iterable[tuple[int, str, float, float]]:
     major_length = major_end - major_start
     cumulative = 0.0
-    for offset in range(len(_DASHA_SEQUENCE)):
-        sub_index = (major_index + offset) % len(_DASHA_SEQUENCE)
-        sub_lord = _DASHA_SEQUENCE[sub_index]
-        fraction = _DASHA_LENGTH_YEARS[sub_lord] / _TOTAL_SEQUENCE_YEARS
+    for offset in range(len(_DASHA_ORDER)):
+        sub_index = (major_index + offset) % len(_DASHA_ORDER)
+        sub_lord = _DASHA_ORDER[sub_index]
+        fraction = _DASHA_YEARS[sub_lord] / _TOTAL_SEQUENCE_YEARS
         sub_start_fraction = cumulative
         sub_end_fraction = cumulative + fraction
         cumulative = sub_end_fraction
@@ -133,7 +113,7 @@ def vimsottari_dashas(
     *,
     include_partial: bool = True,
 ) -> List[DashaPeriod]:
-    """Return Vimsottari dasha sub-periods intersecting ``start_ts`` → ``end_ts``."""
+    """Return Vimśottarī daśā sub-periods intersecting the requested window."""
 
     start_jd = iso_to_jd(start_ts)
     end_jd = iso_to_jd(end_ts)
@@ -145,7 +125,7 @@ def vimsottari_dashas(
     major_index, major_fraction = _major_index_and_fraction(natal_jd)
     major_start = _major_start_jd(natal_jd, major_index, major_fraction)
 
-    periods: list[DashaPeriod] = []
+    periods: List[DashaPeriod] = []
 
     for idx, lord, seg_start, seg_end, start_frac in _iterate_major_periods(
         major_start, major_index, major_fraction, end_jd
@@ -153,7 +133,9 @@ def vimsottari_dashas(
         if seg_end < start_jd and not include_partial:
             continue
 
-        for sub_idx, sub_lord, sub_start, sub_end in _sub_periods(idx, seg_start, seg_end, start_frac):
+        for sub_idx, sub_lord, sub_start, sub_end in _sub_periods(
+            idx, seg_start, seg_end, start_frac
+        ):
             if sub_end < start_jd and not include_partial:
                 continue
             if sub_end < start_jd:
@@ -178,10 +160,6 @@ def vimsottari_dashas(
 
     periods.sort(key=lambda period: period.jd)
     return periods
-
-_TOTAL_CYCLE_YEARS = sum(_DASHA_YEARS.values())
-
-__all__ = ["compute_vimshottari_dasha"]
 
 
 def _ensure_utc(moment: datetime) -> datetime:
@@ -222,7 +200,7 @@ def _generate_antar_periods(
     epsilon = timedelta(days=1e-6)
 
     for sub in order:
-        full_years = maha_total_years * (_DASHA_YEARS[sub] / _TOTAL_CYCLE_YEARS)
+        full_years = maha_total_years * (_DASHA_YEARS[sub] / _TOTAL_SEQUENCE_YEARS)
         if remaining_skip >= full_years:
             remaining_skip -= full_years
             continue
@@ -279,6 +257,8 @@ def compute_vimshottari_dasha(
     levels: Sequence[str] = ("maha", "antar"),
     method: str = "vimshottari",
 ) -> list[DashaPeriodEvent]:
+    """Return Vimśottarī daśā periods from a natal Moon longitude."""
+
     if cycles <= 0:
         raise ValueError("cycles must be >= 1")
     levels_normalized = {level.lower() for level in levels}
@@ -289,12 +269,12 @@ def compute_vimshottari_dasha(
 
     start = _ensure_utc(start)
     longitude = norm360(moon_longitude_deg)
-    nak_index = int(longitude // NAKSHATRA_SIZE)
+    nak_index = int(longitude // NAKSHATRA_DEG)
     ruler_index = nak_index % len(_DASHA_ORDER)
     ruler = _DASHA_ORDER[ruler_index]
     total_years = _DASHA_YEARS[ruler]
-    offset = longitude % NAKSHATRA_SIZE
-    fraction_elapsed = offset / NAKSHATRA_SIZE
+    offset = longitude % NAKSHATRA_DEG
+    fraction_elapsed = offset / NAKSHATRA_DEG
     elapsed_years = total_years * fraction_elapsed
     current = start
     events: list[DashaPeriodEvent] = []
@@ -340,4 +320,3 @@ def compute_vimshottari_dasha(
                 )
             current = maha_end
     return events
-

--- a/docs/cycles_overview.md
+++ b/docs/cycles_overview.md
@@ -1,0 +1,54 @@
+# Cycles & Astrological Ages Toolkit
+
+AstroEngine now ships with a dedicated cycles namespace covering fixed-star
+parans, heliacal phases, outer-planet timelines, and astrological age
+analytics. The new modules extend the module → submodule → channel hierarchy
+without replacing any existing registries so downstream SolarFire datasets
+continue to load without regression.
+
+## Fixed-star parans and heliacal phases
+
+- :func:`astroengine.fixedstars.parans.compute_star_parans` samples the local
+  horizon using Skyfield/JPL kernels to flag moments when a fixed star and a
+  planet simultaneously occupy ASC/MC/DESC/IC angles. The output contains the
+  midpoint timestamp, underlying horizon events, and the absolute separation in
+  minutes for downstream dashboards.
+- :func:`astroengine.fixedstars.parans.compute_heliacal_phases` scans the
+  twilight band either side of sunrise and sunset to estimate heliacal rising
+  and setting windows. Visibility is only reported when the Sun remains below a
+  configurable altitude threshold so every result traces back to real solar and
+  stellar altitude measurements.
+
+Both workflows reference the ``star_names_iau.csv`` dataset shipped with the
+repository and require a locally installed Skyfield kernel (``de440s.bsp`` or
+compatible).
+
+## Generational cycle dashboards
+
+- :func:`astroengine.cycles.outer_cycle_timeline` evaluates Swiss Ephemeris
+  longitudes for Jupiter through Pluto at a regular cadence (default: 30 days)
+  and records the signed/angular separation for every planet pair. Aspect tags
+  (0°, 45°, 60°, 90°, 120°, 135°, 150°, 180°) are attached when the separation
+  falls within a configurable orb so dashboards can highlight conjunctions or
+  alignments automatically.
+- :func:`astroengine.cycles.neptune_pluto_wave` specialises the timeline for the
+  Neptune–Pluto pair and adds a derivative column expressed in degrees per year
+  to track wave crests or troughs in mundane research.
+
+All computations flow through :class:`astroengine.ephemeris.SwissEphemerisAdapter`
+and therefore inherit the project’s provenance guarantees and caching rules.
+
+## Astrological ages
+
+- :func:`astroengine.cycles.compute_age_series` locates the Sun’s Aries ingress
+  for each requested year and records the ayanamsha offset together with the
+  sidereal longitude of the tropical vernal point. The active “age” sign is the
+  sidereal sign containing the projected point.
+- :func:`astroengine.cycles.derive_age_boundaries` collapses the series into
+  boundary markers for dashboards. By default the Lahiri ayanamsha is used, but
+  any ayanamsha supported by :class:`SwissEphemerisAdapter` may be supplied.
+
+These additions surface under a new ``cycles`` module in the registry so API
+consumers can introspect capabilities and datasets alongside the existing VCA
+and esoteric metadata.
+

--- a/profiles/aspects_policy.json
+++ b/profiles/aspects_policy.json
@@ -54,8 +54,8 @@
     "biseptile":  {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
     "triseptile": {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
     "tredecile":  {"luminary": 1.5, "personal": 1.5, "social": 1.5, "outer": 1.5},
-    "undecile":   {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0}
-    "sesquiquadrate":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0}
+    "undecile":   {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
+    "sesquiquadrate": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0}
 
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "ics>=0.7",
   "tzdata>=2023.3",
   "pluggy>=1.5",
+  "streamlit>=1.30",
 ]
 
 [project.optional-dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest>=8.0.0  # ENSURE-LINE
 pytest-cov>=4.1.0  # ENSURE-LINE
 hypothesis>=6.92.0  # ENSURE-LINE
 genbadge[coverage]>=1.1.1  # ENSURE-LINE
+streamlit>=1.30  # ENSURE-LINE

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pluggy>=1.5
 click>=8.1
 rich>=13.7
 ics>=0.7
+streamlit>=1.30
 # QA / property-based testing (used by tests)
 hypothesis>=6.112
 # Optional groups (comment in as needed):

--- a/tests/test_cycles_features.py
+++ b/tests/test_cycles_features.py
@@ -1,0 +1,51 @@
+import pytest
+
+from astroengine.chart.natal import ChartLocation
+from astroengine.cycles import (
+    compute_age_series,
+    derive_age_boundaries,
+    neptune_pluto_wave,
+    outer_cycle_timeline,
+)
+from astroengine.fixedstars import parans
+
+
+def test_outer_cycle_timeline_generates_samples():
+    timeline = outer_cycle_timeline(1990, 1990, step_days=120.0)
+    assert timeline.samples
+    assert {sample.phase for sample in timeline.samples} <= {"waxing", "waning"}
+    assert all(0.0 <= sample.separation <= 180.0 for sample in timeline.samples)
+
+
+def test_neptune_pluto_wave_rates_have_values():
+    wave = neptune_pluto_wave(1990, 1992, step_days=180.0)
+    assert wave.samples
+    rates = [point.rate_deg_per_year for point in wave.samples]
+    assert rates[0] is None
+    assert any(rate is not None for rate in rates[1:])
+
+
+def test_age_series_boundaries():
+    series = compute_age_series(2000, 2002)
+    assert len(series.samples) == 3
+    assert all(sample.zodiac_sign in {"Pisces", "Aquarius"} for sample in series.samples)
+    boundaries = derive_age_boundaries(series)
+    assert boundaries
+    assert boundaries[0].zodiac_sign == series.samples[0].zodiac_sign
+
+
+def test_fixed_star_parans_import_guard():
+    if parans.HAS_SKYFIELD:
+        pytest.skip("skyfield available; guard not triggered")
+    location = ChartLocation(latitude=0.0, longitude=0.0)
+    with pytest.raises(ImportError):
+        parans.compute_star_parans("Regulus", "2020-03-20", location)
+
+
+def test_heliacal_phases_import_guard():
+    if parans.HAS_SKYFIELD:
+        pytest.skip("skyfield available; guard not triggered")
+    location = ChartLocation(latitude=0.0, longitude=0.0)
+    with pytest.raises(ImportError):
+        parans.compute_heliacal_phases("Regulus", "2020-03-20", location)
+

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -22,3 +22,18 @@ def test_serialize_vca_ruleset_matches_registry():
     aspects = rulesets.get_channel("aspects")
     definitions = aspects.get_subchannel("definitions").describe()
     assert payload["id"] == definitions["payload"]["id"]
+
+
+def test_cycles_module_registered():
+    module = DEFAULT_REGISTRY.get_module("cycles")
+    fixedstars = module.get_submodule("fixedstars")
+    parans = fixedstars.get_channel("parans")
+    assert "daily_windows" in parans.subchannels
+    heliacal = fixedstars.get_channel("heliacal")
+    assert "visibility" in heliacal.subchannels
+    generational = module.get_submodule("generational_cycles")
+    outer = generational.get_channel("outer_planets")
+    assert "timeline" in outer.subchannels
+    ages = module.get_submodule("astrological_ages")
+    sidereal = ages.get_channel("sidereal_projection")
+    assert "series" in sidereal.subchannels


### PR DESCRIPTION
## Summary
- rebuild the Swiss ephemeris adapter and provider around `ChartConfig`, centralized house-system codes, and canonical body/house position dataclasses
- normalize event dataclasses and ingress detectors to expose sign-from/to, retrograde, and speed fields while tightening CLI support for natals and timelord period generation
- streamline the Streamlit transit scanner sidebar, detector selection, and scan caching so UI tests can locate widgets and verify cache hits deterministically

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1a0a9c8a483249b5c1c3f2b031ef1