### PR TITLE
Add robust house system fallback and provenance metadata

### DIFF
--- a/astroengine/chart/composite.py
+++ b/astroengine/chart/composite.py
@@ -166,7 +166,15 @@ def _average_houses(
     asc = _midpoint_angle(houses_a.ascendant, houses_b.ascendant)
     mc = _midpoint_angle(houses_a.midheaven, houses_b.midheaven)
     return HousePositions(
-        system=houses_a.system, cusps=cusps, ascendant=asc, midheaven=mc
+        system=houses_a.system,
+        cusps=cusps,
+        ascendant=asc,
+        midheaven=mc,
+        system_name=houses_a.system_name,
+        requested_system=houses_a.requested_system,
+        fallback_from=houses_a.fallback_from,
+        fallback_reason=houses_a.fallback_reason,
+        provenance=houses_a.provenance,
     )
 
 

--- a/astroengine/chart/config.py
+++ b/astroengine/chart/config.py
@@ -20,11 +20,20 @@ __all__ = [
 
 VALID_ZODIAC_SYSTEMS = {"tropical", "sidereal"}
 VALID_HOUSE_SYSTEMS = {
-    "placidus",
-    "koch",
-    "whole_sign",
+    "alcabitius",
+    "campanus",
     "equal",
+    "equal_mc",
+    "koch",
+    "meridian",
+    "morinus",
+    "placidus",
     "porphyry",
+    "regiomontanus",
+    "sripati",
+    "topocentric",
+    "vehlow_equal",
+    "whole_sign",
 }
 
 

--- a/astroengine/ephemeris/swisseph_adapter.py
+++ b/astroengine/ephemeris/swisseph_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -10,6 +11,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar
 
 import swisseph as swe
+
+logger = logging.getLogger(__name__)
 
 from .sidereal import (
     DEFAULT_SIDEREAL_AYANAMSHA,
@@ -58,16 +61,20 @@ class EquatorialPosition:
 
 @dataclass(frozen=True)
 class HousePositions:
-    """Container for house cusps and angles."""
+    """Container for house cusps, angles, and provenance metadata."""
 
     system: str
     cusps: tuple[float, ...]
     ascendant: float
     midheaven: float
     system_name: str | None = None
+    requested_system: str | None = None
+    fallback_from: str | None = None
+    fallback_reason: str | None = None
+    provenance: Mapping[str, object] | None = None
 
-    def to_dict(self) -> Mapping[str, float | str | tuple[float, ...] | None]:
-        payload: dict[str, float | str | tuple[float, ...] | None] = {
+    def to_dict(self) -> Mapping[str, float | str | tuple[float, ...] | None | Mapping[str, object]]:
+        payload: dict[str, float | str | tuple[float, ...] | None | Mapping[str, object]] = {
             "system": self.system,
             "cusps": self.cusps,
             "ascendant": self.ascendant,
@@ -75,6 +82,14 @@ class HousePositions:
         }
         if self.system_name is not None:
             payload["system_name"] = self.system_name
+        if self.requested_system is not None:
+            payload["requested_system"] = self.requested_system
+        if self.fallback_from is not None:
+            payload["fallback_from"] = self.fallback_from
+        if self.fallback_reason is not None:
+            payload["fallback_reason"] = self.fallback_reason
+        if self.provenance is not None:
+            payload["provenance"] = dict(self.provenance)
         return payload
 
 
@@ -100,9 +115,29 @@ class SwissEphemerisAdapter:
     _HOUSE_SYSTEM_CODES: ClassVar[Mapping[str, bytes]] = {
         "placidus": b"P",
         "koch": b"K",
+        "regiomontanus": b"R",
+        "campanus": b"C",
+        "equal": b"A",
         "whole_sign": b"W",
-        "equal": b"E",
         "porphyry": b"O",
+        "alcabitius": b"B",
+        "topocentric": b"T",
+        "morinus": b"M",
+        "meridian": b"X",
+        "vehlow_equal": b"V",
+        "sripati": b"S",
+        "equal_mc": b"D",
+    }
+    _HOUSE_SYSTEM_ALIASES: ClassVar[Mapping[str, str]] = {
+        "ws": "whole_sign",
+        "wholesign": "whole_sign",
+        "whole": "whole_sign",
+        "equalmc": "equal_mc",
+        "equal_mc": "equal_mc",
+        "vehlow": "vehlow_equal",
+        "axial": "meridian",
+        "meridian_axial": "meridian",
+        "topo": "topocentric",
     }
 
     def __init__(
@@ -408,10 +443,37 @@ class SwissEphemerisAdapter:
     ) -> HousePositions:
         """Compute house cusps for a given location."""
 
-        system_key, sys_code = self._resolve_house_system(system)
+        requested_key, requested_code = self._resolve_house_system(system)
 
         self._apply_sidereal_mode()
-        cusps, angles = swe.houses_ex(jd_ut, latitude, longitude, sys_code)
+
+        used_key = requested_key
+        used_code = requested_code
+        fallback_from: str | None = None
+        fallback_reason: str | None = None
+
+        try:
+            cusps, angles = swe.houses_ex(jd_ut, latitude, longitude, used_code)
+        except Exception as exc:
+            # Certain quadrant systems fail at extreme latitudes; fallback to Whole Sign.
+            if used_key != "whole_sign":
+                fallback_from = used_key
+                fallback_reason = str(exc)
+                used_key = "whole_sign"
+                used_code = self._HOUSE_SYSTEM_CODES["whole_sign"]
+                logger.warning(
+                    {
+                        "event": "house_system_fallback",
+                        "from": fallback_from,
+                        "to": "whole_sign",
+                        "latitude": latitude,
+                        "longitude": longitude,
+                        "reason": fallback_reason,
+                    }
+                )
+                cusps, angles = swe.houses_ex(jd_ut, latitude, longitude, used_code)
+            else:
+                raise
 
         if self._is_sidereal:
             ayan = swe.get_ayanamsa_ut(jd_ut)
@@ -422,17 +484,34 @@ class SwissEphemerisAdapter:
             ascendant = angles[0]
             midheaven = angles[1]
 
-        if isinstance(sys_code, bytes | bytearray):
-            system_label = sys_code.decode("ascii")
+        if isinstance(used_code, bytes | bytearray):
+            system_label = used_code.decode("ascii")
         else:
-            system_label = str(sys_code)
+            system_label = str(used_code)
+
+        provenance: dict[str, object] = {
+            "house_system": {
+                "requested": requested_key,
+                "used": used_key,
+                "code": system_label,
+            }
+        }
+        if fallback_from is not None:
+            fallback_info: dict[str, object] = {"from": fallback_from, "to": "whole_sign"}
+            if fallback_reason:
+                fallback_info["reason"] = fallback_reason
+            provenance["house_fallback"] = fallback_info
 
         return HousePositions(
             system=system_label,
             cusps=tuple(cusps),
             ascendant=ascendant,
             midheaven=midheaven,
-            system_name=system_key,
+            system_name=used_key,
+            requested_system=requested_key,
+            fallback_from=fallback_from,
+            fallback_reason=fallback_reason,
+            provenance=provenance,
         )
 
     # ------------------------------------------------------------------
@@ -444,14 +523,17 @@ class SwissEphemerisAdapter:
 
     def _resolve_house_system(self, system: str | None) -> tuple[str, bytes]:
         """Return the canonical house system key and Swiss code."""
+
         if system is None:
             key = self.chart_config.house_system.lower()
         else:
-            key = system.lower()
+            key = system.strip().lower()
 
-        code = self._HOUSE_SYSTEM_CODES.get(key)
+        alias = self._HOUSE_SYSTEM_ALIASES.get(key, key)
+
+        code = self._HOUSE_SYSTEM_CODES.get(alias)
         if code is not None:
-            return key, code
+            return alias, code
 
         if len(key) == 1:
             code = key.upper().encode("ascii")
@@ -461,14 +543,12 @@ class SwissEphemerisAdapter:
                     for name, candidate in self._HOUSE_SYSTEM_CODES.items()
                     if candidate == code
                 ),
-                key,
+                key.lower(),
             )
             return canonical, code
 
         options = ", ".join(sorted(self._HOUSE_SYSTEM_CODES))
         raise ValueError(
-
             "Unsupported house system "
             f"'{system or self.chart_config.house_system}'. Valid options: {options}"
-
         )

--- a/tests/test_swisseph_sidereal.py
+++ b/tests/test_swisseph_sidereal.py
@@ -38,3 +38,22 @@ def test_house_system_mapping_uses_config() -> None:
     jd = adapter.julian_day(datetime(2024, 3, 20, tzinfo=UTC))
     houses = adapter.houses(jd, latitude=0.0, longitude=0.0)
     assert houses.system == "W"
+    assert houses.system_name == "whole_sign"
+    assert houses.requested_system == "whole_sign"
+    assert houses.provenance["house_system"]["used"] == "whole_sign"
+
+
+def test_house_system_fallback_records_provenance() -> None:
+    adapter = SwissEphemerisAdapter(
+        chart_config=ChartConfig(
+            zodiac="tropical", ayanamsha=None, house_system="placidus"
+        )
+    )
+    jd = adapter.julian_day(datetime(2020, 2, 1, tzinfo=UTC))
+    houses = adapter.houses(jd, latitude=78.2232, longitude=15.6469)
+    assert houses.system == "W"
+    assert houses.system_name == "whole_sign"
+    assert houses.requested_system == "placidus"
+    assert houses.fallback_from == "placidus"
+    assert houses.provenance["house_system"]["used"] == "whole_sign"
+    assert houses.provenance["house_fallback"]["from"] == "placidus"


### PR DESCRIPTION
## Summary
- extend the Swiss Ephemeris adapter with additional house system codes, alias resolution, and automatic fallback to Whole Sign with provenance logging when quadrant systems fail
- attach requested/used system metadata to HousePositions and carry it through composite chart averaging while expanding ChartConfig validation to cover the wider set of supported systems
- exercise the new behaviour with updated sidereal adapter tests covering metadata exposure and fallback provenance

## Testing
- pytest tests/test_swisseph_sidereal.py
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d58f5bc4688324ae4728577882a1c7