### PR TITLE
Enable minor and harmonic aspects by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,9 +233,11 @@ production deployments to regain full Swiss Ephemeris precision.
 # >>> AUTO-GEN END: AE README Providers Addendum v1.2
 
 # >>> AUTO-GEN BEGIN: AE README Aspects + Domain Report v1.0
-### Enable minor & harmonic aspects (optional)
-Edit `profiles/aspects_policy.json`, adding desired entries to `enabled_minors` and
-`enabled_harmonics` (accepts canonical names or harmonic numbers 5–12), then:
+### Minor & harmonic aspects (default policy)
+Minor and harmonic families ship **enabled by default** through
+`profiles/aspects_policy.json`. Adjust `enabled_minors` or
+`enabled_harmonics` (accepts canonical names or harmonic numbers 5–12) to
+disable or extend the active set, then:
 ```bash
 python -m astroengine scan --start 2024-06-01T00:00:00Z --end 2024-06-07T00:00:00Z \
   --moving mars --target venus --provider swiss

--- a/astroengine/scoring/orb.py
+++ b/astroengine/scoring/orb.py
@@ -1,11 +1,156 @@
-"""Public orb policy utilities backed by repository JSON."""
+"""Aspect orb policy helpers backed by :mod:`astroengine` JSON profiles."""
 
 from __future__ import annotations
 
-from ..scoring_legacy.orb import (  # noqa: F401
-    DEFAULT_ASPECTS,
-    AspectPolicy,
-    OrbCalculator,
-)
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources as importlib_resources
+from math import isclose
+from typing import Mapping, Sequence
 
-__all__ = ["DEFAULT_ASPECTS", "AspectPolicy", "OrbCalculator"]
+# Prefer the project-level body classification but fall back to a minimal map.
+try:  # pragma: no cover - import guard for editable installs
+    from ..core.bodies import body_class  # type: ignore
+except Exception:  # pragma: no cover
+    def body_class(name: str) -> str:
+        lowered = (name or "").lower()
+        if lowered in {"sun", "moon"}:
+            return "luminary"
+        if lowered in {"mercury", "venus", "mars"}:
+            return "personal"
+        if lowered in {"jupiter", "saturn"}:
+            return "social"
+        return "outer"
+
+
+def _normalize_name(name: str) -> str:
+    return str(name).strip().lower()
+
+
+def _policy_text() -> str:
+    """Return the raw aspects policy JSON, tolerating comment lines."""
+
+    # First attempt to load from the installed package resources.
+    try:
+        resource = importlib_resources.files("astroengine.profiles").joinpath(
+            "aspects_policy.json"
+        )
+        with resource.open("r", encoding="utf-8") as handle:
+            text = handle.read()
+    except (FileNotFoundError, ModuleNotFoundError):  # pragma: no cover - fallback path
+        # Fallback to the repository profiles directory (editable installs).
+        try:
+            from ..infrastructure.paths import profiles_dir
+        except Exception as exc:  # pragma: no cover - defensive guard
+            raise FileNotFoundError("Unable to locate aspects_policy.json") from exc
+        fallback_path = profiles_dir() / "aspects_policy.json"
+        with fallback_path.open("r", encoding="utf-8") as handle:
+            text = handle.read()
+    # Remove comment lines starting with '#'
+    filtered = "\n".join(
+        line for line in text.splitlines() if not line.strip().startswith("#")
+    )
+    return filtered
+
+
+@lru_cache(maxsize=1)
+def _load_aspects_policy() -> dict:
+    return json.loads(_policy_text())
+
+
+@lru_cache(maxsize=1)
+def _angles_index() -> tuple[dict[str, float], dict[float, str]]:
+    policy = _load_aspects_policy()
+    name_to_angle: dict[str, float] = {
+        _normalize_name(k): float(v) for k, v in policy.get("angles_deg", {}).items()
+    }
+    angle_to_name: dict[float, str] = {round(v, 4): k for k, v in name_to_angle.items()}
+    return name_to_angle, angle_to_name
+
+
+def _aspect_name_for_angle(angle_deg: float, *, tol: float = 1e-3) -> str | None:
+    name_to_angle, _ = _angles_index()
+    for name, base in name_to_angle.items():
+        if isclose(float(angle_deg), float(base), abs_tol=tol):
+            return name
+    return None
+
+
+def _family_for_name(name: str) -> str:
+    policy = _load_aspects_policy()
+    normalized = _normalize_name(name)
+    majors = {_normalize_name(n) for n in policy.get("enabled", [])}
+    minors = {_normalize_name(n) for n in policy.get("enabled_minors", [])}
+    if normalized in majors:
+        return "major"
+    if normalized in minors:
+        return "minor"
+    return "harmonic"
+
+
+def _enabled_angle_values() -> Sequence[float]:
+    policy = _load_aspects_policy()
+    name_to_angle, _ = _angles_index()
+    enabled: set[str] = set()
+    for key in ("enabled", "enabled_minors", "enabled_harmonics"):
+        for entry in policy.get(key, []) or []:
+            normalized = _normalize_name(str(entry))
+            if normalized:
+                enabled.add(normalized)
+    return tuple(
+        sorted({name_to_angle[name] for name in enabled if name in name_to_angle})
+    )
+
+
+DEFAULT_ASPECTS: tuple[float, ...] = tuple(_enabled_angle_values())
+
+
+@dataclass(frozen=True)
+class OrbCalculator:
+    """Compute orb allowances for aspect detections based on JSON policy."""
+
+    _policy: Mapping[str, object] | None = None
+
+    def __init__(self, policy: Mapping[str, object] | None = None) -> None:
+        object.__setattr__(self, "_policy", policy or _load_aspects_policy())
+
+    def orb_for(
+        self,
+        body_a: str,
+        body_b: str,
+        angle_deg: float,
+        *,
+        profile: str = "standard",
+    ) -> float:
+        policy = self._policy or {}
+        name = _aspect_name_for_angle(float(angle_deg)) or ""
+
+        per_aspect = policy.get("orbs_deg", {})  # type: ignore[assignment]
+        if name and name in per_aspect:
+            spec = per_aspect[name]  # type: ignore[index]
+            if isinstance(spec, Mapping):
+                class_a = body_class(body_a)
+                class_b = body_class(body_b)
+                allow_a = float(spec.get(class_a, spec.get("outer", 2.0)))
+                allow_b = float(spec.get(class_b, spec.get("outer", 2.0)))
+                return min(allow_a, allow_b)
+            if isinstance(spec, (int, float)):
+                return float(spec)
+
+        family = _family_for_name(name)
+        family_defaults: Mapping[str, float] | None = policy.get("orb_defaults", {}).get(  # type: ignore[index]
+            family
+        )
+        if isinstance(family_defaults, Mapping):
+            class_a = body_class(body_a)
+            class_b = body_class(body_b)
+            default = float(family_defaults.get("default", policy.get("default_orb_deg", 2.0)))
+            allow_a = float(family_defaults.get(class_a, default))
+            allow_b = float(family_defaults.get(class_b, default))
+            return min(allow_a, allow_b)
+
+        return float(policy.get("default_orb_deg", 2.0))
+
+
+__all__ = ["DEFAULT_ASPECTS", "OrbCalculator"]

--- a/docs/HARMONICS_SPEC.md
+++ b/docs/HARMONICS_SPEC.md
@@ -1,6 +1,6 @@
 <!-- >>> AUTO-GEN BEGIN: Harmonics v1.0 (instructions) -->
-Enable harmonic families via profiles:
+Harmonic families are enabled via `profiles/aspects_policy.json`:
 - H5 (quintiles 72/144), H7 (septiles ~51.4286), H9 (noviles 40/80), H11 (undeciles ~32.727).
 Defaults:
-- OFF by default; when ON, orbs ≤ 1° (≤ 1.5° to angles); severity weights conservative.
+- ON by default with orbs ≤ 1° (≤ 1.5° to angles); severity weights conservative.
 <!-- >>> AUTO-GEN END: Harmonics v1.0 (instructions) -->

--- a/profiles/aspects_policy.json
+++ b/profiles/aspects_policy.json
@@ -1,4 +1,4 @@
-# >>> AUTO-GEN BEGIN: AE Aspects Policy v1.0
+# >>> AUTO-GEN BEGIN: AE Aspects Policy v1.1
 {
   "angles_deg": {
     "conjunction": 0,
@@ -8,7 +8,6 @@
     "opposition": 180,
     "semisextile": 30,
     "semisquare": 45,
-
     "sesquisquare": 135,
     "quincunx": 150,
     "quintile": 72,
@@ -21,40 +20,172 @@
     "triseptile": 154.2857,
     "tredecile": 108,
     "undecile": 32.7273
-
   },
-  "enabled": ["conjunction", "sextile", "square", "trine", "opposition"],
-  "enabled_minors": [],
-  "enabled_harmonics": [],
+  "enabled": [
+    "conjunction",
+    "sextile",
+    "square",
+    "trine",
+    "opposition"
+  ],
+  "enabled_minors": [
+    "semisextile",
+    "semisquare",
+    "sesquisquare",
+    "quincunx",
+    "quintile",
+    "biquintile",
+    "semiquintile"
+  ],
+  "enabled_harmonics": [
+    "novile",
+    "binovile",
+    "septile",
+    "biseptile",
+    "triseptile",
+    "tredecile",
+    "undecile"
+  ],
   "partile_threshold_deg": 0.1667,
   "default_orb_deg": 2.0,
   "orb_defaults": {
-    "major": {"luminary": 8.0, "personal": 6.0, "social": 5.0, "outer": 4.0, "default": 4.0},
-    "minor": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0, "default": 2.0},
-    "harmonic": {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0, "default": 1.0}
+    "major": {
+      "luminary": 8.0,
+      "personal": 6.0,
+      "social": 5.0,
+      "outer": 4.0,
+      "default": 4.0
+    },
+    "minor": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0,
+      "default": 2.0
+    },
+    "harmonic": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0,
+      "default": 1.0
+    }
   },
   "orbs_deg": {
-    "conjunction": {"luminary": 8.0, "personal": 6.0, "social": 5.0, "outer": 4.0},
-    "opposition": {"luminary": 8.0, "personal": 6.0, "social": 5.0, "outer": 4.0},
-    "square":     {"luminary": 7.0, "personal": 5.0, "social": 4.5, "outer": 4.0},
-    "trine":      {"luminary": 7.0, "personal": 5.0, "social": 4.5, "outer": 4.0},
-    "sextile":    {"luminary": 5.0, "personal": 4.0, "social": 3.5, "outer": 3.0},
-    "semisextile":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "semisquare": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "sesquisquare":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "quincunx":   {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "quintile":   {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "biquintile": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "semiquintile":{"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0},
-    "novile":     {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "binovile":   {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "septile":    {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "biseptile":  {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "triseptile": {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "tredecile":  {"luminary": 1.5, "personal": 1.5, "social": 1.5, "outer": 1.5},
-    "undecile":   {"luminary": 1.0, "personal": 1.0, "social": 1.0, "outer": 1.0},
-    "sesquiquadrate": {"luminary": 2.0, "personal": 2.0, "social": 2.0, "outer": 2.0}
-
+    "conjunction": {
+      "luminary": 8.0,
+      "personal": 6.0,
+      "social": 5.0,
+      "outer": 4.0
+    },
+    "opposition": {
+      "luminary": 8.0,
+      "personal": 6.0,
+      "social": 5.0,
+      "outer": 4.0
+    },
+    "square": {
+      "luminary": 7.0,
+      "personal": 5.0,
+      "social": 4.5,
+      "outer": 4.0
+    },
+    "trine": {
+      "luminary": 7.0,
+      "personal": 5.0,
+      "social": 4.5,
+      "outer": 4.0
+    },
+    "sextile": {
+      "luminary": 5.0,
+      "personal": 4.0,
+      "social": 3.5,
+      "outer": 3.0
+    },
+    "semisextile": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "semisquare": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "sesquisquare": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "quincunx": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "quintile": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "biquintile": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "semiquintile": {
+      "luminary": 2.0,
+      "personal": 2.0,
+      "social": 2.0,
+      "outer": 2.0
+    },
+    "novile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    },
+    "binovile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    },
+    "septile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    },
+    "biseptile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    },
+    "triseptile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    },
+    "tredecile": {
+      "luminary": 1.5,
+      "personal": 1.5,
+      "social": 1.5,
+      "outer": 1.5
+    },
+    "undecile": {
+      "luminary": 1.0,
+      "personal": 1.0,
+      "social": 1.0,
+      "outer": 1.0
+    }
   }
 }
-# >>> AUTO-GEN END: AE Aspects Policy v1.0
+# >>> AUTO-GEN END: AE Aspects Policy v1.1

--- a/tests/test_orb_policy_min.py
+++ b/tests/test_orb_policy_min.py
@@ -1,0 +1,17 @@
+"""Minimal smoke checks for the consolidated orb policy loader."""
+
+from __future__ import annotations
+
+from astroengine.scoring.orb import DEFAULT_ASPECTS, OrbCalculator
+
+
+def test_defaults_present():
+    required = (0, 30, 36, 40, 45, 51.4286, 60, 72, 80, 90, 102.8571, 108, 120, 135, 144, 150, 154.2857, 180)
+    for angle in required:
+        assert any(abs(value - angle) < 1e-3 for value in DEFAULT_ASPECTS)
+
+
+def test_orb_major_vs_minor():
+    calc = OrbCalculator()
+    assert calc.orb_for("Sun", "Mars", 180) >= 4.0
+    assert calc.orb_for("Sun", "Mars", 150) <= 2.0


### PR DESCRIPTION
## Summary
- enable minor and harmonic aspect definitions by default in the aspects policy profile
- replace the scoring orb module with a JSON-driven loader that unifies default aspects and orb lookups
- add a minimal regression test ensuring the default aspect catalog and orb sizes remain wired to the policy
- document that minor and harmonic families now ship enabled by default and note how to customize the profile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d575d95d108324b2e3c705e3d4997a