### PR TITLE
Add Plus health endpoint router

### DIFF
--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
+from .routers import plus as plus_router
 from .routers import scan as scan_router
 from .routers import synastry as synastry_router
 
 
 def create_app() -> FastAPI:
     app = FastAPI(title="AstroEngine API")
+    app.include_router(plus_router.router)
     app.include_router(scan_router.router, prefix="/v1/scan", tags=["scan"])
     app.include_router(synastry_router.router, prefix="/v1/synastry", tags=["synastry"])
     return app

--- a/astroengine/api/routers/__init__.py
+++ b/astroengine/api/routers/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__all__ = ["scan", "synastry"]
+__all__ = ["plus", "scan", "synastry"]

--- a/astroengine/api/routers/plus.py
+++ b/astroengine/api/routers/plus.py
@@ -1,0 +1,13 @@
+"""Health endpoints for the Plus module."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+
+@router.get("/health/plus", summary="Health check for Plus modules")
+def health_plus() -> dict[str, str]:
+    """Simple readiness probe for Plus features."""
+    return {"status": "ok"}

--- a/astroengine/api_server.py
+++ b/astroengine/api_server.py
@@ -10,8 +10,10 @@ else:
     app = FastAPI(title="AstroEngine API")
 
 if app:
+    from .api.routers.plus import router as plus_router
     from .api.routers.synastry import router as syn_router
 
+    app.include_router(plus_router)
     app.include_router(syn_router, prefix="/v1/synastry", tags=["synastry"])
 
 # >>> AUTO-GEN BEGIN: api-natals v1.0

--- a/tests/api/test_health_plus.py
+++ b/tests/api/test_health_plus.py
@@ -1,0 +1,24 @@
+"""Health endpoint tests for the Plus router."""
+
+from __future__ import annotations
+
+import pytest
+
+try:  # pragma: no cover - optional dependency in test environment
+    from fastapi.testclient import TestClient
+except Exception:  # pragma: no cover - FastAPI not installed
+    TestClient = None  # type: ignore[assignment]
+
+from astroengine.api_server import app
+
+pytestmark = pytest.mark.skipif(
+    app is None or TestClient is None, reason="FastAPI not available"
+)
+
+
+def test_health_plus_endpoint() -> None:
+    client = TestClient(app)  # type: ignore[misc]
+    response = client.get("/health/plus")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+    client.close()


### PR DESCRIPTION
## Summary
- add a Plus router that exposes the /health/plus health check endpoint
- include the Plus router in both FastAPI application entry points to surface the route in OpenAPI
- cover the new endpoint with a FastAPI TestClient regression test

## Testing
- pytest -q tests/api/test_health_plus.py

------
https://chatgpt.com/codex/tasks/task_e_68d80d01f68c8324a71ee66206372af5