### PR TITLE
Add aspect hit ranking helpers and coverage

### DIFF
--- a/astroengine/core/aspects_plus/__init__.py
+++ b/astroengine/core/aspects_plus/__init__.py
@@ -1,6 +1,7 @@
 """Aspect search extensions (harmonics, families, ranking)."""
 
-from . import harmonics, search
+from . import aggregate, harmonics, search
 from .orb_policy import orb_limit
+from .scan import Hit
 
-__all__ = ["search", "harmonics", "orb_limit"]
+__all__ = ["aggregate", "search", "harmonics", "orb_limit", "Hit"]

--- a/astroengine/core/aspects_plus/aggregate.py
+++ b/astroengine/core/aspects_plus/aggregate.py
@@ -1,0 +1,131 @@
+"""Utilities to rank scan hits, bin them by day, and paginate results."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from astroengine.core.scan_plus.ranking import severity
+
+from .scan import Hit
+
+# Best-effort mapping angle → canonical aspect name; keep in sync with scanner
+_ASPECT_LOOKUP: Dict[float, str] = {
+    0.0: "conjunction",
+    30.0: "semisextile",
+    45.0: "semisquare",
+    60.0: "sextile",
+    72.0: "quintile",
+    90.0: "square",
+    120.0: "trine",
+    135.0: "sesquisquare",
+    144.0: "biquintile",
+    150.0: "quincunx",
+    180.0: "opposition",
+}
+
+
+def _aspect_name_from_angle(angle: float) -> str:
+    """Normalize an aspect angle to the canonical scanner label."""
+
+    key = round(float(angle), 6)
+    return _ASPECT_LOOKUP.get(key, str(key))
+
+
+def _ensure_utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _utc_date_key(dt: datetime) -> str:
+    return _ensure_utc(dt).strftime("%Y-%m-%d")
+
+
+def _hit_dict(hit: Hit, aspect_name: str, sev: float) -> Dict[str, Any]:
+    return {
+        "a": hit.a,
+        "b": hit.b,
+        "aspect": aspect_name,
+        "aspect_angle": float(hit.aspect_angle),
+        "exact_time": hit.exact_time,
+        "orb": float(hit.orb),
+        "orb_limit": float(hit.orb_limit),
+        "severity": float(sev),
+    }
+
+
+def _sort_key(order_by: str):
+    if order_by == "severity":
+        return lambda item: (-item["severity"], item["exact_time"])
+    if order_by == "orb":
+        return lambda item: (item["orb"], item["exact_time"])
+    return lambda item: item["exact_time"]
+
+
+def rank_hits(
+    hits: Iterable[Hit],
+    profile: Optional[Mapping[str, Any]] = None,
+    order_by: str = "time",
+) -> List[Dict[str, Any]]:
+    """Attach severity to each hit and return a sorted list of mappings."""
+
+    ranked: List[Dict[str, Any]] = []
+    for hit in hits:
+        aspect_name = _aspect_name_from_angle(hit.aspect_angle)
+        sev = severity(aspect_name, hit.orb, hit.orb_limit, profile)
+        ranked.append(_hit_dict(hit, aspect_name, sev))
+
+    ranked.sort(key=_sort_key(order_by))
+    return ranked
+
+
+def day_bins(hits_with_severity: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    """Aggregate hits per UTC date, computing counts and average severity."""
+
+    counts: Dict[str, int] = defaultdict(int)
+    severity_values: Dict[str, List[float]] = defaultdict(list)
+
+    for hit in hits_with_severity:
+        exact = hit.get("exact_time")
+        if not isinstance(exact, datetime):
+            continue
+        day_key = _utc_date_key(exact)
+        counts[day_key] += 1
+        severity_val = hit.get("severity")
+        try:
+            if severity_val is not None:
+                severity_values[day_key].append(float(severity_val))
+        except Exception:
+            continue
+
+    bins: List[Dict[str, Any]] = []
+    for day in sorted(counts):
+        values = severity_values.get(day, [])
+        score: Optional[float]
+        if values:
+            score = sum(values) / len(values)
+        else:
+            score = None
+        bins.append({"date": day, "count": counts[day], "score": score})
+    return bins
+
+
+def paginate(
+    items: Iterable[Mapping[str, Any]],
+    limit: int,
+    offset: int,
+) -> Tuple[List[Mapping[str, Any]], int]:
+    """Return a window of ``items`` alongside the total length."""
+
+    if limit < 0 or offset < 0:
+        raise ValueError("limit and offset must be non-negative")
+
+    if isinstance(items, list):
+        total = len(items)
+        return items[offset : offset + limit], total
+
+    materialized = list(items)
+    total = len(materialized)
+    return materialized[offset : offset + limit], total

--- a/astroengine/core/aspects_plus/scan.py
+++ b/astroengine/core/aspects_plus/scan.py
@@ -1,0 +1,45 @@
+"""Aspect scan dataclasses for search/ranking pipelines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+@dataclass(slots=True)
+class Hit:
+    """Raw aspect hit emitted by scanning routines.
+
+    Attributes:
+        a: Primary actor identifier (planet/body name).
+        b: Secondary actor identifier.
+        aspect_angle: Exact aspect angle in degrees.
+        exact_time: Timestamp of the aspect hit (timezone-aware preferred).
+        orb: Absolute orb distance in degrees.
+        orb_limit: Maximum orb allowed for this aspect pairing.
+        meta: Optional mutable mapping for downstream annotations.
+    """
+
+    a: str
+    b: str
+    aspect_angle: float
+    exact_time: datetime
+    orb: float
+    orb_limit: float
+    meta: Optional[MutableMapping[str, Any]] = None
+
+    def as_mapping(self) -> Mapping[str, Any]:
+        """Return a shallow mapping representation of this hit."""
+
+        base = {
+            "a": self.a,
+            "b": self.b,
+            "aspect_angle": self.aspect_angle,
+            "exact_time": self.exact_time,
+            "orb": self.orb,
+            "orb_limit": self.orb_limit,
+        }
+        if self.meta:
+            base.update(self.meta)
+        return base

