### PR TITLE
Add database models and CRUD repositories

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application-level utilities for AstroEngine API and persistence layers."""

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,5 @@
+"""Database utilities and models for AstroEngine application services."""
+
+from .base import Base
+
+__all__ = ["Base"]

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,11 @@
+"""SQLAlchemy declarative base for AstroEngine application models."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Declarative base class used by all ORM models in the app package."""
+
+    pass

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,160 @@
+"""ORM models used by the AstroEngine service stack."""
+
+from __future__ import annotations
+
+import enum
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    Enum,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+
+
+class ChartKind(str, enum.Enum):
+    """Enumerates chart categories supported by the persistence layer."""
+
+    natal = "natal"
+    transit = "transit"
+    progressed = "progressed"
+
+
+class EventType(str, enum.Enum):
+    """Enumerates event records stored against charts."""
+
+    custom = "custom"
+    transit = "transit"
+    progression = "progression"
+
+
+class ExportType(str, enum.Enum):
+    """Enumerates supported export job formats."""
+
+    ics = "ics"
+    csv = "csv"
+    json = "json"
+
+
+class OrbPolicy(Base):
+    """Configurable orb policy definitions."""
+
+    __tablename__ = "orb_policies"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), unique=True)
+    per_object: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class SeverityProfile(Base):
+    """Profile definitions for severity computation."""
+
+    __tablename__ = "severity_profiles"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), unique=True)
+    weights: Mapped[Dict[str, float]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class Chart(Base):
+    """Represents a persisted chart instance."""
+
+    __tablename__ = "charts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    kind: Mapped[ChartKind] = mapped_column(Enum(ChartKind), nullable=False)
+    dt_utc: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    lat: Mapped[float] = mapped_column(Float, nullable=False)
+    lon: Mapped[float] = mapped_column(Float, nullable=False)
+    location_name: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
+
+    events: Mapped[List["Event"]] = relationship(
+        "Event",
+        back_populates="chart",
+        cascade="all, delete-orphan",
+    )
+
+
+class Event(Base):
+    """Event entries that can be attached to charts."""
+
+    __tablename__ = "events"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    type: Mapped[EventType] = mapped_column(Enum(EventType), nullable=False)
+    start_ts: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    chart_id: Mapped[int] = mapped_column(ForeignKey("charts.id", ondelete="CASCADE"))
+    objects: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+
+    chart: Mapped[Chart] = relationship("Chart", back_populates="events")
+
+
+class RuleSetVersion(Base):
+    """Versioned rule set definitions."""
+
+    __tablename__ = "ruleset_versions"
+    __table_args__ = (UniqueConstraint("key", "version", name="uq_ruleset_key_version"),)
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    key: Mapped[str] = mapped_column(String(255), nullable=False)
+    version: Mapped[int] = mapped_column(Integer, nullable=False)
+    definition_json: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+
+
+class AsteroidMeta(Base):
+    """Metadata for tracked asteroids and minor planets."""
+
+    __tablename__ = "asteroid_meta"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    name: Mapped[str] = mapped_column(String(128), unique=True, nullable=False)
+    designation: Mapped[Optional[str]] = mapped_column(String(128), nullable=True)
+    data: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+
+
+class ExportJob(Base):
+    """Queued export jobs maintained by the application."""
+
+    __tablename__ = "export_jobs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    type: Mapped[ExportType] = mapped_column(Enum(ExportType), nullable=False)
+    params: Mapped[Dict[str, Any]] = mapped_column(JSON, default=dict)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(timezone.utc)
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+
+__all__ = [
+    "OrbPolicy",
+    "SeverityProfile",
+    "Chart",
+    "Event",
+    "RuleSetVersion",
+    "AsteroidMeta",
+    "ExportJob",
+    "ChartKind",
+    "EventType",
+    "ExportType",
+]

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+import os
+from contextlib import contextmanager
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+DB_URL = os.getenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+engine = create_engine(DB_URL, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
+
+@contextmanager
+def session_scope():
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/repo/__init__.py
+++ b/app/repo/__init__.py
@@ -1,0 +1,17 @@
+from .orb_policies import OrbPolicyRepo
+from .severity_profiles import SeverityProfileRepo
+from .charts import ChartRepo
+from .events import EventRepo
+from .rulesets import RuleSetRepo
+from .asteroids import AsteroidRepo
+from .exports import ExportJobRepo
+
+__all__ = [
+    "OrbPolicyRepo",
+    "SeverityProfileRepo",
+    "ChartRepo",
+    "EventRepo",
+    "RuleSetRepo",
+    "AsteroidRepo",
+    "ExportJobRepo",
+]

--- a/app/repo/asteroids.py
+++ b/app/repo/asteroids.py
@@ -1,0 +1,7 @@
+from app.repo.base import BaseRepo
+from app.db.models import AsteroidMeta
+
+
+class AsteroidRepo(BaseRepo[AsteroidMeta]):
+    def __init__(self) -> None:
+        super().__init__(AsteroidMeta)

--- a/app/repo/base.py
+++ b/app/repo/base.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from typing import Generic, TypeVar, Type, Optional, Iterable
+from sqlalchemy.orm import Session
+
+T = TypeVar("T")
+
+class BaseRepo(Generic[T]):
+    def __init__(self, model: Type[T]):
+        self.model = model
+
+    def create(self, db: Session, **kwargs) -> T:
+        obj = self.model(**kwargs)
+        db.add(obj)
+        db.flush()  # assign PK
+        return obj
+
+    def get(self, db: Session, id: int) -> Optional[T]:
+        return db.get(self.model, id)
+
+    def list(self, db: Session, limit: int = 100, offset: int = 0) -> Iterable[T]:
+        return db.query(self.model).offset(offset).limit(limit).all()
+
+    def update(self, db: Session, id: int, **kwargs) -> T:
+        obj = self.get(db, id)
+        if not obj:
+            raise ValueError(f"{self.model.__name__} {id} not found")
+        for k, v in kwargs.items():
+            setattr(obj, k, v)
+        db.flush()
+        return obj
+
+    def delete(self, db: Session, id: int) -> None:
+        obj = self.get(db, id)
+        if not obj:
+            return
+        db.delete(obj)
+        db.flush()

--- a/app/repo/charts.py
+++ b/app/repo/charts.py
@@ -1,0 +1,13 @@
+from typing import Iterable
+from sqlalchemy.orm import Session
+from app.repo.base import BaseRepo
+from app.db.models import Chart, Event
+
+
+class ChartRepo(BaseRepo[Chart]):
+    def __init__(self) -> None:
+        super().__init__(Chart)
+
+    def list_events(self, db: Session, chart_id: int) -> Iterable[Event]:
+        ch = self.get(db, chart_id)
+        return ch.events if ch else []

--- a/app/repo/events.py
+++ b/app/repo/events.py
@@ -1,0 +1,7 @@
+from app.repo.base import BaseRepo
+from app.db.models import Event
+
+
+class EventRepo(BaseRepo[Event]):
+    def __init__(self) -> None:
+        super().__init__(Event)

--- a/app/repo/exports.py
+++ b/app/repo/exports.py
@@ -1,0 +1,7 @@
+from app.repo.base import BaseRepo
+from app.db.models import ExportJob
+
+
+class ExportJobRepo(BaseRepo[ExportJob]):
+    def __init__(self) -> None:
+        super().__init__(ExportJob)

--- a/app/repo/orb_policies.py
+++ b/app/repo/orb_policies.py
@@ -1,0 +1,7 @@
+from app.repo.base import BaseRepo
+from app.db.models import OrbPolicy
+
+
+class OrbPolicyRepo(BaseRepo[OrbPolicy]):
+    def __init__(self) -> None:
+        super().__init__(OrbPolicy)

--- a/app/repo/rulesets.py
+++ b/app/repo/rulesets.py
@@ -1,0 +1,17 @@
+from typing import Optional
+from sqlalchemy.orm import Session
+from app.repo.base import BaseRepo
+from app.db.models import RuleSetVersion
+
+
+class RuleSetRepo(BaseRepo[RuleSetVersion]):
+    def __init__(self) -> None:
+        super().__init__(RuleSetVersion)
+
+    def get_active(self, db: Session, key: str) -> Optional[RuleSetVersion]:
+        return (
+            db.query(RuleSetVersion)
+            .filter(RuleSetVersion.key == key, RuleSetVersion.is_active == True)  # noqa: E712
+            .order_by(RuleSetVersion.version.desc())
+            .first()
+        )

--- a/app/repo/severity_profiles.py
+++ b/app/repo/severity_profiles.py
@@ -1,0 +1,7 @@
+from app.repo.base import BaseRepo
+from app.db.models import SeverityProfile
+
+
+class SeverityProfileRepo(BaseRepo[SeverityProfile]):
+    def __init__(self) -> None:
+        super().__init__(SeverityProfile)

--- a/tests/test_repos_crud.py
+++ b/tests/test_repos_crud.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timezone
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app.db.base import Base
+from app.db.models import (
+    OrbPolicy, SeverityProfile, Chart, Event, RuleSetVersion,
+    AsteroidMeta, ExportJob, ChartKind, EventType, ExportType
+)
+from app.repo import (
+    OrbPolicyRepo, SeverityProfileRepo, ChartRepo, EventRepo,
+    RuleSetRepo, AsteroidRepo, ExportJobRepo
+)
+
+# In-memory DB for tests
+engine = create_engine("sqlite+pysqlite:///:memory:", future=True)
+TestSession = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base.metadata.create_all(engine)
+
+
+def test_crud_cycle():
+    with TestSession() as db:
+        # OrbPolicy
+        op = OrbPolicyRepo().create(db, name="classic", per_object={"Sun": 8.0})
+        assert op.id is not None
+
+        # SeverityProfile
+        sp = SeverityProfileRepo().create(db, name="default", weights={"conjunction": 1.0})
+        assert sp.id is not None
+
+        # Chart
+        ch = ChartRepo().create(db, kind=ChartKind.natal, dt_utc=datetime.now(timezone.utc), lat=0.0, lon=0.0)
+        assert ch.id is not None
+
+        # Event linked to chart
+        ev = EventRepo().create(
+            db,
+            type=EventType.custom,
+            start_ts=datetime.now(timezone.utc),
+            chart=ch,
+            objects={"A": "Mars", "B": "Venus"},
+        )
+        assert ev.id is not None and ev.chart_id == ch.id
+
+        # Ruleset
+        rs = RuleSetRepo().create(db, key="electional_default", version=1, definition_json={})
+        assert rs.id is not None
+
+        # Asteroid
+        am = AsteroidRepo().create(db, name="Chiron", designation="2060")
+        assert am.id is not None
+
+        # Export job
+        ex = ExportJobRepo().create(db, type=ExportType.ics, params={"foo": "bar"})
+        assert ex.id is not None
+
+        # Update
+        ChartRepo().update(db, ch.id, location_name="Greenwich")
+        assert ChartRepo().get(db, ch.id).location_name == "Greenwich"
+
+        # Delete
+        EventRepo().delete(db, ev.id)
+        assert EventRepo().get(db, ev.id) is None


### PR DESCRIPTION
## Summary
- add SQLAlchemy models covering orb policies, severity profiles, charts, events, rulesets, asteroids, and export jobs
- provide shared Session helpers plus typed repositories with minimal CRUD operations
- validate CRUD flows against an in-memory SQLite database

## Testing
- pytest -q tests/test_repos_crud.py

------
https://chatgpt.com/codex/tasks/task_e_68d80e0314c88324ac684a291383346d