### PR TITLE
Add aspects search API endpoint with ranking

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,24 @@
+"""FastAPI application entry-point for AstroEngine."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from fastapi import FastAPI
+
+from app.routers import aspects as aspects_module
+from app.routers.aspects import router as aspects_router
+
+app = FastAPI(title="AstroEngine API")
+app.include_router(aspects_router)
+
+
+def demo_provider(ts: datetime) -> Dict[str, float]:
+    """Placeholder ephemeris returning static positions."""
+
+    _ = ts
+    return {"Sun": 0.0, "Moon": 0.0, "Mars": 0.0, "Venus": 0.0}
+
+
+aspects_module.position_provider = demo_provider

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI routers for the AstroEngine API surface."""
+
+from __future__ import annotations
+
+__all__ = []

--- a/app/routers/aspects.py
+++ b/app/routers/aspects.py
@@ -1,0 +1,149 @@
+"""REST router exposing the aspect search endpoint."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.aspects import (
+    AspectHit,
+    AspectSearchRequest,
+    AspectSearchResponse,
+    DayBin,
+    Paging,
+)
+from astroengine.core.aspects_plus.aggregate import day_bins, paginate, rank_hits
+from astroengine.core.aspects_plus.scan import TimeWindow, scan_time_range
+
+try:  # Optional repositories for policy lookup
+    from app.repo.orb_policies import OrbPolicyRepo  # type: ignore
+    from app.db.session import session_scope  # type: ignore
+except Exception:  # pragma: no cover
+    OrbPolicyRepo = None  # type: ignore
+    session_scope = None  # type: ignore
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+# -----------------------------------------------------------------------------
+# Position provider injection
+# -----------------------------------------------------------------------------
+position_provider = None  # type: ignore
+
+
+def _get_provider():
+    global position_provider
+    if position_provider is None:
+        def _stub(_ts: datetime):
+            raise RuntimeError("position_provider not configured")
+        return _stub
+    return position_provider
+
+
+# -----------------------------------------------------------------------------
+# Orb policy resolution
+# -----------------------------------------------------------------------------
+DEFAULT_POLICY: Dict[str, Any] = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 4.0,
+        "quincunx": 3.0,
+        "semisquare": 2.0,
+        "sesquisquare": 2.0,
+        "quintile": 2.0,
+        "biquintile": 2.0,
+    },
+    "adaptive_rules": {
+        "luminaries_factor": 0.9,
+        "outers_factor": 1.1,
+        "minor_aspect_factor": 0.9,
+    },
+}
+
+
+def _resolve_orb_policy(req: AspectSearchRequest) -> Dict[str, Any]:
+    if req.orb_policy_inline is not None:
+        return req.orb_policy_inline.model_dump()
+    if req.orb_policy_id is not None:
+        if OrbPolicyRepo is None or session_scope is None:
+            raise HTTPException(
+                status_code=400,
+                detail="orb_policy_id requires DB repos; provide orb_policy_inline instead",
+            )
+        with session_scope() as db:
+            rec = OrbPolicyRepo().get(db, req.orb_policy_id)
+            if not rec:
+                raise HTTPException(status_code=404, detail="orb policy not found")
+            return {
+                "per_object": rec.per_object or {},
+                "per_aspect": rec.per_aspect or {},
+                "adaptive_rules": rec.adaptive_rules or {},
+            }
+    return DEFAULT_POLICY
+
+
+# -----------------------------------------------------------------------------
+# Endpoint
+# -----------------------------------------------------------------------------
+@router.post(
+    "/aspects/search",
+    response_model=AspectSearchResponse,
+    summary="Search aspects over a time window",
+)
+def aspects_search(req: AspectSearchRequest):
+    provider = _get_provider()
+    policy = _resolve_orb_policy(req)
+
+    start = req.window.start.astimezone(timezone.utc)
+    end = req.window.end.astimezone(timezone.utc)
+    window = TimeWindow(start=start, end=end)
+
+    hits = scan_time_range(
+        objects=req.objects,
+        window=window,
+        position_provider=provider,
+        aspects=req.aspects,
+        harmonics=req.harmonics or [],
+        orb_policy=policy,
+        pairs=req.pairs,
+        step_minutes=req.step_minutes,
+    )
+
+    ranked = rank_hits(hits, profile=None, order_by=req.order_by)
+    page, total = paginate(ranked, limit=req.limit, offset=req.offset)
+
+    dto_hits = [
+        AspectHit(
+            a=h["a"],
+            b=h["b"],
+            aspect=h["aspect"],
+            harmonic=h.get("harmonic"),
+            exact_time=h["exact_time"],
+            orb=h["orb"],
+            orb_limit=h["orb_limit"],
+            severity=h.get("severity"),
+            meta=h.get("meta", {}),
+        )
+        for h in page
+    ]
+
+    bins = day_bins(ranked)
+    dto_bins = [
+        DayBin(
+            date=datetime.strptime(b["date"], "%Y-%m-%d").date(),
+            count=b["count"],
+            score=b.get("score"),
+        )
+        for b in bins
+    ]
+
+    return AspectSearchResponse(
+        hits=dto_hits,
+        bins=dto_bins,
+        paging=Paging(limit=req.limit, offset=req.offset, total=total),
+    )

--- a/astroengine/core/aspects_plus/aggregate.py
+++ b/astroengine/core/aspects_plus/aggregate.py
@@ -1,0 +1,108 @@
+"""Aggregation helpers for aspect search results."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+from astroengine.core.scan_plus.ranking import severity as compute_severity
+
+from .harmonics import BASE_ASPECTS
+
+try:  # pragma: no cover - avoid runtime import loop during static analysis
+    from .scan import Hit
+except Exception:  # pragma: no cover
+    Hit = Any  # type: ignore
+
+DateKey = str
+
+
+def _aspect_name_from_angle(angle: float) -> str:
+    for name, base_angle in BASE_ASPECTS.items():
+        if abs(float(angle) - float(base_angle)) <= 1e-6:
+            return name
+    raise ValueError(f"Unsupported aspect angle: {angle}")
+
+
+def _utc_date(ts: datetime) -> DateKey:
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    else:
+        ts = ts.astimezone(timezone.utc)
+    return ts.strftime("%Y-%m-%d")
+
+
+def rank_hits(
+    hits: Iterable[Hit],
+    profile: Mapping[str, Any] | None = None,
+    order_by: str = "time",
+) -> List[Dict[str, Any]]:
+    """Convert raw scan hits into ranked dictionaries ready for serialization."""
+
+    ranked: List[Dict[str, Any]] = []
+    for hit in hits:
+        aspect_name = _aspect_name_from_angle(getattr(hit, "aspect_angle"))
+        sev = compute_severity(aspect_name, float(hit.orb), float(hit.orb_limit), profile)
+        ranked.append(
+            {
+                "a": hit.a,
+                "b": hit.b,
+                "aspect": aspect_name,
+                "harmonic": None,
+                "exact_time": hit.exact_time,
+                "orb": float(hit.orb),
+                "orb_limit": float(hit.orb_limit),
+                "severity": float(sev) if sev is not None else None,
+                "meta": {"angle": float(getattr(hit, "aspect_angle", 0.0))},
+            }
+        )
+
+    if order_by == "severity":
+        ranked.sort(key=lambda h: (-(h["severity"] or 0.0), h["exact_time"]))
+    elif order_by == "orb":
+        ranked.sort(key=lambda h: (h["orb"], h["exact_time"]))
+    else:
+        ranked.sort(key=lambda h: (h["exact_time"], h["orb"]))
+    return ranked
+
+
+def day_bins(hits: Sequence[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    """Aggregate ranked hits into UTC day buckets."""
+
+    counts: Dict[DateKey, int] = defaultdict(int)
+    scores: Dict[DateKey, List[float]] = defaultdict(list)
+
+    for hit in hits:
+        ts = hit.get("exact_time")
+        if not isinstance(ts, datetime):
+            continue
+        key = _utc_date(ts)
+        counts[key] += 1
+        sev = hit.get("severity")
+        if sev is not None:
+            scores[key].append(float(sev))
+
+    out: List[Dict[str, Any]] = []
+    for key in sorted(counts):
+        daily_scores = scores.get(key, [])
+        avg = sum(daily_scores) / len(daily_scores) if daily_scores else None
+        out.append({"date": key, "count": counts[key], "score": avg})
+    return out
+
+
+def paginate(
+    hits: Sequence[Mapping[str, Any]],
+    limit: int,
+    offset: int,
+) -> Tuple[List[Mapping[str, Any]], int]:
+    """Return a window slice with total count for pagination."""
+
+    total = len(hits)
+    if offset >= total:
+        return [], total
+    end = offset + limit
+    return list(hits[offset:end]), total
+
+
+__all__ = ["rank_hits", "day_bins", "paginate"]

--- a/astroengine/core/aspects_plus/harmonics.py
+++ b/astroengine/core/aspects_plus/harmonics.py
@@ -1,8 +1,11 @@
+"""Harmonic aspect angle helpers."""
 
-"""Base aspect angles for named harmonic relationships."""
+from __future__ import annotations
+
+from math import gcd
+from typing import Iterable, List
 
 BASE_ASPECTS = {
-
     "conjunction": 0.0,
     "opposition": 180.0,
     "square": 90.0,
@@ -16,5 +19,52 @@ BASE_ASPECTS = {
 }
 
 
-__all__ = ["BASE_ASPECTS"]
+def base_aspect_angles(names: Iterable[str]) -> List[float]:
+    """Return sorted unique base aspect angles for the provided names."""
 
+    seen = set()
+    angles: List[float] = []
+    for name in names:
+        key = (name or "").strip().lower()
+        if key in BASE_ASPECTS and key not in seen:
+            seen.add(key)
+            angles.append(BASE_ASPECTS[key])
+    angles.sort()
+    return angles
+
+
+def harmonic_angles(order: int) -> List[float]:
+    """Return fundamental harmonic angles for ``order``."""
+
+    n = int(order)
+    if n <= 1:
+        return []
+    # Reduce redundant harmonics (e.g., even orders share bases with lower orders).
+    # We keep only the angles in (0, 180] unique to this harmonic.
+    fundamental: List[float] = []
+    for k in range(1, (n // 2) + 1):
+        if gcd(k, n) != 1:
+            continue
+        angle = 360.0 * k / n
+        if angle <= 180.0:
+            fundamental.append(angle)
+    fundamental.sort()
+    return fundamental
+
+
+def combined_angles(aspects: Iterable[str], harmonics: Iterable[int]) -> List[float]:
+    """Merge base aspects and harmonic-derived angles, deduplicated and sorted."""
+
+    out = set(base_aspect_angles(aspects))
+    for order in harmonics:
+        for angle in harmonic_angles(int(order)):
+            out.add(round(angle, 6))
+    return sorted(out)
+
+
+__all__ = [
+    "BASE_ASPECTS",
+    "base_aspect_angles",
+    "harmonic_angles",
+    "combined_angles",
+]

--- a/tests/test_api_aspects_search.py
+++ b/tests/test_api_aspects_search.py
@@ -1,0 +1,63 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import aspects as aspects_module
+from app.routers.aspects import router as aspects_router
+
+
+class LinearEphemeris:
+    def __init__(self, t0, base, rates):
+        self.t0, self.base, self.rates = t0, base, rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            k: (self.base[k] + self.rates.get(k, 0.0) * dt_days) % 360.0
+            for k in self.base
+        }
+
+
+def build_app(provider):
+    app = FastAPI()
+    aspects_module.position_provider = provider
+    app.include_router(aspects_router)
+    return app
+
+
+def test_post_aspects_search_minimal():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Mars": 10.0, "Venus": 0.0},
+        rates={"Mars": 0.2, "Venus": 1.0},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "objects": ["Mars", "Venus"],
+        "aspects": ["sextile"],
+        "harmonics": [],
+        "window": {
+            "start": t0.isoformat(),
+            "end": (t0 + timedelta(days=100)).isoformat(),
+        },
+        "step_minutes": 360,
+        "limit": 10,
+        "offset": 0,
+        "order_by": "time",
+        "orb_policy_inline": {
+            "per_aspect": {"sextile": 3.0},
+            "adaptive_rules": {},
+        },
+    }
+
+    response = client.post("/aspects/search", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert set(data.keys()) == {"hits", "bins", "paging"}
+    assert data["paging"]["limit"] == 10
+    assert isinstance(data["hits"], list)
+    assert data["hits"], "expected at least one hit"


### PR DESCRIPTION
## Summary
- add harmonic utility functions and aggregation helpers for aspect search results
- expose a FastAPI router for POST /aspects/search with default orb policy and pagination
- wire the router into the app entry point and cover it with an API test using a synthetic ephemeris

## Testing
- pytest -q tests/test_harmonics.py tests/test_scan_timerange.py tests/test_api_aspects_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d81331b9388324af9f7929e138127a