### PR TITLE
T5: Atlas & Timezone resolution (tzid + DST disambiguation)

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
 
+from .atlas import from_utc, is_ambiguous, is_nonexistent, to_utc, tzid_for
 from .astro import declination  # ENSURE-LINE
 from .canonical import BodyPosition  # ENSURE-LINE
 from .catalogs import sbdb  # ENSURE-LINE

--- a/astroengine/atlas/__init__.py
+++ b/astroengine/atlas/__init__.py
@@ -1,0 +1,13 @@
+"""Atlas utilities for timezone resolution and related helpers."""
+
+from __future__ import annotations
+
+__all__ = [
+    "tzid_for",
+    "to_utc",
+    "from_utc",
+    "is_ambiguous",
+    "is_nonexistent",
+]
+
+from .tz import from_utc, is_ambiguous, is_nonexistent, to_utc, tzid_for

--- a/astroengine/atlas/tz.py
+++ b/astroengine/atlas/tz.py
@@ -1,0 +1,123 @@
+"""Timezone resolution utilities for atlas workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from functools import lru_cache
+from typing import Literal
+
+from timezonefinder import TimezoneFinder
+from zoneinfo import ZoneInfo
+
+Policy = Literal["earliest", "latest", "shift_forward", "raise"]
+
+__all__ = [
+    "Policy",
+    "tzid_for",
+    "to_utc",
+    "from_utc",
+    "is_ambiguous",
+    "is_nonexistent",
+]
+
+_tf = TimezoneFinder()
+
+
+@lru_cache(maxsize=None)
+def _get_zoneinfo(tzid: str) -> ZoneInfo:
+    """Cache `ZoneInfo` instances for repeat lookups."""
+
+    return ZoneInfo(tzid)
+
+
+def tzid_for(lat: float, lon: float) -> str:
+    """Return the canonical timezone identifier for the provided coordinates."""
+
+    tz = _tf.timezone_at(lng=lon, lat=lat)
+    if tz:
+        return tz
+    tz = _tf.closest_timezone_at(lng=lon, lat=lat)
+    if tz:
+        return tz
+    raise ValueError("Unable to resolve timezone for coordinates")
+
+
+def _attach(local_naive: datetime, tzid: str, fold: int) -> datetime:
+    if local_naive.tzinfo is not None:
+        raise ValueError("local_naive must be naive")
+    return local_naive.replace(tzinfo=_get_zoneinfo(tzid), fold=fold)
+
+
+def is_ambiguous(local_naive: datetime, tzid: str) -> bool:
+    """Return ``True`` when ``local_naive`` occurs twice due to a DST fall-back."""
+
+    aware0 = _attach(local_naive, tzid, 0)
+    aware1 = _attach(local_naive, tzid, 1)
+    offset0 = aware0.utcoffset()
+    offset1 = aware1.utcoffset()
+    return offset0 is not None and offset1 is not None and offset0 != offset1
+
+
+def is_nonexistent(local_naive: datetime, tzid: str) -> bool:
+    """Return ``True`` when ``local_naive`` falls inside a DST spring-forward gap."""
+
+    zone = _get_zoneinfo(tzid)
+    aware0 = _attach(local_naive, tzid, 0)
+    aware1 = _attach(local_naive, tzid, 1)
+    cand0 = aware0.astimezone(timezone.utc).astimezone(zone).replace(tzinfo=None)
+    cand1 = aware1.astimezone(timezone.utc).astimezone(zone).replace(tzinfo=None)
+    return cand0 != local_naive and cand1 != local_naive
+
+
+def _dst_gap(local_naive: datetime, zone: ZoneInfo) -> timedelta:
+    before = (local_naive - timedelta(hours=1)).replace(tzinfo=zone)
+    after = (local_naive + timedelta(hours=1)).replace(tzinfo=zone)
+    offset_before = before.utcoffset() or timedelta(0)
+    offset_after = after.utcoffset() or timedelta(0)
+    gap = offset_after - offset_before
+    if gap < timedelta(0):
+        gap = -gap
+    return gap
+
+
+_VALID_POLICIES = {"earliest", "latest", "shift_forward", "raise"}
+
+
+def to_utc(
+    local_naive: datetime,
+    lat: float,
+    lon: float,
+    *,
+    policy: Policy = "earliest",
+) -> datetime:
+    """Convert a naive local datetime to UTC using timezone rules at ``lat/lon``."""
+
+    if policy not in _VALID_POLICIES:
+        raise ValueError(f"Unsupported policy: {policy}")
+    tzid = tzid_for(lat, lon)
+    zone = _get_zoneinfo(tzid)
+
+    if is_ambiguous(local_naive, tzid):
+        fold = 0 if policy in {"earliest", "shift_forward"} else 1
+        return _attach(local_naive, tzid, fold).astimezone(timezone.utc)
+
+    if is_nonexistent(local_naive, tzid):
+        if policy == "raise":
+            raise ValueError("Nonexistent local time due to DST gap")
+        if policy == "shift_forward":
+            gap = _dst_gap(local_naive, zone)
+            adjusted = local_naive + gap
+            return adjusted.replace(tzinfo=zone).astimezone(timezone.utc)
+        return _attach(local_naive, tzid, 0).astimezone(timezone.utc)
+
+    return local_naive.replace(tzinfo=zone).astimezone(timezone.utc)
+
+
+def from_utc(utc_dt: datetime, lat: float, lon: float) -> datetime:
+    """Convert ``utc_dt`` to the local timezone indicated by ``lat/lon``."""
+
+    tzid = tzid_for(lat, lon)
+    zone = _get_zoneinfo(tzid)
+    if utc_dt.tzinfo is None:
+        utc_dt = utc_dt.replace(tzinfo=timezone.utc)
+    return utc_dt.astimezone(zone)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "SQLAlchemy>=2.0",
   "alembic>=1.13",
   "ics>=0.7",
+  "timezonefinder>=8.1",
   "tzdata>=2023.3",
   "pluggy>=1.5",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pyarrow>=16.0
 SQLAlchemy>=2.0
 alembic>=1.13
 python-dateutil>=2.9
+timezonefinder>=8.1
 tzdata>=2024.1
 PyYAML>=6.0
 pluggy>=1.5

--- a/tests/test_atlas_tz.py
+++ b/tests/test_atlas_tz.py
@@ -1,0 +1,44 @@
+from datetime import datetime, timezone
+
+from astroengine.atlas.tz import (
+    from_utc,
+    is_ambiguous,
+    is_nonexistent,
+    to_utc,
+    tzid_for,
+)
+
+NYC = (40.7128, -74.0060)
+LON = (51.5074, -0.1278)
+
+
+def test_tzid_basic():
+    assert tzid_for(*NYC) in ("America/New_York", "US/Eastern")
+    assert tzid_for(*LON) == "Europe/London"
+
+
+# Fall-back ambiguity (US): Nov 2, 2025 01:30 occurs twice
+def test_ambiguous_fall_back():
+    dt = datetime(2025, 11, 2, 1, 30)
+    tzid = tzid_for(*NYC)
+    assert is_ambiguous(dt, tzid)
+    early = to_utc(dt, *NYC, policy="earliest")
+    late = to_utc(dt, *NYC, policy="latest")
+    assert (late - early).total_seconds() == 3600
+
+
+# Spring-forward gap (US): Mar 9, 2025 02:30 nonexistent
+def test_nonexistent_spring_forward_shift():
+    dt = datetime(2025, 3, 9, 2, 30)
+    tzid = tzid_for(*NYC)
+    assert is_nonexistent(dt, tzid)
+    u = to_utc(dt, *NYC, policy="shift_forward")
+    lt = from_utc(u, *NYC)
+    assert lt.hour >= 3
+
+
+def test_round_trip():
+    u = datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc)
+    lt = from_utc(u, *NYC)
+    back = to_utc(lt.replace(tzinfo=None), *NYC)
+    assert back == u


### PR DESCRIPTION
## Summary
- add an atlas timezone utility module that resolves tzids and handles DST ambiguity/nonexistence policies
- expose the timezone helpers at the package root for external use
- cover timezone lookups and DST edge cases with targeted pytest coverage
- declare `timezonefinder` as a core dependency so timezone resolution works out of the box

## Testing
- pytest tests/test_atlas_tz.py

------
https://chatgpt.com/codex/tasks/task_e_68d5aca261388324901eb084b2a6258c