### PR TITLE
refactor: centralize JSON loading utilities

### DIFF
--- a/astroengine/detectors_aspects.py
+++ b/astroengine/detectors_aspects.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List
@@ -11,6 +10,7 @@ from .core.angles import DeltaLambdaTracker, classify_relative_motion, signed_de
 from .core.bodies import body_class
 from .infrastructure.paths import profiles_dir
 from .refine import adaptive_corridor_width
+from .utils.io import load_json_document
 
 __all__ = ["AspectHit", "detect_aspects"]
 
@@ -94,9 +94,7 @@ _HARMONIC_FAMILY_TO_NAMES: Dict[int, tuple[str, ...]] = {
 
 def _load_policy(path: str | None = None) -> dict:
     policy_path = Path(path) if path else _DEF_PATH
-    raw_lines = policy_path.read_text(encoding="utf-8").splitlines()
-    payload = "\n".join(line for line in raw_lines if not line.strip().startswith("#"))
-    return json.loads(payload)
+    return load_json_document(policy_path)
 
 
 def _normalize_name(name: str) -> str:

--- a/astroengine/domains.py
+++ b/astroengine/domains.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, Mapping
@@ -16,6 +15,7 @@ from .core.domains import (
     natal_domain_factor,
 )
 from .infrastructure.paths import profiles_dir
+from .utils import load_json_document
 
 __all__ = [
     "DOMAINS",
@@ -67,9 +67,7 @@ _DEF_MAP = profiles_dir() / "domain_mapping.json"
 
 
 def _load_json(path: Path) -> dict:
-    lines = path.read_text(encoding="utf-8").splitlines()
-    payload = "\n".join(line for line in lines if not line.strip().startswith("#"))
-    return json.loads(payload) if payload.strip() else {}
+    return load_json_document(path, default={})
 
 
 def _make_empty_scores(tree: Mapping[str, Any]) -> Dict[str, DomainScore]:

--- a/astroengine/narrative/__init__.py
+++ b/astroengine/narrative/__init__.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import html
-import json
 import logging
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
@@ -15,6 +14,7 @@ from typing import Any
 
 from ..domains import rollup_domain_scores
 from ..infrastructure.paths import profiles_dir
+from ..utils import load_json_document
 from .gpt_api import GPTNarrativeClient
 from .profiles import render_profile, timelord_outline
 from .prompts import build_summary_prompt, build_template_summary
@@ -651,9 +651,7 @@ def _build_categories(highlights: Sequence[NarrativeHighlight]) -> list[Narrativ
 @lru_cache(maxsize=1)
 def _domain_tree() -> Mapping[str, Any]:
     path = profiles_dir() / "domain_tree.json"
-    lines = path.read_text(encoding="utf-8").splitlines()
-    payload = "\n".join(line for line in lines if not line.strip().startswith("#"))
-    return json.loads(payload) if payload.strip() else {}
+    return load_json_document(path, default={})
 
 
 def _domain_names() -> tuple[dict[str, str], dict[str, dict[str, str]]]:

--- a/astroengine/scoring/contact.py
+++ b/astroengine/scoring/contact.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import math
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -15,7 +14,7 @@ from ..core.bodies import body_class
 from ..infrastructure.paths import profiles_dir
 from ..refine import branch_sensitive_angles, fuzzy_membership
 from ..plugins import apply_score_extensions
-from ..utils import deep_merge
+from ..utils import deep_merge, load_json_document
 from ..utils.angles import delta_angle
 from .tradition import get_tradition_spec
 
@@ -63,9 +62,7 @@ class ScoreResult:
 @lru_cache(maxsize=None)
 def _load_policy(path: str | None) -> dict:
     policy_path = Path(path) if path else _DEF_POLICY
-    raw = policy_path.read_text().splitlines()
-    payload = "\n".join(line for line in raw if not line.strip().startswith("#"))
-    return json.loads(payload)
+    return load_json_document(policy_path)
 
 
 def _resolve_policy(policy: Mapping[str, object] | None, policy_path: str | None) -> dict:

--- a/astroengine/scoring/policy.py
+++ b/astroengine/scoring/policy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass
@@ -11,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from ..infrastructure.paths import profiles_dir
-from ..utils import deep_merge
+from ..utils import deep_merge, load_json_document
 
 __all__ = [
     "OrbPolicy",
@@ -28,9 +27,7 @@ _DEF_VISIBILITY_POLICY = profiles_dir() / "visibility_policy.json"
 
 
 def _load_json(path: Path) -> dict[str, Any]:
-    raw_lines = path.read_text(encoding="utf-8").splitlines()
-    payload = "\n".join(line for line in raw_lines if not line.strip().startswith("#"))
-    return json.loads(payload)
+    return load_json_document(path)
 
 
 @lru_cache(maxsize=1)

--- a/astroengine/scoring/tradition.py
+++ b/astroengine/scoring/tradition.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Mapping, Sequence
 
 from ..infrastructure.paths import profiles_dir
+from ..utils import load_json_document
 
 __all__ = ["TraditionSpec", "get_tradition_spec", "load_tradition_table"]
 
@@ -21,9 +21,7 @@ def _tradition_policy_path() -> Path:
 @lru_cache(maxsize=1)
 def load_tradition_table() -> Mapping[str, object]:
     path = _tradition_policy_path()
-    raw_lines = path.read_text(encoding="utf-8").splitlines()
-    payload = "\n".join(line for line in raw_lines if not line.strip().startswith("#"))
-    return json.loads(payload)
+    return load_json_document(path)
 
 
 @dataclass(frozen=True)

--- a/astroengine/utils/__init__.py
+++ b/astroengine/utils/__init__.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-
+from .detectors import DETECTOR_NAMES, ENGINE_FLAG_MAP
+from .io import load_json_document
+from .merging import deep_merge
 from .target_frames import (
     DEFAULT_TARGET_FRAMES,
     DEFAULT_TARGET_SELECTION,
@@ -11,7 +13,6 @@ from .target_frames import (
     expand_targets,
     frame_body_options,
 )
-from .detectors import DETECTOR_NAMES, ENGINE_FLAG_MAP
 
 __all__ = [
     "DEFAULT_TARGET_FRAMES",
@@ -22,9 +23,7 @@ __all__ = [
     "frame_body_options",
     "DETECTOR_NAMES",
     "ENGINE_FLAG_MAP",
+    "deep_merge",
+    "load_json_document",
 ]
-
-from .merging import deep_merge
-
-__all__ = ["deep_merge"]
 

--- a/astroengine/utils/io.py
+++ b/astroengine/utils/io.py
@@ -1,0 +1,70 @@
+"""Shared I/O helpers for working with repository data files."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+__all__ = ["load_json_document"]
+
+
+_DEFAULT_SENTINEL = object()
+
+
+def _filtered_lines(text: str, prefixes: Sequence[str]) -> Iterable[str]:
+    """Yield ``text`` lines excluding those that start with *prefixes* after stripping.
+
+    The repository stores a number of JSON documents that include comment lines
+    beginning with ``#`` (or other prefixes).  Several modules previously
+    duplicated the same filtering logic before calling :func:`json.loads`.  This
+    helper centralises the behaviour and guarantees consistent handling of
+    comment prefixes across the code base.
+    """
+
+    if not prefixes:
+        yield from text.splitlines()
+        return
+
+    prefix_tuple = tuple(prefixes)
+    for line in text.splitlines():
+        if not line.strip().startswith(prefix_tuple):
+            yield line
+
+
+def load_json_document(
+    path: str | Path,
+    *,
+    comment_prefixes: Sequence[str] = ("#",),
+    default: Any = _DEFAULT_SENTINEL,
+    encoding: str = "utf-8",
+) -> Any:
+    """Return JSON content from ``path`` while ignoring comment-prefixed lines.
+
+    Args:
+        path: Location of the JSON document to read.
+        comment_prefixes: One or more prefixes that denote comment lines.  Lines
+            whose stripped form starts with any of the prefixes are excluded.
+        default: Optional fallback value returned when the resulting payload is
+            empty after comment filtering.  When omitted, the function mirrors
+            ``json.loads`` behaviour and raises a :class:`json.JSONDecodeError`
+            for empty payloads.
+        encoding: Text encoding used when reading ``path``.
+
+    Returns:
+        The deserialised JSON content (typically a ``dict`` or ``list``).
+    """
+
+    payload_path = Path(path)
+    text = payload_path.read_text(encoding=encoding)
+    payload = "\n".join(_filtered_lines(text, comment_prefixes))
+
+    if not payload.strip():
+        if default is _DEFAULT_SENTINEL:
+            # Match the previous behaviour by delegating to ``json.loads`` to
+            # raise ``JSONDecodeError`` when no content is present.
+            return json.loads(payload)
+        return default
+
+    return json.loads(payload)
+

--- a/astroengine/valence.py
+++ b/astroengine/valence.py
@@ -1,27 +1,36 @@
 # >>> AUTO-GEN BEGIN: AE Valence Module v1.0
 from __future__ import annotations
-import json
+
+from copy import deepcopy
 from pathlib import Path
 from typing import Literal, Optional, Tuple
 
 from .infrastructure.paths import profiles_dir
+from .utils import load_json_document
 
 Valence = Literal["positive", "neutral", "negative"]
 
 _DEF = profiles_dir() / "valence_policy.json"
 
+_DEFAULT_POLICY_TEMPLATE = {
+    "scale": {"positive": 1, "neutral": 0, "negative": -1},
+    "neutral_effects": {"amplify_factor": 1.15, "attenuate_factor": 0.85},
+    "bodies": {},
+    "aspects": {},
+    "contacts": {},
+    "overrides": {},
+}
+
+
+def _default_policy() -> dict:
+    return deepcopy(_DEFAULT_POLICY_TEMPLATE)
+
 
 def _load(path: Optional[str] = None) -> dict:
-    p = Path(path) if path else _DEF
-    if p.exists():
-        raw = p.read_text()
-        clean = "\n".join(line for line in raw.splitlines() if not line.strip().startswith("# >>>"))
-        return json.loads(clean)
-    return {
-        "scale": {"positive": 1, "neutral": 0, "negative": -1},
-        "neutral_effects": {"amplify_factor": 1.15, "attenuate_factor": 0.85},
-        "bodies": {}, "aspects": {}, "contacts": {}, "overrides": {}
-    }
+    policy_path = Path(path) if path else _DEF
+    if policy_path.exists():
+        return load_json_document(policy_path, comment_prefixes=("# >>>",))
+    return _default_policy()
 
 
 def body_valence(name: str, pol: dict) -> Tuple[Valence, float, str]:


### PR DESCRIPTION
## Summary
- add a shared `load_json_document` helper that strips comment-prefixed lines before parsing JSON data files
- update aspect detectors, scoring policies, domain aggregation, and narrative helpers to use the shared loader and expose it via `astroengine.utils`
- streamline the valence policy loader with a reusable default template while preserving the auto-generated module marker

## Testing
- pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log

------
https://chatgpt.com/codex/tasks/task_e_68d44f3cc7648324b411a9edbb9b1bc4