### PR TITLE
Fix sample entry point package discovery

### DIFF
--- a/astroengine/plugins/runtime.py
+++ b/astroengine/plugins/runtime.py
@@ -1,0 +1,47 @@
+"""Entry point discovery utilities for AstroEngine plugins and providers."""
+
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+
+class Registry:
+    """In-memory registry populated by plugin and provider entry points."""
+
+    def __init__(self) -> None:
+        self.rulesets: dict[str, object] = {}
+        self.providers: dict[str, object] = {}
+
+    def register_ruleset(self, name: str, obj: object) -> None:
+        """Record a ruleset supplied by a plugin."""
+
+        self.rulesets[name] = obj
+
+    def register_provider(self, name: str, obj: object) -> None:
+        """Record an external provider implementation."""
+
+        self.providers[name] = obj
+
+
+def load_plugins(registry: Registry) -> list[str]:
+    """Load plugin entry points and allow them to self-register."""
+
+    names: list[str] = []
+    for ep in entry_points(group="astroengine.plugins"):
+        fn = ep.load()
+        fn(registry)
+        names.append(ep.name)
+    return sorted(names)
+
+
+def load_providers(registry: Registry) -> list[str]:
+    """Load provider entry points and register them with the runtime."""
+
+    names: list[str] = []
+    for ep in entry_points(group="astroengine.providers"):
+        fn = ep.load()
+        prov_name, prov_obj = fn()
+        registry.register_provider(prov_name, prov_obj)
+        names.append(ep.name)
+    return sorted(names)
+

--- a/plugins/sample_plugin/pyproject.toml
+++ b/plugins/sample_plugin/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "astroengine-sample-plugin"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.entry-points."astroengine.plugins"]
+example_vca = "astroengine_plugins.vca:register"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/plugins/sample_plugin/src/astroengine_plugins/__init__.py
+++ b/plugins/sample_plugin/src/astroengine_plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Sample AstroEngine plugin package used for entry point tests."""

--- a/plugins/sample_plugin/src/astroengine_plugins/vca.py
+++ b/plugins/sample_plugin/src/astroengine_plugins/vca.py
@@ -1,0 +1,10 @@
+"""Sample plugin exposing a basic VCA ruleset."""
+
+
+def register(registry):
+    """Register a single ruleset in the provided registry."""
+
+    registry.register_ruleset(
+        "vca.basic",
+        {"weights": {"Mind": 0.34, "Body": 0.33, "Spirit": 0.33}},
+    )

--- a/plugins/sample_provider/pyproject.toml
+++ b/plugins/sample_provider/pyproject.toml
@@ -1,0 +1,17 @@
+[project]
+name = "astroengine-sample-provider"
+version = "0.1.0"
+requires-python = ">=3.11"
+
+[project.entry-points."astroengine.providers"]
+swiss_ephemeris = "astroengine_providers.swisseph:provider"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/plugins/sample_provider/src/astroengine_providers/__init__.py
+++ b/plugins/sample_provider/src/astroengine_providers/__init__.py
@@ -1,0 +1,1 @@
+"""Sample provider package for AstroEngine entry point tests."""

--- a/plugins/sample_provider/src/astroengine_providers/swisseph.py
+++ b/plugins/sample_provider/src/astroengine_providers/swisseph.py
@@ -1,0 +1,7 @@
+"""Sample provider returning a static Swiss Ephemeris descriptor."""
+
+
+def provider():
+    """Return the provider name and payload expected by the registry."""
+
+    return "swiss_ephemeris", {"impl": "swisseph", "version": "mvp"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,12 @@ astroengine = "astroengine.cli:main"
 astroengine-api = "astroengine.api_server:run"  # guarded import; only works with [api]
 
 [project.entry-points."astroengine.plugins"]
-
+# name = "module:function"
 fixed_star_hits = "astroengine.plugins.examples.fixed_star_hits"
 example = "astroengine.ux.plugins.example:ExamplePlugin"
+
+[project.entry-points."astroengine.providers"]
+# name = "module:function"
 
 
 [tool.setuptools]

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -1,0 +1,53 @@
+"""Tests for runtime entry point discovery of AstroEngine plugins and providers."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+from astroengine.plugins.runtime import Registry, load_plugins, load_providers
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_editable_install(dist_name: str, relative_path: str, module_name: str) -> None:
+    """Install the local sample package in editable mode if it is missing."""
+
+    needs_install = False
+
+    try:
+        metadata.distribution(dist_name)
+    except metadata.PackageNotFoundError:
+        needs_install = True
+    else:
+        try:
+            __import__(module_name)
+        except ModuleNotFoundError:
+            needs_install = True
+
+    if needs_install:
+        package_dir = _REPO_ROOT / relative_path
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "-e", str(package_dir)],
+            cwd=_REPO_ROOT,
+        )
+
+
+def test_entry_points_discovery() -> None:
+    _ensure_editable_install(
+        "astroengine-sample-plugin", "plugins/sample_plugin", "astroengine_plugins"
+    )
+    _ensure_editable_install(
+        "astroengine-sample-provider", "plugins/sample_provider", "astroengine_providers"
+    )
+
+    registry = Registry()
+    plugin_names = load_plugins(registry)
+    provider_names = load_providers(registry)
+
+    assert "example_vca" in plugin_names
+    assert "swiss_ephemeris" in provider_names
+    assert "vca.basic" in registry.rulesets
+    assert "swiss_ephemeris" in registry.providers


### PR DESCRIPTION
## Summary
- ensure the editable sample plugin and provider packages expose their src-based modules
- auto-install the local sample packages from tests before exercising entry point loading

## Testing
- pytest -q tests/test_entrypoints.py

------
https://chatgpt.com/codex/tasks/task_e_68d5abe7d8f083249ecfe8727d73e01a