### PR TITLE
Add TTL caching for ephemeris provider

### DIFF
--- a/app/routers/aspects.py
+++ b/app/routers/aspects.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
@@ -15,6 +16,7 @@ from app.schemas.aspects import (
     Paging,
 )
 from astroengine.core.aspects_plus.aggregate import day_bins, paginate, rank_hits
+from astroengine.core.aspects_plus.provider_wrappers import cached_position_provider
 from astroengine.core.aspects_plus.scan import TimeWindow, scan_time_range
 
 try:  # Optional repositories for policy lookup
@@ -30,15 +32,24 @@ router = APIRouter(prefix="", tags=["Plus"])
 # Position provider injection
 # -----------------------------------------------------------------------------
 position_provider = None  # type: ignore
+_cached: Any = None
 
 
 def _get_provider():
-    global position_provider
+    global position_provider, _cached
     if position_provider is None:
         def _stub(_ts: datetime):
             raise RuntimeError("position_provider not configured")
         return _stub
-    return position_provider
+    if _cached is None:
+        res_min = int(os.getenv("ASTRO_CACHE_RES_MIN", "5"))
+        ttl_sec = float(os.getenv("ASTRO_CACHE_TTL_SEC", "600"))
+        _cached = cached_position_provider(
+            position_provider,
+            resolution_minutes=res_min,
+            ttl_seconds=ttl_sec,
+        )
+    return _cached
 
 
 # -----------------------------------------------------------------------------

