### PR TITLE
T9: Property-based test suite (angles, detectors, tz, exports)

### DIFF
--- a/tests/property/test_angles.py
+++ b/tests/property/test_angles.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from astroengine.utils.angles import delta_angle
+
+hypothesis = pytest.importorskip("hypothesis")
+given = hypothesis.given
+st = hypothesis.strategies
+settings = hypothesis.settings
+
+FLOATS = st.floats(
+    min_value=-1e6,
+    max_value=1e6,
+    allow_nan=False,
+    allow_infinity=False,
+)
+INTS = st.integers(min_value=-20, max_value=20)
+
+
+@settings(deadline=None)
+@given(a=FLOATS, b=FLOATS)
+def test_delta_angle_antisymmetric(a: float, b: float) -> None:
+    """delta(a, b) == -delta(b, a) within numeric tolerance."""
+
+    forward = delta_angle(a, b)
+    backward = delta_angle(b, a)
+    assert math.isclose(forward, -backward, abs_tol=1e-9)
+
+
+@settings(deadline=None)
+@given(a=FLOATS, b=FLOATS, k=INTS, m=INTS)
+def test_delta_angle_periodic(a: float, b: float, k: int, m: int) -> None:
+    """Adding full turns does not change the delta."""
+
+    shifted = delta_angle(a + 360.0 * k, b + 360.0 * m)
+    base = delta_angle(a, b)
+    assert math.isclose(shifted, base, abs_tol=1e-9)
+
+
+@settings(deadline=None)
+@given(a=FLOATS, b=FLOATS)
+def test_delta_angle_range(a: float, b: float) -> None:
+    """delta(a, b) stays within (-180, 180]."""
+
+    delta = delta_angle(a, b)
+    assert -180.0 < delta <= 180.0
+
+
+@settings(deadline=None)
+@given(a=FLOATS, b=FLOATS)
+def test_delta_angle_zero_implies_congruent(a: float, b: float) -> None:
+    """delta(a, b) == 0 => angles congruent modulo 360 degrees."""
+
+    delta = delta_angle(a, b)
+    if math.isclose(delta, 0.0, abs_tol=1e-9):
+        congruent = math.fmod(b - a, 360.0)
+        if congruent < 0.0:
+            congruent += 360.0
+        if congruent >= 360.0 - 1e-9:
+            congruent -= 360.0
+        assert math.isclose(congruent, 0.0, abs_tol=1e-9)

--- a/tests/property/test_aspects.py
+++ b/tests/property/test_aspects.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from astroengine.detectors.directed_aspects import solar_arc_natal_aspects
+from astroengine.detectors.progressed_aspects import progressed_natal_aspects
+
+hypothesis = pytest.importorskip("hypothesis")
+given = hypothesis.given
+settings = hypothesis.settings
+st = hypothesis.strategies
+
+SE_OK = bool(os.environ.get("SE_EPHE_PATH") or os.environ.get("SWE_EPH_PATH"))
+ANGLES = (0.0, 60.0, 90.0, 120.0, 180.0)
+ORB_STRATEGY = st.floats(
+    min_value=0.5,
+    max_value=3.0,
+    allow_nan=False,
+    allow_infinity=False,
+)
+
+
+def _orb_abs(hit: Any) -> float:
+    return float(getattr(hit, "orb_abs"))
+
+
+def _angle_value(hit: Any) -> float:
+    if hasattr(hit, "angle_deg"):
+        return float(getattr(hit, "angle_deg"))
+    return float(getattr(hit, "angle"))
+
+
+def _sorted_hits(hits: list[Any]) -> list[Any]:
+    return sorted(hits, key=lambda h: (h.when_iso, h.moving, h.target, _angle_value(h)))
+
+
+def _assert_hits_within_orb(hits: list[Any], orb: float) -> None:
+    for hit in hits:
+        assert _orb_abs(hit) <= orb + 1e-6
+        angle = _angle_value(hit)
+        assert any(abs(angle - candidate) <= 1e-6 for candidate in ANGLES)
+
+
+@settings(deadline=None)
+@given(orb=ORB_STRATEGY)
+def test_progressed_aspects_respect_orb(orb: float) -> None:
+    if not SE_OK:
+        pytest.skip("Swiss ephemeris path not configured")
+
+    try:
+        hits = progressed_natal_aspects(
+            natal_ts="1990-01-01T12:00:00Z",
+            start_ts="2020-01-01T00:00:00Z",
+            end_ts="2020-01-05T00:00:00Z",
+            aspects=tuple(int(a) for a in ANGLES),
+            orb_deg=float(orb),
+        )
+    except NotImplementedError:
+        pytest.skip("progressed natal aspects detector not implemented")
+
+    assert hits == _sorted_hits(hits)
+    _assert_hits_within_orb(list(hits), float(orb))
+
+
+@settings(deadline=None)
+@given(orb=ORB_STRATEGY)
+def test_solar_arc_aspects_respect_orb(orb: float) -> None:
+    if not SE_OK:
+        pytest.skip("Swiss ephemeris path not configured")
+
+    try:
+        hits = solar_arc_natal_aspects(
+            natal_ts="1990-01-01T12:00:00Z",
+            start_ts="2020-01-01T00:00:00Z",
+            end_ts="2020-01-05T00:00:00Z",
+            aspects=tuple(int(a) for a in ANGLES),
+            orb_deg=float(orb),
+        )
+    except NotImplementedError:
+        pytest.skip("solar arc aspects detector not implemented")
+
+    assert hits == _sorted_hits(hits)
+    _assert_hits_within_orb(list(hits), float(orb))

