### PR TITLE
Add FastAPI CRUD endpoints for orb policies

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -63,30 +63,19 @@ class ModuleScopeMixin:
 
 
 class OrbPolicy(ModuleScopeMixin, TimestampMixin, Base):
-    """Normalized orb policy entries keyed by profile, body, and aspect."""
+    """Aggregate orb policy definitions exposed via the Plus API."""
 
     __tablename__ = "orb_policies"
     __table_args__ = (
-        UniqueConstraint(
-            "profile_key",
-            "module",
-            "submodule",
-            "channel",
-            "subchannel",
-            "body",
-            "aspect",
-            name="uq_orb_policy_scope",
-        ),
-        Index("ix_orb_policies_profile_module", "profile_key", "module", "channel"),
+        UniqueConstraint("name", name="uq_orb_policy_name"),
     )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    profile_key: Mapped[str] = mapped_column(String(64), nullable=False)
-    body: Mapped[str] = mapped_column(String(64), nullable=False)
-    aspect: Mapped[str] = mapped_column(String(64), nullable=False)
-    orb_degrees: Mapped[float] = mapped_column(Float, nullable=False)
-    source_id: Mapped[str | None] = mapped_column(String(128), nullable=True)
-    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    name: Mapped[str] = mapped_column(String(80), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    per_object: Mapped[dict[str, float]] = mapped_column(JSON, nullable=False, default=dict)
+    per_aspect: Mapped[dict[str, float]] = mapped_column(JSON, nullable=False, default=dict)
+    adaptive_rules: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
 
 
 class SeverityProfile(ModuleScopeMixin, TimestampMixin, Base):
@@ -127,7 +116,7 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
     events: Mapped[list["Event"]] = relationship(back_populates="chart", cascade="all, delete-orphan")
 
 
-class RulesetVersion(ModuleScopeMixin, TimestampMixin, Base):
+class RuleSetVersion(ModuleScopeMixin, TimestampMixin, Base):
     """Versioned rulesets linking scans to reproducible logic bundles."""
 
     __tablename__ = "ruleset_versions"
@@ -187,7 +176,7 @@ class Event(ModuleScopeMixin, TimestampMixin, Base):
     source: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
     chart: Mapped[Chart] = relationship(back_populates="events")
-    ruleset_version: Mapped[RulesetVersion] = relationship(back_populates="events")
+    ruleset_version: Mapped[RuleSetVersion] = relationship(back_populates="events")
     severity_profile: Mapped[SeverityProfile | None] = relationship(back_populates="events")
     export_jobs: Mapped[list["ExportJob"]] = relationship(back_populates="event")
 
@@ -250,7 +239,7 @@ __all__ = [
     "ExportJob",
     "ModuleScopeMixin",
     "OrbPolicy",
-    "RulesetVersion",
+    "RuleSetVersion",
     "SeverityProfile",
     "TimestampMixin",
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,13 @@
+"""FastAPI application exposing AstroEngine Plus CRUD services."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from app.routers import policies_router
+
+app = FastAPI(title="AstroEngine Plus API")
+app.include_router(policies_router)
+
+
+__all__ = ["app"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,5 @@
+"""API routers for AstroEngine Plus services."""
+
+from .policies import router as policies_router
+
+__all__ = ["policies_router"]

--- a/app/routers/policies.py
+++ b/app/routers/policies.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+from fastapi import APIRouter, HTTPException, Query
+from app.db.session import session_scope
+from app.repo.orb_policies import OrbPolicyRepo
+from app.schemas.orb_policy import (
+    OrbPolicyCreate, OrbPolicyUpdate, OrbPolicyOut, OrbPolicyListOut, Paging
+)
+
+router = APIRouter(prefix="", tags=["Plus"])
+repo = OrbPolicyRepo()
+
+
+@router.get("/policies", response_model=OrbPolicyListOut)
+def list_policies(limit: int = Query(50, ge=1, le=500), offset: int = Query(0, ge=0)):
+    with session_scope() as db:
+        items = [
+            OrbPolicyOut(
+                id=p.id,
+                name=p.name,
+                description=p.description,
+                per_object=p.per_object or {},
+                per_aspect=p.per_aspect or {},
+                adaptive_rules=p.adaptive_rules or {},
+            )
+            for p in db.query(repo.model).offset(offset).limit(limit).all()
+        ]
+        total = db.query(repo.model).count()
+    return OrbPolicyListOut(items=items, paging=Paging(limit=limit, offset=offset, total=total))
+
+
+@router.get("/policies/{policy_id}", response_model=OrbPolicyOut)
+def get_policy(policy_id: int):
+    with session_scope() as db:
+        p = repo.get(db, policy_id)
+        if not p:
+            raise HTTPException(status_code=404, detail="policy not found")
+        return OrbPolicyOut(
+            id=p.id, name=p.name, description=p.description,
+            per_object=p.per_object or {}, per_aspect=p.per_aspect or {}, adaptive_rules=p.adaptive_rules or {},
+        )
+
+
+@router.post("/policies", response_model=OrbPolicyOut, status_code=201)
+def create_policy(payload: OrbPolicyCreate):
+    with session_scope() as db:
+        p = repo.create(db, **payload.model_dump())
+        return OrbPolicyOut(
+            id=p.id, name=p.name, description=p.description,
+            per_object=p.per_object or {}, per_aspect=p.per_aspect or {}, adaptive_rules=p.adaptive_rules or {},
+        )
+
+
+@router.put("/policies/{policy_id}", response_model=OrbPolicyOut)
+def update_policy(policy_id: int, payload: OrbPolicyUpdate):
+    with session_scope() as db:
+        p = repo.get(db, policy_id)
+        if not p:
+            raise HTTPException(status_code=404, detail="policy not found")
+        data = {k: v for k, v in payload.model_dump(exclude_unset=True).items()}
+        p = repo.update(db, policy_id, **data)
+        return OrbPolicyOut(
+            id=p.id, name=p.name, description=p.description,
+            per_object=p.per_object or {}, per_aspect=p.per_aspect or {}, adaptive_rules=p.adaptive_rules or {},
+        )
+
+
+@router.delete("/policies/{policy_id}", status_code=204)
+def delete_policy(policy_id: int):
+    with session_scope() as db:
+        p = repo.get(db, policy_id)
+        if not p:
+            return
+        repo.delete(db, policy_id)
+        return

--- a/app/schemas/orb_policy.py
+++ b/app/schemas/orb_policy.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from typing import Any, Dict, Optional
+from pydantic import BaseModel, Field, constr
+
+NameStr = constr(strip_whitespace=True, min_length=1, max_length=80)
+
+
+class OrbPolicyBase(BaseModel):
+    name: NameStr
+    description: Optional[str] = None
+    per_object: Dict[str, float] = Field(default_factory=dict)
+    per_aspect: Dict[str, float] = Field(default_factory=dict)
+    adaptive_rules: Dict[str, Any] = Field(default_factory=dict)
+
+
+class OrbPolicyCreate(OrbPolicyBase):
+    pass
+
+
+class OrbPolicyUpdate(BaseModel):
+    description: Optional[str] = None
+    per_object: Optional[Dict[str, float]] = None
+    per_aspect: Optional[Dict[str, float]] = None
+    adaptive_rules: Optional[Dict[str, Any]] = None
+
+
+class OrbPolicyOut(OrbPolicyBase):
+    id: int
+
+
+class Paging(BaseModel):
+    limit: int
+    offset: int
+    total: int
+
+
+class OrbPolicyListOut(BaseModel):
+    items: list[OrbPolicyOut]
+    paging: Paging

--- a/migrations/versions/20241006_0001_plus_core_models.py
+++ b/migrations/versions/20241006_0001_plus_core_models.py
@@ -17,16 +17,15 @@ def upgrade() -> None:
     op.create_table(
         "orb_policies",
         sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
-        sa.Column("profile_key", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=80), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("per_object", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("per_aspect", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("adaptive_rules", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
         sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'plus'")),
         sa.Column("submodule", sa.String(length=64), nullable=True),
         sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'transits'")),
         sa.Column("subchannel", sa.String(length=64), nullable=True),
-        sa.Column("body", sa.String(length=64), nullable=False),
-        sa.Column("aspect", sa.String(length=64), nullable=False),
-        sa.Column("orb_degrees", sa.Float(), nullable=False),
-        sa.Column("source_id", sa.String(length=128), nullable=True),
-        sa.Column("notes", sa.Text(), nullable=True),
         sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
         sa.Column(
             "updated_at",
@@ -35,21 +34,12 @@ def upgrade() -> None:
             server_onupdate=timestamp_default,
             nullable=False,
         ),
-        sa.UniqueConstraint(
-            "profile_key",
-            "module",
-            "submodule",
-            "channel",
-            "subchannel",
-            "body",
-            "aspect",
-            name="uq_orb_policy_scope",
-        ),
+        sa.UniqueConstraint("name", name="uq_orb_policy_name"),
     )
     op.create_index(
-        "ix_orb_policies_profile_module",
+        "ix_orb_policies_module_channel",
         "orb_policies",
-        ["profile_key", "module", "channel"],
+        ["module", "channel"],
     )
 
     op.create_table(
@@ -262,5 +252,5 @@ def downgrade() -> None:
     op.drop_index("ix_severity_profiles_module_channel", table_name="severity_profiles")
     op.drop_table("severity_profiles")
 
-    op.drop_index("ix_orb_policies_profile_module", table_name="orb_policies")
+    op.drop_index("ix_orb_policies_module_channel", table_name="orb_policies")
     op.drop_table("orb_policies")

--- a/tests/test_api_policies.py
+++ b/tests/test_api_policies.py
@@ -1,0 +1,50 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.policies import router as policies_router
+
+
+def build_app():
+    app = FastAPI()
+    app.include_router(policies_router)
+    return app
+
+
+def test_policy_crud_cycle(tmp_path, monkeypatch):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from app.db.base import Base
+    from app.db import models  # ensure models imported
+    from app.db import session as dbsession
+
+    test_db = f"sqlite:///{tmp_path}/test.db"
+    engine = create_engine(test_db, future=True)
+    Base.metadata.create_all(engine)
+    dbsession.engine = engine
+    dbsession.SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+
+    app = build_app()
+    client = TestClient(app)
+
+    payload = {
+        "name": "classic",
+        "description": "Default classical orbs",
+        "per_aspect": {"sextile": 3.0, "square": 6.0},
+        "adaptive_rules": {"luminaries_factor": 0.9},
+    }
+    r = client.post("/policies", json=payload)
+    assert r.status_code == 201
+    pid = r.json()["id"]
+
+    r = client.get(f"/policies/{pid}")
+    assert r.status_code == 200
+    assert r.json()["name"] == "classic"
+
+    r = client.put(f"/policies/{pid}", json={"description": "Updated"})
+    assert r.status_code == 200 and r.json()["description"] == "Updated"
+
+    r = client.get("/policies?limit=10&offset=0")
+    assert r.status_code == 200 and r.json()["paging"]["total"] >= 1
+
+    r = client.delete(f"/policies/{pid}")
+    assert r.status_code == 204


### PR DESCRIPTION
## Summary
- add orb policy schemas and a FastAPI router that exposes CRUD endpoints for policies
- update the SQLAlchemy model and Alembic migration to match the aggregated orb policy shape
- wire the router into a new FastAPI application entrypoint and cover the CRUD flow with tests

## Testing
- pytest -q tests/test_api_policies.py

------
https://chatgpt.com/codex/tasks/task_e_68d814b381c483248d33afe98961cf27