### PR TITLE
Add Alembic migration for Plus core tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ Thumbs.db
 
 # Local artifacts
 diagnostics.json
+dev.db
 # >>> AUTO-GEN END: Gitignore Additions v1.0
 # >>> AUTO-GEN BEGIN: perf artifacts ignore v1.0
 .prof

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,36 @@
+[alembic]
+script_location = migrations
+prepend_sys_path = .
+sqlalchemy.url = ${DATABASE_URL:sqlite:///./dev.db}
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,5 @@
+"""Application package exposing database models for the AstroEngine Plus stack."""
+
+from __future__ import annotations
+
+__all__ = ["db"]

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,0 +1,8 @@
+"""Database primitives for AstroEngine Plus models."""
+
+from __future__ import annotations
+
+from .base import Base
+from . import models as models
+
+__all__ = ["Base", "models"]

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,14 @@
+"""Declarative base used by Alembic to reflect AstroEngine Plus models."""
+
+from __future__ import annotations
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):
+    """Shared declarative base ensuring a single metadata tree for migrations."""
+
+    pass
+
+
+__all__ = ["Base"]

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,0 +1,253 @@
+"""SQLAlchemy models backing AstroEngine Plus persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    JSON,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
+
+from .base import Base
+
+
+class TimestampMixin:
+    """Adds audited timestamps used across persisted AstroEngine records."""
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class ModuleScopeMixin:
+    """Ensures every record tracks the module/submodule/channel scope."""
+
+    module: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default="plus",
+        server_default=text("'plus'"),
+    )
+    submodule: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    channel: Mapped[str] = mapped_column(
+        String(64),
+        nullable=False,
+        default="transits",
+        server_default=text("'transits'"),
+    )
+    subchannel: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+
+class OrbPolicy(ModuleScopeMixin, TimestampMixin, Base):
+    """Normalized orb policy entries keyed by profile, body, and aspect."""
+
+    __tablename__ = "orb_policies"
+    __table_args__ = (
+        UniqueConstraint(
+            "profile_key",
+            "module",
+            "submodule",
+            "channel",
+            "subchannel",
+            "body",
+            "aspect",
+            name="uq_orb_policy_scope",
+        ),
+        Index("ix_orb_policies_profile_module", "profile_key", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    body: Mapped[str] = mapped_column(String(64), nullable=False)
+    aspect: Mapped[str] = mapped_column(String(64), nullable=False)
+    orb_degrees: Mapped[float] = mapped_column(Float, nullable=False)
+    source_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class SeverityProfile(ModuleScopeMixin, TimestampMixin, Base):
+    """Severity multipliers and thresholds used during scoring."""
+
+    __tablename__ = "severity_profiles"
+    __table_args__ = (
+        UniqueConstraint("profile_key", name="uq_severity_profile_key"),
+        Index("ix_severity_profiles_module_channel", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    profile_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    weights: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    modifiers: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    events: Mapped[list["Event"]] = relationship(back_populates="severity_profile")
+
+
+class Chart(ModuleScopeMixin, TimestampMixin, Base):
+    """Natal or derived charts used to contextualize detected events."""
+
+    __tablename__ = "charts"
+    __table_args__ = (
+        UniqueConstraint("chart_key", name="uq_charts_chart_key"),
+        Index("ix_charts_profile_module", "profile_key", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    chart_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    profile_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    reference_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    timezone: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    source: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
+    events: Mapped[list["Event"]] = relationship(back_populates="chart", cascade="all, delete-orphan")
+
+
+class RulesetVersion(ModuleScopeMixin, TimestampMixin, Base):
+    """Versioned rulesets linking scans to reproducible logic bundles."""
+
+    __tablename__ = "ruleset_versions"
+    __table_args__ = (
+        UniqueConstraint("ruleset_key", "version", name="uq_ruleset_version"),
+        Index("ix_ruleset_versions_module_channel", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    ruleset_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    version: Mapped[str] = mapped_column(String(32), nullable=False)
+    checksum: Mapped[str] = mapped_column(String(128), nullable=False)
+    definition: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=text("1"),
+    )
+
+    events: Mapped[list["Event"]] = relationship(back_populates="ruleset_version")
+
+
+class Event(ModuleScopeMixin, TimestampMixin, Base):
+    """Detected events ready for downstream export and auditing."""
+
+    __tablename__ = "events"
+    __table_args__ = (
+        UniqueConstraint("event_key", name="uq_events_event_key"),
+        Index("ix_events_event_time", "event_time"),
+        Index("ix_events_chart", "chart_id"),
+        Index("ix_events_module_channel", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    event_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    chart_id: Mapped[int] = mapped_column(ForeignKey("charts.id", ondelete="CASCADE"), nullable=False)
+    ruleset_version_id: Mapped[int] = mapped_column(
+        ForeignKey("ruleset_versions.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    severity_profile_id: Mapped[int | None] = mapped_column(
+        ForeignKey("severity_profiles.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    event_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    event_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    score: Mapped[float | None] = mapped_column(Float, nullable=True)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="pending",
+        server_default=text("'pending'"),
+    )
+    source: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    chart: Mapped[Chart] = relationship(back_populates="events")
+    ruleset_version: Mapped[RulesetVersion] = relationship(back_populates="events")
+    severity_profile: Mapped[SeverityProfile | None] = relationship(back_populates="events")
+    export_jobs: Mapped[list["ExportJob"]] = relationship(back_populates="event")
+
+
+class AsteroidMeta(ModuleScopeMixin, TimestampMixin, Base):
+    """Metadata for indexed asteroids used in scans and exports."""
+
+    __tablename__ = "asteroid_meta"
+    __table_args__ = (
+        UniqueConstraint("designation", name="uq_asteroid_designation"),
+        Index("ix_asteroid_meta_module_channel", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    asteroid_id: Mapped[str] = mapped_column(String(32), nullable=False)
+    designation: Mapped[str] = mapped_column(String(64), nullable=False)
+    common_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    attributes: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    orbit_class: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    source_catalog: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+
+class ExportJob(ModuleScopeMixin, TimestampMixin, Base):
+    """Queued export jobs referencing detected events."""
+
+    __tablename__ = "export_jobs"
+    __table_args__ = (
+        UniqueConstraint("job_key", name="uq_export_job_key"),
+        Index("ix_export_jobs_status_requested", "status", "requested_at"),
+        Index("ix_export_jobs_module_channel", "module", "channel"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    job_key: Mapped[str] = mapped_column(String(64), nullable=False)
+    event_id: Mapped[int | None] = mapped_column(
+        ForeignKey("events.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    job_type: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32),
+        nullable=False,
+        default="queued",
+        server_default=text("'queued'"),
+    )
+    payload: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    result_uri: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    requested_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    event: Mapped[Event | None] = relationship(back_populates="export_jobs")
+
+
+__all__ = [
+    "AsteroidMeta",
+    "Chart",
+    "Event",
+    "ExportJob",
+    "ModuleScopeMixin",
+    "OrbPolicy",
+    "RulesetVersion",
+    "SeverityProfile",
+    "TimestampMixin",
+]

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,5 @@
+AstroEngine Plus Alembic migrations.
+
+This directory is intentionally tracked to ensure reproducible schema updates
+for the Plus data models. The migrations rely on the metadata defined in
+``app.db.base`` and ``app.db.models``.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,75 @@
+"""Alembic environment configuring AstroEngine Plus metadata."""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from app.db.base import Base
+from app.db import models  # noqa: F401 - ensure models are registered with the metadata
+
+DEFAULT_DB_URL = "sqlite:///./dev.db"
+
+config = context.config
+configured_url = config.get_main_option("sqlalchemy.url") or DEFAULT_DB_URL
+database_url = os.getenv("DATABASE_URL", configured_url if "${" not in configured_url else DEFAULT_DB_URL)
+config.set_main_option("sqlalchemy.url", database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Run migrations without a live connection."""
+
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        render_as_batch=True,
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations with a connection to the configured database."""
+
+    section = config.get_section(config.config_ini_section) or {}
+    section["sqlalchemy.url"] = config.get_main_option("sqlalchemy.url")
+
+    connectable = engine_from_config(
+        section,
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+        future=True,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            render_as_batch=True,
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+def run_migrations() -> None:
+    """Entry point invoked by Alembic based on execution mode."""
+
+    if context.is_offline_mode():
+        run_migrations_offline()
+    else:
+        run_migrations_online()
+
+
+run_migrations()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,20 @@
+"""${message}"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+revision = ${repr(revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/20241006_0001_plus_core_models.py
+++ b/migrations/versions/20241006_0001_plus_core_models.py
@@ -1,0 +1,266 @@
+"""Create AstroEngine Plus core tables."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20241006_0001"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    timestamp_default = sa.text("CURRENT_TIMESTAMP")
+
+    op.create_table(
+        "orb_policies",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("profile_key", sa.String(length=64), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("body", sa.String(length=64), nullable=False),
+        sa.Column("aspect", sa.String(length=64), nullable=False),
+        sa.Column("orb_degrees", sa.Float(), nullable=False),
+        sa.Column("source_id", sa.String(length=128), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "profile_key",
+            "module",
+            "submodule",
+            "channel",
+            "subchannel",
+            "body",
+            "aspect",
+            name="uq_orb_policy_scope",
+        ),
+    )
+    op.create_index(
+        "ix_orb_policies_profile_module",
+        "orb_policies",
+        ["profile_key", "module", "channel"],
+    )
+
+    op.create_table(
+        "severity_profiles",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("profile_key", sa.String(length=64), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("weights", sa.JSON(), nullable=False),
+        sa.Column("modifiers", sa.JSON(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("profile_key", name="uq_severity_profile_key"),
+    )
+    op.create_index(
+        "ix_severity_profiles_module_channel",
+        "severity_profiles",
+        ["module", "channel"],
+    )
+
+    op.create_table(
+        "charts",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("chart_key", sa.String(length=64), nullable=False),
+        sa.Column("profile_key", sa.String(length=64), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("reference_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("timezone", sa.String(length=64), nullable=True),
+        sa.Column("source", sa.String(length=128), nullable=True),
+        sa.Column("data", sa.JSON(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("chart_key", name="uq_charts_chart_key"),
+    )
+    op.create_index(
+        "ix_charts_profile_module",
+        "charts",
+        ["profile_key", "module", "channel"],
+    )
+
+    op.create_table(
+        "ruleset_versions",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("ruleset_key", sa.String(length=64), nullable=False),
+        sa.Column("version", sa.String(length=32), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("checksum", sa.String(length=128), nullable=False),
+        sa.Column("definition", sa.JSON(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("ruleset_key", "version", name="uq_ruleset_version"),
+    )
+    op.create_index(
+        "ix_ruleset_versions_module_channel",
+        "ruleset_versions",
+        ["module", "channel"],
+    )
+
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("event_key", sa.String(length=64), nullable=False),
+        sa.Column("chart_id", sa.Integer(), nullable=False),
+        sa.Column("ruleset_version_id", sa.Integer(), nullable=False),
+        sa.Column("severity_profile_id", sa.Integer(), nullable=True),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("event_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("event_type", sa.String(length=64), nullable=False),
+        sa.Column("payload", sa.JSON(), nullable=False),
+        sa.Column("score", sa.Float(), nullable=True),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("source", sa.String(length=128), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["chart_id"], ["charts.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["ruleset_version_id"], ["ruleset_versions.id"], ondelete="RESTRICT"),
+        sa.ForeignKeyConstraint(["severity_profile_id"], ["severity_profiles.id"], ondelete="SET NULL"),
+        sa.UniqueConstraint("event_key", name="uq_events_event_key"),
+    )
+    op.create_index("ix_events_event_time", "events", ["event_time"])
+    op.create_index("ix_events_chart", "events", ["chart_id"])
+    op.create_index("ix_events_module_channel", "events", ["module", "channel"])
+
+    op.create_table(
+        "asteroid_meta",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("asteroid_id", sa.String(length=32), nullable=False),
+        sa.Column("designation", sa.String(length=64), nullable=False),
+        sa.Column("common_name", sa.String(length=128), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("attributes", sa.JSON(), nullable=False),
+        sa.Column("orbit_class", sa.String(length=64), nullable=True),
+        sa.Column("source_catalog", sa.String(length=128), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("designation", name="uq_asteroid_designation"),
+    )
+    op.create_index(
+        "ix_asteroid_meta_module_channel",
+        "asteroid_meta",
+        ["module", "channel"],
+    )
+
+    op.create_table(
+        "export_jobs",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("job_key", sa.String(length=64), nullable=False),
+        sa.Column("event_id", sa.Integer(), nullable=True),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("job_type", sa.String(length=64), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False, server_default=sa.text("'queued'")),
+        sa.Column("payload", sa.JSON(), nullable=True),
+        sa.Column("result_uri", sa.String(length=255), nullable=True),
+        sa.Column("requested_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["event_id"], ["events.id"], ondelete="SET NULL"),
+        sa.UniqueConstraint("job_key", name="uq_export_job_key"),
+    )
+    op.create_index(
+        "ix_export_jobs_status_requested",
+        "export_jobs",
+        ["status", "requested_at"],
+    )
+    op.create_index(
+        "ix_export_jobs_module_channel",
+        "export_jobs",
+        ["module", "channel"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_export_jobs_module_channel", table_name="export_jobs")
+    op.drop_index("ix_export_jobs_status_requested", table_name="export_jobs")
+    op.drop_table("export_jobs")
+
+    op.drop_index("ix_asteroid_meta_module_channel", table_name="asteroid_meta")
+    op.drop_table("asteroid_meta")
+
+    op.drop_index("ix_events_module_channel", table_name="events")
+    op.drop_index("ix_events_chart", table_name="events")
+    op.drop_index("ix_events_event_time", table_name="events")
+    op.drop_table("events")
+
+    op.drop_index("ix_ruleset_versions_module_channel", table_name="ruleset_versions")
+    op.drop_table("ruleset_versions")
+
+    op.drop_index("ix_charts_profile_module", table_name="charts")
+    op.drop_table("charts")
+
+    op.drop_index("ix_severity_profiles_module_channel", table_name="severity_profiles")
+    op.drop_table("severity_profiles")
+
+    op.drop_index("ix_orb_policies_profile_module", table_name="orb_policies")
+    op.drop_table("orb_policies")

--- a/tests/test_migration_tables.py
+++ b/tests/test_migration_tables.py
@@ -1,0 +1,50 @@
+"""Smoke test verifying Alembic migrations for AstroEngine Plus models."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, inspect
+
+EXPECTED_TABLES = {
+    "orb_policies",
+    "severity_profiles",
+    "charts",
+    "ruleset_versions",
+    "events",
+    "asteroid_meta",
+    "export_jobs",
+}
+
+
+def _make_config(database_url: str) -> Config:
+    root = Path(__file__).resolve().parents[1]
+    cfg = Config(str(root / "alembic.ini"))
+    cfg.set_main_option("script_location", str(root / "migrations"))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    cfg.attributes["configure_logger"] = False
+    return cfg
+
+
+def _introspect_tables(database_url: str) -> set[str]:
+    engine = create_engine(database_url)
+    try:
+        return set(inspect(engine).get_table_names())
+    finally:
+        engine.dispose()
+
+
+def test_tables_exist_after_upgrade(tmp_path) -> None:
+    db_path = tmp_path / "plus.db"
+    database_url = f"sqlite:///{db_path}"
+    cfg = _make_config(database_url)
+
+    command.upgrade(cfg, "head")
+    tables_after_upgrade = _introspect_tables(database_url)
+    assert EXPECTED_TABLES.issubset(tables_after_upgrade)
+
+    command.downgrade(cfg, "-1")
+    tables_after_downgrade = _introspect_tables(database_url)
+    assert EXPECTED_TABLES.isdisjoint(tables_after_downgrade)


### PR DESCRIPTION
## Summary
- add declarative Base and Plus data models capturing orb policies, severity profiles, charts, rulesets, events, asteroid metadata, and export jobs
- configure a standalone Alembic environment with an initial revision that creates the Plus tables and supporting indexes
- add a smoke test that exercises upgrade/downgrade against a temporary SQLite database and ignore the generated dev.db artifact

## Testing
- pytest -q tests/test_migration_tables.py

------
https://chatgpt.com/codex/tasks/task_e_68d80dc52704832486ff9e9cf8c95d9d