### PR TITLE
Add harmonic angle utilities for aspects

### DIFF
--- a/astroengine/core/aspects_plus/__init__.py
+++ b/astroengine/core/aspects_plus/__init__.py
@@ -1,6 +1,6 @@
 """Aspect search extensions (harmonics, families, ranking)."""
 
-from . import search
+from . import harmonics, search
 from .orb_policy import orb_limit
 
-__all__ = ["search", "orb_limit"]
+__all__ = ["search", "harmonics", "orb_limit"]

--- a/astroengine/core/aspects_plus/harmonics.py
+++ b/astroengine/core/aspects_plus/harmonics.py
@@ -1,0 +1,87 @@
+"""Utilities for computing base aspect and harmonic angles.
+
+The helpers defined here allow other modules to map between canonical aspect
+names and their corresponding angles, generate harmonic series angles, and
+combine both sources into a single deduplicated list.  The utilities stay
+within the 0°–180° range which matches the expectations of the downstream
+aspect matching logic.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+# Canonical base aspect angles (degrees)
+BASE_ASPECTS: Dict[str, float] = {
+    "conjunction": 0.0,
+    "opposition": 180.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "sextile": 60.0,
+    "quincunx": 150.0,
+    "semisquare": 45.0,
+    "sesquisquare": 135.0,
+    "quintile": 72.0,
+    "biquintile": 144.0,
+}
+
+EPS = 1e-6
+
+
+def _dedupe_sorted(values: Iterable[float]) -> List[float]:
+    """Return the sorted unique values with tolerance-based deduplication."""
+
+    out: List[float] = []
+    for value in sorted(values):
+        if not out or abs(value - out[-1]) > EPS:
+            out.append(value)
+    return out
+
+
+def base_aspect_angles(names: Iterable[str]) -> List[float]:
+    """Map aspect names to exact angles in degrees.
+
+    Unknown aspect names are ignored. The returned list is sorted and contains
+    unique angles.
+    """
+
+    values: List[float] = []
+    for name in names:
+        key = str(name).lower()
+        if key in BASE_ASPECTS:
+            values.append(float(BASE_ASPECTS[key]))
+    return _dedupe_sorted(values)
+
+
+def harmonic_angles(h: int) -> List[float]:
+    """Return harmonic angles for step Δ=360/h within (0, 180].
+
+    The generated angles correspond to k * Δ for k=1..⌊h/2⌋. Values are clipped
+    to 180 when numerical precision errors make them extremely close to the
+    boundary. The resulting list is sorted and deduplicated.
+    """
+
+    if h <= 1:
+        return []
+    step = 360.0 / float(h)
+    values = [k * step for k in range(1, (h // 2) + 1)]
+    values = [180.0 if abs(value - 180.0) <= 1e-9 else value for value in values]
+    return _dedupe_sorted(values)
+
+
+def combined_angles(aspects: Iterable[str], harmonics: Iterable[int]) -> List[float]:
+    """Merge base aspect and harmonic angles into a single sorted list."""
+
+    angles: List[float] = []
+    angles.extend(base_aspect_angles(aspects))
+    for harmonic in harmonics:
+        angles.extend(harmonic_angles(int(harmonic)))
+    return _dedupe_sorted(angles)
+
+
+__all__ = [
+    "BASE_ASPECTS",
+    "base_aspect_angles",
+    "harmonic_angles",
+    "combined_angles",
+]

--- a/tests/test_harmonics.py
+++ b/tests/test_harmonics.py
@@ -1,0 +1,34 @@
+"""Unit tests for harmonic angle utilities."""
+
+from astroengine.core.aspects_plus.harmonics import (
+    base_aspect_angles,
+    combined_angles,
+    harmonic_angles,
+)
+
+EPS = 1e-6
+
+
+def approx(a: float, b: float, eps: float = EPS) -> bool:
+    return abs(a - b) <= eps
+
+
+def test_base_aspect_angles_classic():
+    values = base_aspect_angles(["sextile", "square", "trine", "bogus"])
+    assert values == [60.0, 90.0, 120.0]
+
+
+def test_harmonic_5_and_7():
+    h5 = harmonic_angles(5)
+    assert len(h5) == 2 and approx(h5[0], 72.0) and approx(h5[1], 144.0)
+
+    h7 = harmonic_angles(7)
+    assert len(h7) == 3
+    assert 51.428 - EPS <= h7[0] <= 51.429 + EPS
+    assert 102.857 - EPS <= h7[1] <= 102.858 + EPS
+    assert 154.285 - EPS <= h7[2] <= 154.286 + EPS
+
+
+def test_combined_angles_dedup_and_sort():
+    values = combined_angles(["square", "biquintile"], [5])
+    assert values == [72.0, 90.0, 144.0]


### PR DESCRIPTION
## Summary
- add reusable utilities for computing base aspect and harmonic angles
- expose the harmonics module through the aspects_plus package
- add unit coverage for harmonic and combined angle helpers

## Testing
- pytest -q tests/test_harmonics.py

------
https://chatgpt.com/codex/tasks/task_e_68d8103109f48324b2005a4ecf220316