### PR TITLE
Implement severity scoring and composite aggregations

### DIFF
--- a/astroengine/core/scan_plus/ranking.py
+++ b/astroengine/core/scan_plus/ranking.py
@@ -1,1 +1,124 @@
-"""Placeholder for scoring and ranking utilities."""
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from math import cos, pi
+from typing import Dict, Iterable, List, Mapping, Optional
+
+# Default aspect weights; can be overridden by SeverityProfile.weights
+DEFAULT_WEIGHTS: Dict[str, float] = {
+    "conjunction": 1.00,
+    "opposition": 0.95,
+    "square": 0.90,
+    "trine": 0.80,
+    "sextile": 0.60,
+    "quincunx": 0.50,
+    "semisquare": 0.45,
+    "sesquisquare": 0.45,
+    "quintile": 0.40,
+    "biquintile": 0.40,
+}
+
+
+def _weight_for(aspect_name: str, profile_weights: Mapping[str, float] | None) -> float:
+    key = aspect_name.lower()
+    if profile_weights and key in profile_weights:
+        return float(profile_weights[key])
+    return DEFAULT_WEIGHTS.get(key, 0.50)
+
+
+def taper_by_orb(orb_deg: float, orb_limit_deg: float) -> float:
+    """Cosine taper from 1.0 at exact to 0.0 at orb_limit.
+
+    - If orb >= limit → 0.0
+    - If orb == 0 → 1.0
+    - Smooth, monotonic decay: 0.5 * (1 + cos(pi * orb/limit))
+    """
+    if orb_limit_deg <= 0:
+        return 0.0
+    x = max(0.0, min(1.0, float(orb_deg) / float(orb_limit_deg)))
+    return 0.5 * (1.0 + cos(pi * x)) if x < 1.0 else 0.0
+
+
+def apply_modifiers(base: float, modifiers: Optional[Mapping[str, float]]) -> float:
+    """Multiply base by each modifier (e.g., dignity, house strength). None → 1.0.
+    Values should be >=0; clip at 0.
+    """
+    if not modifiers:
+        return base
+    m = 1.0
+    for _, val in modifiers.items():
+        try:
+            f = float(val)
+        except Exception:
+            f = 1.0
+        m *= max(0.0, f)
+    return base * m
+
+
+def severity(
+    aspect_name: str,
+    orb_deg: float,
+    orb_limit_deg: float,
+    profile: Mapping[str, object] | None = None,
+    modifiers: Optional[Mapping[str, float]] = None,
+) -> float:
+    """Compute a severity score.
+
+    Args:
+        aspect_name: e.g., "square".
+        orb_deg: absolute orb distance in degrees (>=0).
+        orb_limit_deg: allowed orb for this pair/aspect.
+        profile: dict with key "weights" (mapping aspect→weight), optional.
+        modifiers: optional multiplicative factors (e.g., dignity/house), floats.
+
+    Returns:
+        Non-negative float score.
+    """
+    weights = (profile or {}).get("weights") if profile else None
+    profile_weights: Mapping[str, float] | None
+    if isinstance(weights, Mapping):
+        profile_weights = weights  # type: ignore[assignment]
+    else:
+        profile_weights = None
+    base_w = _weight_for(aspect_name, profile_weights)
+    taper = taper_by_orb(orb_deg, orb_limit_deg)
+    score = base_w * taper
+    score = apply_modifiers(score, modifiers)
+    return max(0.0, float(score))
+
+
+@dataclass(frozen=True)
+class EventPoint:
+    ts: datetime  # timezone-aware UTC preferred
+    score: float
+
+
+def _date_key_utc(dt: datetime) -> str:
+    # Normalize to UTC date key YYYY-MM-DD
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    else:
+        dt = dt.astimezone(timezone.utc)
+    return dt.strftime("%Y-%m-%d")
+
+
+def daily_composite(events: Iterable[EventPoint]) -> Dict[str, float]:
+    """Average event scores per UTC day.
+    Returns mapping YYYY-MM-DD → average score.
+    """
+    buckets: Dict[str, List[float]] = {}
+    for ev in events:
+        k = _date_key_utc(ev.ts)
+        buckets.setdefault(k, []).append(float(ev.score))
+    return {k: (sum(v) / len(v)) if v else 0.0 for k, v in sorted(buckets.items())}
+
+
+def monthly_composite(daily_series: Mapping[str, float]) -> Dict[str, float]:
+    """Average of daily values per month.
+    Input keys: YYYY-MM-DD → value. Output keys: YYYY-MM → average.
+    """
+    months: Dict[str, List[float]] = {}
+    for day_key, val in daily_series.items():
+        month = day_key[:7]
+        months.setdefault(month, []).append(float(val))
+    return {m: (sum(v) / len(v)) if v else 0.0 for m, v in sorted(months.items())}

--- a/tests/test_severity.py
+++ b/tests/test_severity.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timezone, timedelta
+
+from astroengine.core.scan_plus.ranking import (
+    EventPoint,
+    daily_composite,
+    monthly_composite,
+    severity,
+    taper_by_orb,
+)
+
+PROFILE = {"weights": {"square": 1.2, "trine": 0.8, "conjunction": 1.0}}
+
+
+def test_taper_monotonic_and_bounds():
+    assert taper_by_orb(0.0, 6.0) == 1.0
+    assert 0.0 < taper_by_orb(3.0, 6.0) < 1.0
+    assert taper_by_orb(6.0, 6.0) == 0.0
+
+
+def test_severity_uses_profile_weights():
+    # Exact square should use weight 1.2 at orb 0, limit 6
+    s = severity("square", 0.0, 6.0, PROFILE)
+    assert 1.19 <= s <= 1.20
+
+
+def test_severity_tapers_with_orb():
+    s0 = severity("trine", 0.0, 6.0, PROFILE)
+    s3 = severity("trine", 3.0, 6.0, PROFILE)
+    s6 = severity("trine", 6.0, 6.0, PROFILE)
+    assert s0 > s3 > s6 >= 0.0
+
+
+def test_daily_and_monthly_composites():
+    base = datetime(2024, 1, 30, 12, 0, tzinfo=timezone.utc)
+    events = [
+        EventPoint(base + timedelta(hours=1), 1.0),
+        EventPoint(base + timedelta(hours=5), 0.5),
+        EventPoint(base + timedelta(days=1, hours=3), 2.0),  # next day
+        EventPoint(base + timedelta(days=2, hours=2), 1.5),  # next next day (Feb)
+    ]
+    daily = daily_composite(events)
+    assert list(daily.keys()) == ["2024-01-30", "2024-01-31", "2024-02-01"]
+    assert abs(daily["2024-01-30"] - 0.75) < 1e-6
+
+    monthly = monthly_composite(daily)
+    assert set(monthly.keys()) == {"2024-01", "2024-02"}
+    # Jan average of two days: (0.75 + 2.0)/2 = 1.375
+    assert abs(monthly["2024-01"] - 1.375) < 1e-6


### PR DESCRIPTION
## Summary
- add severity scoring utilities with orbital tapering and modifier support
- implement daily and monthly composite aggregation helpers for event scores
- introduce unit tests covering severity weights, tapering, and aggregations

## Testing
- pytest -q tests/test_severity.py

------
https://chatgpt.com/codex/tasks/task_e_68d80f0feeb08324aa8642e86d8994ed