--- a/tests/property/test_exports.py
+++ b/tests/property/test_exports.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from astroengine import canonical
+from astroengine.canonical import TransitEvent
+from astroengine.exporters import write_parquet_canonical
+
+hypothesis = pytest.importorskip("hypothesis")
+given = hypothesis.given
+settings = hypothesis.settings
+st = hypothesis.strategies
+
+pd = pytest.importorskip("pandas")
+pytest.importorskip("pyarrow")
+
+ASPECTS = (
+    "conjunction",
+    "sextile",
+    "square",
+    "trine",
+    "opposition",
+    "semi-sextile",
+    "semi-square",
+    "sesquiquadrate",
+    "quincunx",
+)
+BODIES = ("Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn")
+
+ISO_TIMESTAMPS = st.datetimes(
+    min_value=datetime(1950, 1, 1),
+    max_value=datetime(2050, 12, 31),
+).map(lambda dt: dt.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z"))
+
+META_VALUES = st.one_of(
+    st.none(),
+    st.integers(-10, 10),
+    st.from_regex(r"[A-Za-z0-9 _]{0,16}", fullmatch=True),
+)
+META_DICT = st.dictionaries(
+    keys=st.sampled_from(["profile_id", "natal_id", "source", "notes"]),
+    values=META_VALUES,
+    max_size=3,
+)
+
+TRANSIT_EVENTS = st.builds(
+    TransitEvent,
+    ts=ISO_TIMESTAMPS,
+    moving=st.sampled_from(BODIES),
+    target=st.sampled_from(tuple(f"natal_{body}" for body in BODIES)),
+    aspect=st.sampled_from(ASPECTS),
+    orb=st.floats(min_value=-5.0, max_value=5.0, allow_nan=False, allow_infinity=False),
+    applying=st.booleans(),
+    score=st.one_of(
+        st.none(),
+        st.floats(min_value=-25.0, max_value=25.0, allow_nan=False, allow_infinity=False),
+    ),
+    meta=META_DICT,
+)
+
+
+def _expected_rows(events: Sequence[TransitEvent]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for event in events:
+        row = canonical._event_row(event)
+        row.pop("meta", None)
+        row["natal_id"] = row.get("natal_id") or "unknown"
+        rows.append(row)
+    return rows
+
+
+@settings(deadline=None)
+@given(events=st.lists(TRANSIT_EVENTS, min_size=1, max_size=20))
+def test_parquet_export_round_trip(events: Sequence[TransitEvent]) -> None:
+    with tempfile.TemporaryDirectory() as tmpdir:
+        parquet_path = Path(tmpdir) / "hits.parquet"
+        count = write_parquet_canonical(str(parquet_path), events)
+        assert count == len(events)
+
+        df = pd.read_parquet(parquet_path)
+        canonical_events = canonical.events_from_any(events)
+        expected = _expected_rows(canonical_events)
+        expected_df = pd.DataFrame(expected)
+
+        sort_columns = ["ts", "moving", "target", "aspect", "orb"]
+        df_sorted = df.sort_values(sort_columns).reset_index(drop=True)
+        expected_sorted = expected_df.sort_values(sort_columns).reset_index(drop=True)
+        expected_sorted = expected_sorted[df_sorted.columns]
+
+        assert len(df_sorted) == len(expected_sorted)
+        pd.testing.assert_frame_equal(
+            df_sorted,
+            expected_sorted,
+            check_dtype=False,
+            check_like=False,
+        )

--- a/tests/property/test_timezones.py
+++ b/tests/property/test_timezones.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import inspect
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+hypothesis = pytest.importorskip("hypothesis")
+given = hypothesis.given
+settings = hypothesis.settings
+st = hypothesis.strategies
+
+atlas_tz = pytest.importorskip("astroengine.atlas.tz")
+TO_UTC = getattr(atlas_tz, "to_utc")
+FROM_UTC = getattr(atlas_tz, "from_utc")
+_TO_UTC_PARAMS = inspect.signature(TO_UTC).parameters
+
+COORDS = st.tuples(
+    st.floats(min_value=-80.0, max_value=80.0, allow_nan=False, allow_infinity=False),
+    st.floats(min_value=-179.9, max_value=179.9, allow_nan=False, allow_infinity=False),
+)
+INSTANTS = st.datetimes(
+    min_value=datetime(1970, 1, 1, tzinfo=timezone.utc),
+    max_value=datetime(2035, 12, 31, tzinfo=timezone.utc),
+    timezones=st.just(timezone.utc),
+)
+
+
+def _ensure_datetime(value: Any) -> datetime:
+    if isinstance(value, tuple | list):
+        candidate = value[0]
+    else:
+        candidate = value
+    if not isinstance(candidate, datetime):
+        raise TypeError(f"Expected datetime from timezone helper, got {type(candidate)!r}")
+    return candidate
+
+
+def _call_from_utc(moment: datetime, lat: float, lon: float) -> datetime:
+    try:
+        local = FROM_UTC(moment, lat, lon)
+    except TypeError:
+        local = FROM_UTC(moment, latitude=lat, longitude=lon)
+    return _ensure_datetime(local)
+
+
+def _call_to_utc(moment: datetime, lat: float, lon: float, *, ambiguous: bool = False) -> datetime:
+    kwargs: dict[str, Any] = {}
+    if "policy" in _TO_UTC_PARAMS:
+        kwargs.setdefault("policy", "shift_forward")
+    if "nonexistent" in _TO_UTC_PARAMS:
+        kwargs.setdefault("nonexistent", "shift_forward")
+    if ambiguous and "ambiguous" in _TO_UTC_PARAMS:
+        kwargs.setdefault("ambiguous", "earliest")
+    try:
+        utc_moment = TO_UTC(moment, lat, lon, **kwargs)
+    except TypeError:
+        utc_moment = TO_UTC(moment, latitude=lat, longitude=lon, **kwargs)
+    return _ensure_datetime(utc_moment)
+
+
+@settings(deadline=None)
+@given(instant=INSTANTS, coords=COORDS)
+def test_timezone_round_trip(instant: datetime, coords: tuple[float, float]) -> None:
+    lat, lon = coords
+    local = _call_from_utc(instant, lat, lon)
+    local_naive = local.replace(tzinfo=None)
+    back = _call_to_utc(local_naive, lat, lon)
+    assert back == instant
+
+
+def test_ambiguous_time_does_not_raise() -> None:
+    lat, lon = 40.7128, -74.0060  # New York City
+    ambiguous = datetime(2021, 11, 7, 1, 30)
+    try:
+        result = _call_to_utc(ambiguous, lat, lon, ambiguous=True)
+    except Exception as exc:  # pragma: no cover - ensures explicit failure detail
+        pytest.fail(f"Ambiguous local time should not raise, got {exc!r}")
+    round_trip = _call_from_utc(result, lat, lon).replace(tzinfo=None)
+    assert round_trip.hour in {1, 2, 3}
+
+
+def test_nonexistent_time_shift_forward() -> None:
+    lat, lon = 40.7128, -74.0060
+    nonexistent = datetime(2021, 3, 14, 2, 30)
+    result = _call_to_utc(nonexistent, lat, lon)
+    local_after = _call_from_utc(result, lat, lon).replace(tzinfo=None)
+    assert local_after > nonexistent


### PR DESCRIPTION
## Summary
- add Hypothesis-powered property tests for angle delta invariants
- cover progressed and directed aspect detectors with orb and ordering checks
- validate timezone helpers and canonical export round-trips with property tests

## Testing
- pytest -q tests/property

------
https://chatgpt.com/codex/tasks/task_e_68d5aeabd740832495f7a05113074768