### PR TITLE
Add time-ranged aspect scanner with bisection search

### DIFF
--- a/astroengine/core/aspects_plus/__init__.py
+++ b/astroengine/core/aspects_plus/__init__.py
@@ -1,6 +1,6 @@
 """Aspect search extensions (harmonics, families, ranking)."""
 
-from . import harmonics, search
+from . import harmonics, matcher, scan, search
 from .orb_policy import orb_limit
 
-__all__ = ["search", "harmonics", "orb_limit"]
+__all__ = ["search", "harmonics", "matcher", "scan", "orb_limit"]

--- a/astroengine/core/aspects_plus/matcher.py
+++ b/astroengine/core/aspects_plus/matcher.py
@@ -1,0 +1,27 @@
+"""Angular separation helpers for aspect matching."""
+
+from __future__ import annotations
+
+__all__ = ["angular_sep_deg"]
+
+
+def angular_sep_deg(a: float, b: float) -> float:
+    """Return the smallest angular distance between two ecliptic longitudes.
+
+    Args:
+        a: Longitude in degrees (any real value; wraps modulo 360).
+        b: Longitude in degrees (any real value; wraps modulo 360).
+
+    Returns:
+        Absolute separation in degrees within the inclusive range [0, 180].
+    """
+
+    # Normalize the delta to (-180, 180] using modular arithmetic. The nested
+    # modulo keeps the implementation numerically stable for arbitrarily large
+    # inputs while avoiding floating-point drift near the wrap-around point.
+    delta = (a - b + 180.0) % 360.0 - 180.0
+    if delta < -180.0:
+        delta += 360.0
+    elif delta > 180.0:
+        delta -= 360.0
+    return abs(delta)

