### PR TITLE
Support sidereal mode in ephemeris adapter

### DIFF
--- a/astroengine/cache/positions_cache.py
+++ b/astroengine/cache/positions_cache.py
@@ -1,8 +1,8 @@
 # >>> AUTO-GEN BEGIN: positions-cache v1.0
 from __future__ import annotations
 from typing import Iterable
-from pathlib import Path
 import sqlite3
+from ..ephemeris import SwissEphemerisAdapter
 from ..infrastructure.home import ae_home
 
 CACHE_DIR = ae_home() / "cache"
@@ -59,7 +59,13 @@ def get_lon_daily(jd_ut: float, body: str) -> float:
         'mercury': swe.MERCURY, 'venus': swe.VENUS, 'mars': swe.MARS,
         'jupiter': swe.JUPITER, 'saturn': swe.SATURN, 'uranus': swe.URANUS, 'neptune': swe.NEPTUNE, 'pluto': swe.PLUTO,
     }[body.lower()]
-    lon, lat, dist, speed = swe.calc_ut(float(_day_jd(jd_ut)), code)
+    adapter = SwissEphemerisAdapter.get_default_adapter()
+    sample = adapter.body_position(
+        float(_day_jd(jd_ut)), code, body_name=body.title()
+    )
+    lon = float(sample.longitude)
+    lat = float(sample.latitude)
+    speed = float(sample.speed_longitude)
     con = _connect()
     try:
         con.execute(_SQL["upsert"], (_day_jd(jd_ut), body.lower(), float(lon), float(lat), float(speed)))

--- a/astroengine/providers/swiss_provider.py
+++ b/astroengine/providers/swiss_provider.py
@@ -90,10 +90,18 @@ class SwissProvider:
             updates["sidereal"] = sidereal
         if time_scale is not None:
             updates["time_scale"] = time_scale
-        if updates:
-            cfg = replace(cfg, **updates)
-            self._config = cfg
-            self._adapter = EphemerisAdapter(cfg)
+        if not updates:
+            return
+
+        new_config = replace(cfg, **updates)
+        if new_config == self._config:
+            return
+
+        self._config = new_config
+        try:
+            self._adapter.reconfigure(new_config)
+        except AttributeError:  # pragma: no cover - legacy adapter fallback
+            self._adapter = EphemerisAdapter(new_config)
 
     @staticmethod
     def _normalize_iso(iso_utc: str) -> datetime:

--- a/tests/test_ephemeris_adapter.py
+++ b/tests/test_ephemeris_adapter.py
@@ -1,6 +1,14 @@
 from datetime import UTC, datetime
 
+import pytest
+
+try:  # pragma: no cover - exercised via runtime availability
+    import swisseph as swe
+except Exception:  # pragma: no cover - fallback when pyswisseph missing
+    swe = None  # type: ignore[assignment]
+
 from astroengine.core.angles import DeltaLambdaTracker
+from astroengine.core.time import to_tt
 from astroengine.ephemeris import EphemerisAdapter, EphemerisConfig, ObserverLocation
 
 
@@ -32,3 +40,17 @@ def test_topocentric_longitude_delta_within_bounds() -> None:
     assert 0.0 < lon_delta < 1.0
     assert lat_delta < 1.0
     assert abs(topocentric.declination - geocentric.declination) < 1.0
+
+
+@pytest.mark.skipif(swe is None, reason="pyswisseph unavailable")
+def test_sidereal_mode_configures_swiss_backend() -> None:
+    moment = datetime(2000, 4, 13, 11, 52, 10, 808741, tzinfo=UTC)
+    adapter = EphemerisAdapter(
+        EphemerisConfig(sidereal=True, sidereal_mode="lahiri"),
+    )
+    sample = adapter.sample(swe.SUN, moment)
+    conv = to_tt(moment)
+    swe.set_sid_mode(swe.SIDM_LAHIRI, 0.0, 0.0)
+    values, _ = swe.calc_ut(conv.jd_utc, swe.SUN, swe.FLG_SWIEPH | swe.FLG_SIDEREAL)
+    expected = float(values[0]) % 360.0
+    assert abs(sample.longitude - expected) < 1e-6


### PR DESCRIPTION
## Summary
- add sidereal ayanamsha resolution to `EphemerisAdapter`, enabling Swiss Ephemeris sidereal mode configuration and flag propagation
- expose the active sidereal mode via `describe_configuration` metadata and guard against unsupported or missing ayanamsha constants
- extend the ephemeris adapter test suite with a sidereal regression that compares adapter output to raw Swiss Ephemeris results

## Testing
- pytest tests/test_ephemeris_adapter.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4071eba388324a24d361bcca04fac