--- a/tests/test_ranking_bins.py
+++ b/tests/test_ranking_bins.py
@@ -1,0 +1,70 @@
+from datetime import datetime, timedelta, timezone
+
+from astroengine.core.aspects_plus.aggregate import day_bins, paginate, rank_hits
+from astroengine.core.aspects_plus.scan import Hit
+
+PROFILE = {"weights": {"sextile": 0.6, "square": 0.9}}
+
+
+def mk_hit(dt: datetime, orb: float, angle: float = 60.0) -> Hit:
+    return Hit(
+        a="Mars",
+        b="Venus",
+        aspect_angle=angle,
+        exact_time=dt,
+        orb=orb,
+        orb_limit=3.0,
+    )
+
+
+def test_rank_hits_and_ordering():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    hits = [mk_hit(t0 + timedelta(hours=2), 0.5), mk_hit(t0 + timedelta(hours=1), 0.1)]
+
+    ranked_time = rank_hits(hits, PROFILE, order_by="time")
+    assert ranked_time[0]["exact_time"] == t0 + timedelta(hours=1)
+
+    ranked_sev = rank_hits(hits, PROFILE, order_by="severity")
+    assert ranked_sev[0]["severity"] >= ranked_sev[1]["severity"]
+
+    ranked_orb = rank_hits(hits, PROFILE, order_by="orb")
+    assert ranked_orb[0]["orb"] <= ranked_orb[1]["orb"]
+
+
+def test_day_bins_and_pagination():
+    t0 = datetime(2025, 1, 1, 10, tzinfo=timezone.utc)
+    hits = [
+        mk_hit(t0, 0.1),
+        mk_hit(t0 + timedelta(hours=3), 0.2),
+        mk_hit(t0 + timedelta(days=1), 0.3),
+    ]
+    ranked = rank_hits(hits, PROFILE)
+    bins = day_bins(ranked)
+
+    assert bins[0]["date"] == "2025-01-01" and bins[0]["count"] == 2
+    assert bins[1]["date"] == "2025-01-02" and bins[1]["count"] == 1
+    assert bins[0]["score"] is not None and bins[0]["score"] >= bins[1]["score"]
+
+    page, total = paginate(ranked, limit=2, offset=0)
+    assert total == 3 and len(page) == 2
+
+
+def test_day_bins_handles_missing_severity():
+    day = datetime(2025, 5, 1, 9, tzinfo=timezone.utc)
+    hits = [
+        {"exact_time": day, "severity": 0.4},
+        {"exact_time": day + timedelta(hours=1), "severity": None},
+        {"exact_time": day + timedelta(hours=2)},
+    ]
+    bins = day_bins(hits)
+    assert bins == [{"date": "2025-05-01", "count": 3, "score": 0.4}]
+
+
+def test_paginate_rejects_negative_values():
+    ranked = rank_hits([mk_hit(datetime(2025, 1, 1, tzinfo=timezone.utc), 0.2)], PROFILE)
+    try:
+        paginate(ranked, limit=-1, offset=0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("negative limit must raise ValueError")


### PR DESCRIPTION
## Summary
- add a Hit dataclass for aspect scan results and expose it through the aspects_plus package
- implement ranking, daily binning, and pagination helpers that attach severity to hits
- cover the new helpers with unit tests validating ordering, binning, and pagination behaviours

## Testing
- pytest -q tests/test_ranking_bins.py

------
https://chatgpt.com/codex/tasks/task_e_68d812af350c8324885175a3263fa964