### PR TITLE
Enable full body gating and variant-aware Swiss provider

### DIFF
--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1108,6 +1108,8 @@ def cmd_transits(args: argparse.Namespace) -> int:
         include_mirrors=include_mirrors,
         include_aspects=include_aspects,
         antiscia_axis=args.mirror_axis,
+        nodes_variant=args.nodes_variant,
+        lilith_variant=args.lilith_variant,
     )
 
     narrative_bundle = None
@@ -1925,6 +1927,18 @@ def build_parser() -> argparse.ArgumentParser:
     transits.add_argument("--step", type=int, default=60)
     transits.add_argument("--aspects-policy")
     transits.add_argument("--target-longitude", type=float, default=None)
+    transits.add_argument(
+        "--nodes-variant",
+        choices=("mean", "true"),
+        default="mean",
+        help="Lunar node variant to use (default: mean)",
+    )
+    transits.add_argument(
+        "--lilith-variant",
+        choices=("mean", "true"),
+        default="mean",
+        help="Black Moon Lilith variant to use (default: mean)",
+    )
 
     transits.add_argument(
         "--narrative",

--- a/astroengine/core/bodies.py
+++ b/astroengine/core/bodies.py
@@ -1,12 +1,22 @@
-"""Body classification helpers for scoring and orb policies."""
+"""Body catalogue helpers for gating, scoring, and default profiles."""
 
 from __future__ import annotations
 
-from functools import cache
+from functools import lru_cache
+from typing import Dict, Set
 
-__all__ = ["body_class"]
+__all__ = [
+    "ALL_SUPPORTED_BODIES",
+    "body_class",
+    "body_priority",
+    "canonical_name",
+    "step_multiplier",
+]
 
-_BODY_CLASS_MAP = {
+
+# Canonical body classification including nodes, points, asteroids, and TNOs.
+_BODY_CLASS: Dict[str, str] = {
+    # Luminaries / classical planets
     "sun": "luminary",
     "moon": "luminary",
     "mercury": "personal",
@@ -17,20 +27,103 @@ _BODY_CLASS_MAP = {
     "uranus": "outer",
     "neptune": "outer",
     "pluto": "outer",
-    "ceres": "outer",
-    "pallas": "outer",
-    "juno": "outer",
-    "vesta": "outer",
-    "chiron": "outer",
-    "north_node": "outer",
-    "south_node": "outer",
+    # Asteroids / centaurs
+    "ceres": "asteroid",
+    "pallas": "asteroid",
+    "juno": "asteroid",
+    "vesta": "asteroid",
+    "chiron": "centaur",
+    "pholus": "centaur",
+    "nessus": "centaur",
+    # Trans-Neptunian / dwarf planets
+    "eris": "tno",
+    "haumea": "tno",
+    "makemake": "tno",
+    "sedna": "tno",
+    "quaoar": "tno",
+    "orcus": "tno",
+    "ixion": "tno",
+    # Lunar nodes
+    "mean_node": "point",
+    "true_node": "point",
+    "south_node": "point",
+    "north_node": "point",
+    # Black Moon Lilith variants
+    "mean_lilith": "point",
+    "true_lilith": "point",
+    # Vertex / lots
+    "vertex": "point",
+    "antivertex": "point",
+    "fortune": "point",
+    "spirit": "point",
 }
 
 
-@cache
-def body_class(name: str) -> str:
-    """Return the scoring class for the provided body name."""
+_BODY_ALIASES: Dict[str, str] = {
+    "nn": "mean_node",
+    "node": "mean_node",
+    "northnode": "mean_node",
+    "north_node": "mean_node",
+    "sn": "south_node",
+    "southnode": "south_node",
+    "black_moon_lilith": "mean_lilith",
+    "lilith": "mean_lilith",
+    "trueblackmoon": "true_lilith",
+    "avx": "antivertex",
+    "part_of_fortune": "fortune",
+    "pof": "fortune",
+}
 
-    if not name:
+
+def canonical_name(name: str) -> str:
+    """Return the canonical lower-case identifier for ``name``."""
+
+    lowered = (name or "").strip().lower()
+    if not lowered:
+        return ""
+    return _BODY_ALIASES.get(lowered, lowered)
+
+
+@lru_cache(maxsize=None)
+def body_class(name: str) -> str:
+    """Return the scoring/gating class for the supplied body name."""
+
+    canonical = canonical_name(name)
+    if not canonical:
         return "outer"
-    return _BODY_CLASS_MAP.get(name.lower(), "outer")
+    return _BODY_CLASS.get(canonical, "outer")
+
+
+_ALL_CANONICAL: Set[str] = set(_BODY_CLASS)
+ALL_SUPPORTED_BODIES: Set[str] = set(sorted(_ALL_CANONICAL))
+
+
+_BODY_TIER: Dict[str, int] = {}
+for _name in ALL_SUPPORTED_BODIES:
+    _cls = _BODY_CLASS.get(_name, "outer")
+    _BODY_TIER[_name] = {
+        "luminary": 0,
+        "personal": 0,
+        "social": 1,
+        "outer": 2,
+        "centaur": 2,
+        "asteroid": 2,
+        "tno": 3,
+        "point": 1,
+    }.get(_cls, 2)
+
+
+_TIER_STEP_MULT = {0: 1.0, 1: 1.5, 2: 2.5, 3: 3.5}
+
+
+def body_priority(name: str) -> int:
+    """Return an integer tier ranking for scanning priority (lower is faster)."""
+
+    canonical = canonical_name(name)
+    return _BODY_TIER.get(canonical, 2)
+
+
+def step_multiplier(name: str) -> float:
+    """Return the cadence multiplier for ``name`` based on its tier."""
+
+    return _TIER_STEP_MULT.get(body_priority(name), 2.5)

--- a/astroengine/engine/scanning.py
+++ b/astroengine/engine/scanning.py
@@ -5,6 +5,8 @@
 from __future__ import annotations
 
 import datetime as dt
+import inspect
+import logging
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -19,8 +21,10 @@ from ..detectors import detect_antiscia_contacts, detect_decl_contacts
 from ..detectors.common import body_lon, delta_deg, iso_to_jd, jd_to_iso, norm360
 from ..detectors_aspects import AspectHit, detect_aspects
 from ..ephemeris import EphemerisConfig, SwissEphemerisAdapter
+from ..ephemeris.support import filter_supported
 from ..exporters import LegacyTransitEvent
 from ..plugins import DetectorContext, get_plugin_manager
+from ..scheduling.gating import choose_step
 from ..providers import get_provider
 from ..scoring import ScoreInputs, compute_score
 from .context import (
@@ -47,6 +51,8 @@ try:  # pragma: no cover - optional for environments without pyswisseph
     import swisseph as swe  # type: ignore
 except Exception:  # pragma: no cover
     swe = None  # type: ignore
+
+LOG = logging.getLogger(__name__)
 
 __all__ = [
     "events_to_dicts",
@@ -149,6 +155,7 @@ class ScanConfig:
     aspect_angle_deg: float
     orb_deg: float
     tick_minutes: int = 60
+    resolution: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -192,6 +199,30 @@ def _iso_ticks(start_iso: str, end_iso: str, *, step_minutes: int) -> Iterable[s
     while current <= end_dt:
         yield current.replace(tzinfo=dt.UTC).isoformat().replace("+00:00", "Z")
         current += step
+
+
+def _resolution_from_minutes(step_minutes: int) -> str:
+    if step_minutes <= 1:
+        return "minute"
+    if step_minutes <= 60:
+        return "hour"
+    if step_minutes <= 1440:
+        return "day"
+    if step_minutes <= 4320:
+        return "month"
+    if step_minutes <= 20160:
+        return "year"
+    return "long"
+
+
+def _gated_step_minutes(step_minutes: int, moving: str) -> tuple[int, str]:
+    resolution = _resolution_from_minutes(step_minutes)
+    gated = choose_step(resolution, moving)
+    gated_minutes = int(round(gated.total_seconds() / 60.0))
+    if gated_minutes <= 0:
+        gated_minutes = step_minutes
+    effective = max(step_minutes, gated_minutes)
+    return effective, resolution
 
 
 def _score_from_hit(
@@ -459,19 +490,29 @@ def scan_contacts(
     antiscia_axis: str | None = None,
     tradition_profile: str | None = None,
     chart_sect: str | None = None,
+    nodes_variant: str = "mean",
+    lilith_variant: str = "mean",
 ) -> list[LegacyTransitEvent]:
     """Scan for declination, antiscia, and aspect contacts between two bodies."""
 
     base_provider = provider or get_provider(provider_name)
+    nodes_variant = (nodes_variant or "mean").lower()
+    lilith_variant = (lilith_variant or "mean").lower()
     if ephemeris_config is not None:
         configure = getattr(base_provider, "configure", None)
         if callable(configure):
-            configure(
-                topocentric=ephemeris_config.topocentric,
-                observer=ephemeris_config.observer,
-                sidereal=ephemeris_config.sidereal,
-                time_scale=ephemeris_config.time_scale,
-            )
+            cfg_kwargs = {
+                "topocentric": ephemeris_config.topocentric,
+                "observer": ephemeris_config.observer,
+                "sidereal": ephemeris_config.sidereal,
+                "time_scale": ephemeris_config.time_scale,
+            }
+            params = inspect.signature(configure).parameters
+            if "nodes_variant" in params:
+                cfg_kwargs["nodes_variant"] = nodes_variant
+            if "lilith_variant" in params:
+                cfg_kwargs["lilith_variant"] = lilith_variant
+            configure(**cfg_kwargs)
 
     frame = (target_frame or "transit").lower()
     resolver = target_resolver
@@ -525,13 +566,31 @@ def scan_contacts(
     )
 
     feature_metadata = feature_plan.plugin_metadata()
+    feature_metadata.setdefault(
+        "variants", {"nodes": nodes_variant, "lilith": lilith_variant}
+    )
 
-    tick_source = _iso_ticks(start_iso, end_iso, step_minutes=step_minutes)
+    events: list[LegacyTransitEvent] = []
+
+    supported_bodies, support_issues = filter_supported((moving, target), scan_provider)
+    if support_issues:
+        feature_metadata["support_issues"] = [issue.__dict__ for issue in support_issues]
+        for issue in support_issues:
+            LOG.warning(
+                "body_unsupported: %s (%s)",
+                issue.body,
+                issue.reason,
+                extra={"event": "body_unsupported", "body": issue.body, "reason": issue.reason},
+            )
+    if moving not in supported_bodies or target not in supported_bodies:
+        return events
+
+    gated_step_minutes, gated_resolution = _gated_step_minutes(step_minutes, moving)
+
+    tick_source = _iso_ticks(start_iso, end_iso, step_minutes=gated_step_minutes)
     decl_ticks, mirror_ticks, aspect_ticks, plugin_ticks = tee(tick_source, 4)
 
     cached_provider = _TickCachingProvider(scan_provider)
-
-    events: list[LegacyTransitEvent] = []
 
     def _append_event(event: LegacyTransitEvent) -> None:
         _attach_timelords(event, timelord_calculator)
@@ -586,7 +645,9 @@ def scan_contacts(
             "decl_contra_orb": decl_contra_allow,
             "antiscia_orb": antiscia_allow,
             "contra_antiscia_orb": contra_antiscia_allow,
-            "step_minutes": step_minutes,
+            "step_minutes": gated_step_minutes,
+            "requested_step_minutes": step_minutes,
+            "gated_resolution": gated_resolution,
             "aspects_policy_path": aspects_policy_path,
             "antiscia_axis": axis,
             **feature_metadata,
@@ -631,12 +692,19 @@ def fast_scan(start: datetime, end: datetime, config: ScanConfig) -> list[dict]:
     if end_jd <= start_jd:
         return []
 
-    step_days = config.tick_minutes / (24.0 * 60.0)
+    resolution = config.resolution or _resolution_from_minutes(config.tick_minutes)
+    base_step = dt.timedelta(minutes=config.tick_minutes)
+    gated_step = choose_step(resolution, body_name)
+    if gated_step.total_seconds() <= base_step.total_seconds():
+        step_td = base_step
+    else:
+        step_td = gated_step
+    step_days = step_td.total_seconds() / 86400.0
     target_lon = norm360(config.natal_lon_deg + config.aspect_angle_deg)
 
     restore_cache_flag = detectors_common.USE_CACHE
     cache_available = getattr(detectors_common, "get_lon_daily", None) is not None
-    dense_sampling = config.tick_minutes < 720
+    dense_sampling = step_td.total_seconds() / 60.0 < 720
     toggled_cache = False
     if cache_available and dense_sampling and not restore_cache_flag:
         detectors_common.enable_cache(True)

--- a/astroengine/ephemeris/support.py
+++ b/astroengine/ephemeris/support.py
@@ -1,0 +1,56 @@
+"""Ephemeris capability probing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class SupportIssue:
+    """Represents an unsupported body probe against a provider."""
+
+    body: str
+    reason: str
+
+
+def _probe_timestamp(provider) -> str:
+    value = getattr(provider, "probe_timestamp", None)
+    if isinstance(value, str):
+        return value
+    return "2000-01-01T12:00:00Z"  # J2000 epoch
+
+
+def filter_supported(bodies: Iterable[str], provider) -> tuple[List[str], List[SupportIssue]]:
+    """Return (supported, issues) for ``bodies`` against ``provider``."""
+
+    probe = getattr(provider, "position", None)
+    if probe is None or not callable(probe):  # legacy providers may lack single-body API
+        unique = []
+        seen: set[str] = set()
+        for body in bodies:
+            name = str(body)
+            if name not in seen:
+                seen.add(name)
+                unique.append(name)
+        return unique, []
+
+    supported: List[str] = []
+    issues: List[SupportIssue] = []
+    probe_ts = _probe_timestamp(provider)
+    seen: set[str] = set()
+    for body in bodies:
+        name = str(body)
+        if name in seen:
+            continue
+        seen.add(name)
+        try:
+            provider.position(name, probe_ts)
+        except Exception as exc:  # pragma: no cover - defensive guard
+            issues.append(SupportIssue(body=name, reason=str(exc)))
+        else:
+            supported.append(name)
+    return supported, issues
+
+
+__all__ = ["SupportIssue", "filter_supported"]

--- a/astroengine/providers/swisseph_adapter.py
+++ b/astroengine/providers/swisseph_adapter.py
@@ -1,0 +1,78 @@
+"""Swiss Ephemeris helpers for variant-sensitive bodies (nodes, Lilith)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Tuple
+
+try:  # pragma: no cover - optional dependency in some environments
+    import swisseph as swe
+except Exception:  # pragma: no cover
+    swe = None
+
+from ..core.bodies import canonical_name
+
+SE_SUN = getattr(swe, "SUN", 0) if swe else 0
+SE_MOON = getattr(swe, "MOON", 1) if swe else 1
+SE_MEAN_NODE = getattr(swe, "MEAN_NODE", 10) if swe else 10
+SE_TRUE_NODE = getattr(swe, "TRUE_NODE", 11) if swe else 11
+SE_MEAN_APOG = getattr(swe, "MEAN_APOG", 12) if swe else 12
+SE_OSCU_APOG = getattr(swe, "OSCU_APOG", 13) if swe else 13
+
+
+@dataclass(frozen=True)
+class VariantConfig:
+    nodes_variant: str = "mean"
+    lilith_variant: str = "mean"
+
+
+def se_body_id_for(name: str, vc: VariantConfig) -> Tuple[int, bool]:
+    """Return ``(id, derived)`` for ``name`` respecting variant config."""
+
+    canonical = canonical_name(name)
+    if canonical in {"mean_node", "north_node", "node"}:
+        return (SE_TRUE_NODE if vc.nodes_variant == "true" else SE_MEAN_NODE, False)
+    if canonical == "true_node":
+        return SE_TRUE_NODE, False
+    if canonical in {"south_node", "sn"}:
+        code = SE_TRUE_NODE if vc.nodes_variant == "true" else SE_MEAN_NODE
+        return code, True
+    if canonical in {"lilith", "black_moon_lilith", "mean_lilith"}:
+        return (SE_OSCU_APOG if vc.lilith_variant == "true" else SE_MEAN_APOG, False)
+    if canonical == "true_lilith":
+        return SE_OSCU_APOG, False
+    return -1, False
+
+
+def position_vec(body_id: int, jd_ut: float, *, flags: int = 0):
+    if swe is None:
+        raise RuntimeError("pyswisseph not available")
+    values, rc = swe.calc_ut(jd_ut, body_id, flags)
+    if rc < 0:
+        raise RuntimeError(f"swe.calc_ut failed with code {rc}")
+    return values
+
+
+def position_with_variants(name: str, jd_ut: float, vc: VariantConfig, *, flags: int = 0):
+    """Return Swiss ephemeris vector for ``name`` considering variants."""
+
+    body_id, derived = se_body_id_for(name, vc)
+    if body_id < 0:
+        raise LookupError(name)
+    values = position_vec(body_id, jd_ut, flags=flags)
+    if not derived:
+        return values
+    lon, lat, dist, lon_spd, lat_spd, dist_spd = values
+    lon = (lon + 180.0) % 360.0
+    lat = -lat
+    lon_spd = lon_spd
+    lat_spd = -lat_spd
+    return lon, lat, dist, lon_spd, lat_spd, dist_spd
+
+
+__all__ = [
+    "VariantConfig",
+    "position_vec",
+    "position_with_variants",
+    "se_body_id_for",
+]

--- a/astroengine/scheduling/__init__.py
+++ b/astroengine/scheduling/__init__.py
@@ -1,0 +1,11 @@
+"""Scheduling helpers controlling scan cadence and body gating."""
+
+from .gating import adapt_step_near_bracket, base_step, body_priority, choose_step, sort_bodies_for_scan
+
+__all__ = [
+    "adapt_step_near_bracket",
+    "base_step",
+    "body_priority",
+    "choose_step",
+    "sort_bodies_for_scan",
+]

--- a/astroengine/scheduling/gating.py
+++ b/astroengine/scheduling/gating.py
@@ -1,0 +1,56 @@
+"""Resolution-aware body gating utilities used by the scan orchestrator."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Iterable, List
+
+from ..core.bodies import body_priority, canonical_name, step_multiplier
+
+# Base cadence per resolution before body-specific multipliers are applied.
+_BASE_STEP = {
+    "minute": timedelta(seconds=15),
+    "hour": timedelta(minutes=2),
+    "day": timedelta(hours=2),
+    "month": timedelta(hours=8),
+    "year": timedelta(days=2),
+    "long": timedelta(days=10),
+}
+
+
+def base_step(resolution: str) -> timedelta:
+    """Return the base cadence for ``resolution`` (defaults to daily sweep)."""
+
+    return _BASE_STEP.get(resolution, timedelta(hours=2))
+
+
+def choose_step(resolution: str, body: str) -> timedelta:
+    """Return the gated timestep for ``body`` at the given ``resolution``."""
+
+    step = base_step(resolution)
+    multiplier = step_multiplier(body)
+    return timedelta(seconds=step.total_seconds() * multiplier)
+
+
+def sort_bodies_for_scan(bodies: Iterable[str]) -> List[str]:
+    """Return bodies ordered by scanning priority (fast movers first)."""
+
+    canonical = {canonical_name(body) for body in bodies}
+    return sorted((b for b in canonical if b), key=body_priority)
+
+
+def adapt_step_near_bracket(step: timedelta) -> timedelta:
+    """Tighten the step locally once a bracket has been detected."""
+
+    if step.total_seconds() <= 0:
+        return step
+    return timedelta(seconds=step.total_seconds() / 2.5)
+
+
+__all__ = [
+    "adapt_step_near_bracket",
+    "base_step",
+    "body_priority",
+    "choose_step",
+    "sort_bodies_for_scan",
+]

--- a/profiles/base_profile.yaml
+++ b/profiles/base_profile.yaml
@@ -51,8 +51,10 @@ bodies:
     inner: [sun, moon, mercury, venus, mars]
     outer: [jupiter, saturn, uranus, neptune, pluto]
     minor: [ceres, pallas, juno, vesta]
+    centaur: [chiron, pholus, nessus]
+    tno: [eris, haumea, makemake, sedna, quaoar, orcus, ixion]
     dwarf: [eris, sedna]
-    points: [asc, mc, ic, dsc, vertex, antivertex, fortune, spirit]
+    points: [asc, mc, ic, dsc, vertex, antivertex, fortune, spirit, mean_node, mean_lilith]
   enablement:
     sun: true
     moon: true
@@ -64,16 +66,26 @@ bodies:
     uranus: true
     neptune: true
     pluto: true
-    ceres: false
-    pallas: false
-    juno: false
-    vesta: false
-    eris: false
-    sedna: false
+    ceres: true
+    pallas: true
+    juno: true
+    vesta: true
+    chiron: true
+    pholus: true
+    nessus: true
+    eris: true
+    haumea: true
+    makemake: true
+    sedna: true
+    quaoar: true
+    orcus: true
+    ixion: true
     vertex: true
     antivertex: true
     fortune: true
     spirit: true
+    mean_node: true
+    mean_lilith: true
   severity_weights:
     sun: 1.00
     moon: 1.10


### PR DESCRIPTION
## Summary
- extend core body catalogue with aliases, gating tiers, and expose a shared scheduling module that drives adaptive steps
- update the scan engine to honour body gating, filter unsupported bodies, surface node/Lilith variants, and accept new CLI flags
- broaden Swiss ephemeris coverage with variant-aware node/Lilith resolution, structured warnings, new support helpers, and enable all bodies by default in the base profile

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d58aa89a088324b14dabe11661ce4a