--- a/astroengine/core/aspects_plus/scan.py
+++ b/astroengine/core/aspects_plus/scan.py
@@ -1,0 +1,229 @@
+"""Time window scanner for aspect alignments with bisection refinement."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+from .harmonics import combined_angles
+from .matcher import angular_sep_deg
+from .orb_policy import orb_limit
+
+# ----------------------------------------------------------------------------
+# Provider protocol
+# ----------------------------------------------------------------------------
+# position_provider(ts) -> {name: ecliptic_longitude_deg}
+PositionProvider = Callable[[datetime], Dict[str, float]]
+
+
+# ----------------------------------------------------------------------------
+# Data structures
+# ----------------------------------------------------------------------------
+@dataclass
+class TimeWindow:
+    start: datetime
+    end: datetime
+
+
+@dataclass
+class Hit:
+    a: str
+    b: str
+    aspect_angle: float  # degrees (e.g., 60.0)
+    exact_time: datetime
+    orb: float  # |Δ - aspect_angle| at exact_time (should be small)
+    orb_limit: float
+
+
+# ----------------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------------
+
+def _date_iter(start: datetime, end: datetime, step: timedelta) -> Iterable[datetime]:
+    t = start
+    while t <= end:
+        yield t
+        t = t + step
+
+
+def _signed_diff(delta_abs: float, target_angle: float) -> float:
+    """Return f(Δ) = |Δ| - target; negative when inside, positive when outside."""
+
+    return float(delta_abs) - float(target_angle)
+
+
+def _refine_bisection(
+    f: Callable[[datetime], float],
+    t0: datetime,
+    t1: datetime,
+    max_iter: int = 40,
+    tol_seconds: float = 1.0,
+) -> datetime:
+    """Binary search for root of f(t)=0 within [t0, t1]."""
+
+    a, b = t0, t1
+    fa, fb = f(a), f(b)
+
+    # If either endpoint is already precise enough, return it immediately.
+    if abs(fa) < 1e-6:
+        return a
+    if abs(fb) < 1e-6:
+        return b
+
+    for _ in range(max_iter):
+        mid = a + (b - a) / 2
+        fm = f(mid)
+        if (b - a).total_seconds() <= tol_seconds or abs(fm) < 1e-6:
+            return mid
+        if (fa <= 0 and fm >= 0) or (fa >= 0 and fm <= 0):
+            b, fb = mid, fm
+        else:
+            a, fa = mid, fm
+
+    return a + (b - a) / 2
+
+
+# ----------------------------------------------------------------------------
+# Core: scan a single pair across time for multiple target angles
+# ----------------------------------------------------------------------------
+
+def scan_pair_time_range(
+    a_name: str,
+    b_name: str,
+    window: TimeWindow,
+    position_provider: PositionProvider,
+    aspect_angles: Iterable[float],
+    orb_policy: Dict,
+    step_minutes: int = 60,
+    dedup_minutes: int = 30,
+) -> List[Hit]:
+    """Scan [start, end] for times when |Δ(t) - angle| crosses zero."""
+
+    start = window.start.astimezone(timezone.utc)
+    end = window.end.astimezone(timezone.utc)
+    step = timedelta(minutes=int(step_minutes))
+
+    aspect_angles = sorted({float(x) for x in aspect_angles})
+    hits: List[Hit] = []
+    last_hit_time: Dict[float, datetime] = {}
+
+    def delta_abs_at(ts: datetime) -> float:
+        pos = position_provider(ts)
+        return angular_sep_deg(pos[a_name], pos[b_name])
+
+    for angle in aspect_angles:
+        prev_t: Optional[datetime] = None
+        prev_f: Optional[float] = None
+
+        for t in _date_iter(start, end, step):
+            d = delta_abs_at(t)
+            f = _signed_diff(d, angle)
+
+            if prev_t is not None and prev_f is not None:
+                sign_change = (prev_f <= 0 and f >= 0) or (prev_f >= 0 and f <= 0)
+                if sign_change:
+                    root = _refine_bisection(
+                        lambda x, target=angle: _signed_diff(delta_abs_at(x), target),
+                        prev_t,
+                        t,
+                    )
+                    root = min(max(root, start), end)
+
+                    last = last_hit_time.get(angle)
+                    if last and abs((root - last).total_seconds()) < dedup_minutes * 60:
+                        prev_t, prev_f = t, f
+                        continue
+
+                    d_root = delta_abs_at(root)
+                    orb = abs(d_root - angle)
+                    limit = orb_limit(
+                        a_name,
+                        b_name,
+                        _aspect_name_from_angle(angle),
+                        orb_policy,
+                    )
+                    if orb <= limit + 1e-6:
+                        hits.append(
+                            Hit(
+                                a=a_name,
+                                b=b_name,
+                                aspect_angle=angle,
+                                exact_time=root,
+                                orb=orb,
+                                orb_limit=float(limit),
+                            )
+                        )
+                        last_hit_time[angle] = root
+
+            prev_t, prev_f = t, f
+
+    hits.sort(key=lambda h: h.exact_time)
+    return hits
+
+
+_ASPECT_LOOKUP = {
+    0.0: "conjunction",
+    60.0: "sextile",
+    72.0: "quintile",
+    90.0: "square",
+    120.0: "trine",
+    135.0: "sesquisquare",
+    144.0: "biquintile",
+    150.0: "quincunx",
+    180.0: "opposition",
+}
+
+
+def _aspect_name_from_angle(angle: float) -> str:
+    rounded = round(angle, 6)
+    return _ASPECT_LOOKUP.get(rounded, str(rounded))
+
+
+# ----------------------------------------------------------------------------
+# Top-level multi-pair scan
+# ----------------------------------------------------------------------------
+
+def scan_time_range(
+    objects: Iterable[str],
+    window: TimeWindow,
+    position_provider: PositionProvider,
+    aspects: Iterable[str],
+    harmonics: Iterable[int],
+    orb_policy: Dict,
+    pairs: Optional[Iterable[Tuple[str, str]]] = None,
+    step_minutes: int = 60,
+) -> List[Hit]:
+    names = list(objects)
+    if pairs is None:
+        from itertools import combinations
+
+        pairs_iter = combinations(names, 2)
+    else:
+        pairs_iter = pairs
+
+    angles = combined_angles(aspects, harmonics)
+
+    all_hits: List[Hit] = []
+    for a, b in pairs_iter:
+        pair_hits = scan_pair_time_range(
+            a,
+            b,
+            window,
+            position_provider,
+            angles,
+            orb_policy,
+            step_minutes=step_minutes,
+        )
+        all_hits.extend(pair_hits)
+
+    all_hits.sort(key=lambda h: h.exact_time)
+    return all_hits
+
+
+__all__ = [
+    "TimeWindow",
+    "Hit",
+    "scan_pair_time_range",
+    "scan_time_range",
+]

--- a/tests/test_scan_timerange.py
+++ b/tests/test_scan_timerange.py
@@ -1,0 +1,81 @@
+from datetime import datetime, timedelta, timezone
+
+from astroengine.core.aspects_plus.scan import (
+    Hit,
+    TimeWindow,
+    scan_pair_time_range,
+    scan_time_range,
+)
+
+
+class LinearEphemeris:
+    """Synthetic linear-motion ephemeris for testing."""
+
+    def __init__(
+        self,
+        t0: datetime,
+        base: dict[str, float],
+        rates_deg_per_day: dict[str, float],
+    ) -> None:
+        self.t0 = t0
+        self.base = base
+        self.rates = rates_deg_per_day
+
+    def __call__(self, ts: datetime):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        out: dict[str, float] = {}
+        for name, lon0 in self.base.items():
+            out[name] = (lon0 + self.rates.get(name, 0.0) * dt_days) % 360.0
+        return out
+
+
+POLICY = {"per_object": {}, "per_aspect": {"sextile": 3.0}, "adaptive_rules": {}}
+
+
+def test_find_single_sextile_with_bisection():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Mars": 10.0, "Venus": 0.0},
+        rates_deg_per_day={"Mars": 0.2, "Venus": 1.0},
+    )
+    win = TimeWindow(start=t0, end=t0 + timedelta(days=100))
+
+    hits = scan_pair_time_range(
+        "Mars",
+        "Venus",
+        win,
+        eph,
+        [60.0],
+        POLICY,
+        step_minutes=720,
+    )
+    assert hits
+
+    h0 = hits[0]
+    # Analytic solution: |10 - 0.8 t| = 60 -> t = 87.5 days (post-conjunction branch)
+    expected = t0 + timedelta(days=87.5)
+    assert abs((h0.exact_time - expected).total_seconds()) <= 30
+    assert h0.orb <= 1e-3
+
+
+def test_multi_pair_scan_wrapper():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Mars": 10.0, "Venus": 0.0, "Sun": 0.0},
+        rates_deg_per_day={"Mars": 0.2, "Venus": 1.0, "Sun": 0.9856},
+    )
+    win = TimeWindow(start=t0, end=t0 + timedelta(days=30))
+
+    hits = scan_time_range(
+        objects=["Sun", "Mars", "Venus"],
+        window=win,
+        position_provider=eph,
+        aspects=["sextile"],
+        harmonics=[],
+        orb_policy=POLICY,
+        step_minutes=360,
+    )
+
+    assert hits == sorted(hits, key=lambda h: h.exact_time)


### PR DESCRIPTION
## Summary
- add an angular separation helper for aspects_plus workflows
- implement time-window scanning with bisection refinement for aspect hits
- cover the scanner with linear-ephemeris regression tests

## Testing
- pytest -q tests/test_scan_timerange.py

------
https://chatgpt.com/codex/tasks/task_e_68d8117752b0832493e71d48e2fc4815