--- a/astroengine/core/aspects_plus/provider_wrappers.py
+++ b/astroengine/core/aspects_plus/provider_wrappers.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict
+
+from astroengine.core.common.cache import TTLCache
+
+PositionProvider = Callable[[datetime], Dict[str, float]]
+
+
+def _bucket_ts(ts: datetime, resolution_minutes: int) -> datetime:
+    ts = ts.astimezone(timezone.utc)
+    minutes = (ts.minute // resolution_minutes) * resolution_minutes
+    return ts.replace(minute=0, second=0, microsecond=0) + timedelta(minutes=minutes)
+
+
+def cached_position_provider(
+    provider: PositionProvider,
+    resolution_minutes: int = 5,
+    ttl_seconds: float = 600.0,
+    maxsize: int = 4096,
+) -> PositionProvider:
+    """Wrap a position provider with bucketed timestamp caching.
+
+    - Buckets timestamps to `resolution_minutes` to increase hit rate.
+    - Caches the full positions mapping for that bucket.
+    """
+    cache: TTLCache[tuple, Dict[str, float]] = TTLCache(maxsize=maxsize)
+
+    def inner(ts: datetime) -> Dict[str, float]:
+        bucket = _bucket_ts(ts, resolution_minutes)
+        key = (bucket.year, bucket.month, bucket.day, bucket.hour, bucket.minute)
+        val = cache.get(key)
+        if val is not None:
+            return val
+        res = provider(ts)
+        cache.set(key, res, ttl_seconds)
+        return res
+
+    # expose cache for testing
+    inner._cache = cache  # type: ignore[attr-defined]
+    inner._resolution_minutes = resolution_minutes  # type: ignore[attr-defined]
+    return inner

--- a/astroengine/core/common/__init__.py
+++ b/astroengine/core/common/__init__.py
@@ -1,0 +1,5 @@
+"""Common utilities shared across AstroEngine core modules."""
+
+from .cache import TTLCache, ttl_cache  # noqa: F401
+
+__all__ = ["TTLCache", "ttl_cache"]

--- a/astroengine/core/common/cache.py
+++ b/astroengine/core/common/cache.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Generic, Hashable, Optional, TypeVar
+
+K = TypeVar("K", bound=Hashable)
+V = TypeVar("V")
+
+
+@dataclass
+class _Entry(Generic[V]):
+    value: V
+    expires_at: float
+
+
+class TTLCache(Generic[K, V]):
+    def __init__(self, maxsize: int = 2048):
+        self.maxsize = maxsize
+        self._lock = threading.Lock()
+        self._data: Dict[K, _Entry[V]] = {}
+
+    def get(self, key: K) -> Optional[V]:
+        now = time.time()
+        with self._lock:
+            ent = self._data.get(key)
+            if not ent:
+                return None
+            if ent.expires_at < now:
+                # expired
+                self._data.pop(key, None)
+                return None
+            return ent.value
+
+    def set(self, key: K, value: V, ttl_seconds: float) -> None:
+        with self._lock:
+            if len(self._data) >= self.maxsize:
+                # naive eviction: drop an arbitrary item (FIFO/LRU not needed for MVP)
+                self._data.pop(next(iter(self._data)))
+            self._data[key] = _Entry(value=value, expires_at=time.time() + float(ttl_seconds))
+
+    def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+
+def ttl_cache(ttl_seconds: float, key_fn: Optional[Callable[..., Hashable]] = None, maxsize: int = 2048):
+    """Decorator for simple function result caching with TTL.
+    key_fn maps args/kwargs → hashable key. If None, uses (args, frozenset(kwargs.items())).
+    """
+    cache: TTLCache[Hashable, Any] = TTLCache(maxsize=maxsize)
+
+    def _default_key_fn(*args, **kwargs):
+        return (args, frozenset(kwargs.items()))
+
+    def decorator(fn: Callable[..., V]):
+        def wrapper(*args, **kwargs):
+            k = (key_fn or _default_key_fn)(*args, **kwargs)
+            v = cache.get(k)
+            if v is not None:
+                return v
+            res = fn(*args, **kwargs)
+            cache.set(k, res, ttl_seconds)
+            return res
+
+        wrapper._ttl_cache = cache  # expose for tests
+        return wrapper
+
+    return decorator

--- a/tests/test_cache_ttl.py
+++ b/tests/test_cache_ttl.py
@@ -1,0 +1,27 @@
+import time
+
+from astroengine.core.common.cache import TTLCache, ttl_cache
+
+
+def test_ttlcache_basic_set_get_expire():
+    c = TTLCache(maxsize=4)
+    c.set("a", 1, ttl_seconds=0.2)
+    assert c.get("a") == 1
+    time.sleep(0.25)
+    assert c.get("a") is None
+
+
+def test_ttl_cache_decorator():
+    calls = {"n": 0}
+
+    @ttl_cache(0.5)
+    def f(x):
+        calls["n"] += 1
+        return x * 2
+
+    assert f(2) == 4
+    assert f(2) == 4
+    assert calls["n"] == 1  # cached
+    time.sleep(0.6)
+    assert f(2) == 4
+    assert calls["n"] == 2  # expired

--- a/tests/test_cached_provider.py
+++ b/tests/test_cached_provider.py
@@ -1,0 +1,24 @@
+from datetime import datetime, timedelta, timezone
+
+from astroengine.core.aspects_plus.provider_wrappers import cached_position_provider
+
+
+def test_cached_provider_buckets_and_caches():
+    calls = {"n": 0}
+
+    def provider(ts):
+        calls["n"] += 1
+        return {"Sun": 0.0, "Moon": 0.0}
+
+    cached = cached_position_provider(provider, resolution_minutes=5, ttl_seconds=60)
+
+    t0 = datetime(2025, 1, 1, 12, 3, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(minutes=1)  # same 5-min bucket
+    t2 = t0 + timedelta(minutes=7)  # next bucket
+
+    cached(t0)
+    cached(t1)
+    cached(t2)
+
+    # provider should have been called twice (two buckets)
+    assert calls["n"] == 2


### PR DESCRIPTION
## Summary
- add a reusable TTL cache utility and decorator in the core package
- wrap position providers with a bucketed caching helper to reduce duplicate ephemeris calls
- enable caching in the aspects API router and cover the new behavior with unit tests

## Testing
- pytest -q tests/test_cache_ttl.py tests/test_cached_provider.py

------
https://chatgpt.com/codex/tasks/task_e_68d8188beff083248121de4b7a6feda0