### PR TITLE
Restore FastAPI dependencies and aspect scanning

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import policies_router
+from app.routers import aspects_router, policies_router, transits_router
 
 app = FastAPI(title="AstroEngine Plus API")
+app.include_router(aspects_router)
+app.include_router(transits_router)
 app.include_router(policies_router)
 
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,6 +1,8 @@
 
 """API routers for AstroEngine Plus services."""
 
+from .aspects import router as aspects_router
 from .policies import router as policies_router
+from .transits import router as transits_router
 
-__all__ = ["policies_router"]
+__all__ = ["aspects_router", "policies_router", "transits_router"]

--- a/app/routers/aspects.py
+++ b/app/routers/aspects.py
@@ -94,6 +94,11 @@ def _resolve_orb_policy(req: AspectSearchRequest) -> Dict[str, Any]:
     "/aspects/search",
     response_model=AspectSearchResponse,
     summary="Search aspects over a time window",
+    description=(
+        "Scans a time range for aspect hits across object pairs with optional harmonics "
+        "and adaptive orb policy."
+    ),
+    operation_id="plus_aspects_search",
 )
 def aspects_search(req: AspectSearchRequest):
     provider = _get_provider()

--- a/app/routers/policies.py
+++ b/app/routers/policies.py
@@ -6,11 +6,17 @@ from app.schemas.orb_policy import (
     OrbPolicyCreate, OrbPolicyUpdate, OrbPolicyOut, OrbPolicyListOut, Paging
 )
 
-router = APIRouter(prefix="", tags=["Plus"])
+router = APIRouter(prefix="", tags=["Plus"], responses={404: {"description": "Not found"}})
 repo = OrbPolicyRepo()
 
 
-@router.get("/policies", response_model=OrbPolicyListOut)
+@router.get(
+    "/policies",
+    response_model=OrbPolicyListOut,
+    summary="List orb policies",
+    description="Return paginated orb policy definitions for Plus modules.",
+    operation_id="plus_list_policies",
+)
 def list_policies(limit: int = Query(50, ge=1, le=500), offset: int = Query(0, ge=0)):
     with session_scope() as db:
         items = [
@@ -28,7 +34,13 @@ def list_policies(limit: int = Query(50, ge=1, le=500), offset: int = Query(0, g
     return OrbPolicyListOut(items=items, paging=Paging(limit=limit, offset=offset, total=total))
 
 
-@router.get("/policies/{policy_id}", response_model=OrbPolicyOut)
+@router.get(
+    "/policies/{policy_id}",
+    response_model=OrbPolicyOut,
+    summary="Get orb policy",
+    description="Fetch a single orb policy by identifier.",
+    operation_id="plus_get_policy",
+)
 def get_policy(policy_id: int):
     with session_scope() as db:
         p = repo.get(db, policy_id)
@@ -40,7 +52,14 @@ def get_policy(policy_id: int):
         )
 
 
-@router.post("/policies", response_model=OrbPolicyOut, status_code=201)
+@router.post(
+    "/policies",
+    response_model=OrbPolicyOut,
+    status_code=201,
+    summary="Create orb policy",
+    description="Persist a new orb policy definition for Plus modules.",
+    operation_id="plus_create_policy",
+)
 def create_policy(payload: OrbPolicyCreate):
     with session_scope() as db:
         p = repo.create(db, **payload.model_dump())
@@ -50,7 +69,13 @@ def create_policy(payload: OrbPolicyCreate):
         )
 
 
-@router.put("/policies/{policy_id}", response_model=OrbPolicyOut)
+@router.put(
+    "/policies/{policy_id}",
+    response_model=OrbPolicyOut,
+    summary="Update orb policy",
+    description="Replace mutable fields of an existing orb policy.",
+    operation_id="plus_update_policy",
+)
 def update_policy(policy_id: int, payload: OrbPolicyUpdate):
     with session_scope() as db:
         p = repo.get(db, policy_id)
@@ -64,7 +89,13 @@ def update_policy(policy_id: int, payload: OrbPolicyUpdate):
         )
 
 
-@router.delete("/policies/{policy_id}", status_code=204)
+@router.delete(
+    "/policies/{policy_id}",
+    status_code=204,
+    summary="Delete orb policy",
+    description="Remove an orb policy. No content is returned on success.",
+    operation_id="plus_delete_policy",
+)
 def delete_policy(policy_id: int):
     with session_scope() as db:
         p = repo.get(db, policy_id)

--- a/app/routers/transits.py
+++ b/app/routers/transits.py
@@ -1,0 +1,159 @@
+"""REST router exposing transit score series aggregation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Iterable, List
+
+from fastapi import APIRouter, HTTPException
+
+from app.routers import aspects as aspects_router
+from app.schemas.aspects import AspectHit, AspectSearchRequest
+from app.schemas.series import (
+    DailyScore,
+    MonthlyScore,
+    ScoreSeriesMeta,
+    ScoreSeriesRequest,
+    ScoreSeriesResponse,
+    ScoreSeriesScan,
+    TimeWindow,
+)
+from astroengine.core.aspects_plus.aggregate import rank_hits
+from astroengine.core.aspects_plus.scan import TimeWindow as ScanTimeWindow, scan_time_range
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+
+def _ensure_provider():
+    try:
+        return aspects_router._get_provider()
+    except AttributeError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=500, detail="position provider unavailable") from exc
+
+
+def _scan_hits(scan: ScoreSeriesScan) -> List[AspectHit]:
+    provider = _ensure_provider()
+    stub_request = AspectSearchRequest(
+        objects=scan.objects,
+        aspects=scan.aspects,
+        harmonics=scan.harmonics,
+        window=scan.window,
+        pairs=scan.pairs,
+        orb_policy_id=scan.orb_policy_id,
+        orb_policy_inline=scan.orb_policy_inline,
+        step_minutes=scan.step_minutes,
+        limit=5000,
+        offset=0,
+        order_by="time",
+    )
+    policy = aspects_router._resolve_orb_policy(stub_request)
+
+    start = scan.window.start.astimezone(timezone.utc)
+    end = scan.window.end.astimezone(timezone.utc)
+    scan_window = ScanTimeWindow(start=start, end=end)
+
+    raw_hits = scan_time_range(
+        objects=scan.objects,
+        window=scan_window,
+        position_provider=provider,
+        aspects=scan.aspects,
+        harmonics=scan.harmonics or [],
+        orb_policy=policy,
+        pairs=scan.pairs,
+        step_minutes=scan.step_minutes,
+    )
+    ranked = rank_hits(raw_hits, profile=None, order_by="time")
+    return [
+        AspectHit(
+            a=item["a"],
+            b=item["b"],
+            aspect=item["aspect"],
+            harmonic=item.get("harmonic"),
+            exact_time=item["exact_time"],
+            orb=float(item["orb"]),
+            orb_limit=float(item["orb_limit"]),
+            severity=item.get("severity"),
+            meta=item.get("meta", {}),
+        )
+        for item in ranked
+    ]
+
+
+def _aggregate_daily(hits: Iterable[AspectHit]) -> List[DailyScore]:
+    buckets: Dict[datetime, List[float]] = defaultdict(list)
+    for hit in hits:
+        ts = hit.exact_time
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+        else:
+            ts = ts.astimezone(timezone.utc)
+        if hit.severity is not None:
+            buckets[datetime(ts.year, ts.month, ts.day, tzinfo=timezone.utc)].append(float(hit.severity))
+    daily: List[DailyScore] = []
+    for key in sorted(buckets):
+        scores = buckets[key]
+        avg = sum(scores) / len(scores) if scores else None
+        daily.append(DailyScore(date=key.date(), score=avg))
+    return daily
+
+
+def _aggregate_monthly(daily: Iterable[DailyScore]) -> List[MonthlyScore]:
+    buckets: Dict[str, List[float]] = defaultdict(list)
+    for entry in daily:
+        if entry.score is None:
+            continue
+        key = entry.date.strftime("%Y-%m")
+        buckets[key].append(float(entry.score))
+    monthly: List[MonthlyScore] = []
+    for key in sorted(buckets):
+        scores = buckets[key]
+        avg = sum(scores) / len(scores) if scores else None
+        monthly.append(MonthlyScore(month=key, score=avg))
+    return monthly
+
+
+def _infer_window(request: ScoreSeriesRequest, hits: List[AspectHit]) -> TimeWindow | None:
+    if request.scan is not None:
+        return request.scan.window
+    times = [hit.exact_time for hit in hits if isinstance(hit.exact_time, datetime)]
+    if not times:
+        return None
+    start = min(times)
+    end = max(times)
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    else:
+        start = start.astimezone(timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    else:
+        end = end.astimezone(timezone.utc)
+    if end <= start:
+        end = start + timedelta(minutes=1)
+    return TimeWindow(start=start, end=end)
+
+
+@router.post(
+    "/transits/score-series",
+    response_model=ScoreSeriesResponse,
+    summary="Daily & monthly composite severity",
+    description="Aggregate severity by UTC day and month from either a fresh scan or a provided list of hits.",
+    operation_id="plus_score_series",
+)
+def score_series(request: ScoreSeriesRequest) -> ScoreSeriesResponse:
+    if request.hits is not None:
+        hits = request.hits
+    elif request.scan is not None:
+        hits = _scan_hits(request.scan)
+    else:  # pragma: no cover - guarded by model validator
+        raise HTTPException(status_code=400, detail="Either scan or hits must be provided")
+
+    daily = _aggregate_daily(hits)
+    monthly = _aggregate_monthly(daily)
+    window = _infer_window(request, hits)
+    meta = ScoreSeriesMeta(count_hits=len(hits), window=window)
+    return ScoreSeriesResponse(daily=daily, monthly=monthly, meta=meta)
+
+
+__all__ = ["router", "score_series"]

--- a/app/schemas/aspects.py
+++ b/app/schemas/aspects.py
@@ -54,12 +54,14 @@ class AspectSearchRequest(BaseModel):
                 "objects": ["Sun", "Moon", "Mars", "Venus"],
                 "aspects": ["sextile", "trine", "square"],
                 "harmonics": [5, 7, 13],
-                "window": {"start": "2025-01-01T00:00:00Z", "end": "2025-04-01T00:00:00Z"},
+                "window": {"start": "2025-01-01T00:00:00Z", "end": "2025-03-01T00:00:00Z"},
                 "pairs": [["Mars", "Venus"]],
-                "orb_policy_id": 1,
-                "step_minutes": 30,
+                "step_minutes": 60,
+                "order_by": "time",
                 "limit": 200,
-                "order_by": "severity",
+                "orb_policy_inline": {
+                    "per_aspect": {"sextile": 3.0, "square": 6.0, "trine": 6.0}
+                },
             }
         }
     )
@@ -98,12 +100,11 @@ class AspectSearchResponse(BaseModel):
                     {
                         "a": "Mars", "b": "Venus", "aspect": "sextile", "harmonic": 5,
                         "exact_time": "2025-02-14T08:12:00Z", "orb": 0.12, "orb_limit": 3.0,
-                        "severity": 0.66, "meta": {"step": 30}
+                        "severity": 0.66
                     }
                 ],
                 "bins": [
-                    {"date": "2025-02-14", "count": 3, "score": 0.71},
-                    {"date": "2025-02-15", "count": 1, "score": 0.40}
+                    {"date": "2025-02-14", "count": 3, "score": 0.71}
                 ],
                 "paging": {"limit": 200, "offset": 0, "total": 137}
             }

--- a/app/schemas/orb_policy.py
+++ b/app/schemas/orb_policy.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 from typing import Any, Dict, Optional
-from pydantic import BaseModel, Field, constr
+from pydantic import BaseModel, Field, ConfigDict, constr
 
 NameStr = constr(strip_whitespace=True, min_length=1, max_length=80)
 
@@ -14,7 +14,22 @@ class OrbPolicyBase(BaseModel):
 
 
 class OrbPolicyCreate(OrbPolicyBase):
-    pass
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "name": "classic",
+                "description": "Default classical orbs",
+                "per_object": {"Sun": 8.0, "Moon": 6.0},
+                "per_aspect": {
+                    "sextile": 3.0,
+                    "square": 6.0,
+                    "trine": 6.0,
+                    "conjunction": 8.0,
+                },
+                "adaptive_rules": {"luminaries_factor": 0.9, "outers_factor": 1.1},
+            }
+        }
+    )
 
 
 class OrbPolicyUpdate(BaseModel):
@@ -27,6 +42,19 @@ class OrbPolicyUpdate(BaseModel):
 class OrbPolicyOut(OrbPolicyBase):
     id: int
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "id": 1,
+                "name": "classic",
+                "description": "Default classical orbs",
+                "per_object": {"Sun": 8.0, "Moon": 6.0},
+                "per_aspect": {"sextile": 3.0, "square": 6.0},
+                "adaptive_rules": {"luminaries_factor": 0.9},
+            }
+        }
+    )
+
 
 class Paging(BaseModel):
     limit: int
@@ -37,3 +65,21 @@ class Paging(BaseModel):
 class OrbPolicyListOut(BaseModel):
     items: list[OrbPolicyOut]
     paging: Paging
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "items": [
+                    {
+                        "id": 1,
+                        "name": "classic",
+                        "description": "Default classical orbs",
+                        "per_object": {"Sun": 8.0, "Moon": 6.0},
+                        "per_aspect": {"sextile": 3.0, "square": 6.0},
+                        "adaptive_rules": {"luminaries_factor": 0.9},
+                    }
+                ],
+                "paging": {"limit": 50, "offset": 0, "total": 1},
+            }
+        }
+    )

--- a/app/schemas/series.py
+++ b/app/schemas/series.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, conint, constr, model_validator
+
+from .aspects import AspectHit, AspectName, OrbPolicyInline, TimeWindow, StrName
+
+
+class ScoreSeriesScan(BaseModel):
+    objects: List[StrName] = Field(..., description="Objects to include when scanning")
+    aspects: List[AspectName] = Field(..., description="Aspect families to score")
+    harmonics: List[conint(ge=1, le=64)] = Field(
+        default_factory=list,
+        description="Optional harmonics to include while scanning",
+    )
+    window: TimeWindow
+    pairs: Optional[List[Tuple[StrName, StrName]]] = Field(
+        default=None,
+        description="Restrict scan to these pairs when provided",
+    )
+    orb_policy_id: Optional[int] = Field(default=None)
+    orb_policy_inline: Optional[OrbPolicyInline] = Field(default=None)
+    step_minutes: int = Field(60, ge=1, le=720, description="Sampling step before refinements")
+
+
+class ScoreSeriesRequest(BaseModel):
+    scan: Optional[ScoreSeriesScan] = Field(
+        default=None, description="Scan instructions to produce hits before scoring"
+    )
+    hits: Optional[List[AspectHit]] = Field(
+        default=None, description="Precomputed aspect hits to aggregate"
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_mode(self) -> "ScoreSeriesRequest":
+        if (self.scan is None) == (self.hits is None):
+            raise ValueError("Provide either scan or hits")
+        return self
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "summary": "Scan window and aggregate",
+                    "value": {
+                        "scan": {
+                            "objects": ["Mars", "Venus"],
+                            "aspects": ["sextile"],
+                            "window": {
+                                "start": "2025-01-01T00:00:00Z",
+                                "end": "2025-02-01T00:00:00Z",
+                            },
+                            "step_minutes": 60,
+                            "orb_policy_inline": {"per_aspect": {"sextile": 3.0}},
+                        }
+                    },
+                },
+                {
+                    "summary": "Aggregate provided hits",
+                    "value": {
+                        "hits": [
+                            {
+                                "a": "Mars",
+                                "b": "Venus",
+                                "aspect": "sextile",
+                                "exact_time": "2025-01-15T12:00:00Z",
+                                "orb": 0.2,
+                                "orb_limit": 3.0,
+                                "severity": 0.6,
+                            }
+                        ]
+                    },
+                },
+            ]
+        }
+    )
+
+
+class DailyScore(BaseModel):
+    date: date
+    score: Optional[float] = Field(default=None, ge=0)
+
+
+class MonthlyScore(BaseModel):
+    month: constr(strip_whitespace=True, min_length=7, max_length=7)
+    score: Optional[float] = Field(default=None, ge=0)
+
+
+class ScoreSeriesMeta(BaseModel):
+    count_hits: int = Field(..., ge=0)
+    window: Optional[TimeWindow] = None
+
+
+class ScoreSeriesResponse(BaseModel):
+    daily: List[DailyScore] = Field(default_factory=list)
+    monthly: List[MonthlyScore] = Field(default_factory=list)
+    meta: ScoreSeriesMeta
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "daily": [{"date": "2025-01-15", "score": 0.62}],
+                "monthly": [{"month": "2025-01", "score": 0.55}],
+                "meta": {
+                    "count_hits": 42,
+                    "window": {
+                        "start": "2025-01-01T00:00:00Z",
+                        "end": "2025-02-01T00:00:00Z",
+                    },
+                },
+            }
+        }
+    )
+
+
+__all__ = [
+    "DailyScore",
+    "MonthlyScore",
+    "ScoreSeriesMeta",
+    "ScoreSeriesRequest",
+    "ScoreSeriesResponse",
+    "ScoreSeriesScan",
+]

--- a/astroengine/api/routers/plus.py
+++ b/astroengine/api/routers/plus.py
@@ -7,7 +7,11 @@ from fastapi import APIRouter
 router = APIRouter(prefix="", tags=["Plus"])
 
 
-@router.get("/health/plus", summary="Health check for Plus modules")
+@router.get(
+    "/health/plus",
+    summary="Health check for Plus modules",
+    description="Returns {status:'ok'} if Plus routes are wired.",
+)
 def health_plus() -> dict[str, str]:
     """Simple readiness probe for Plus features."""
     return {"status": "ok"}

--- a/astroengine/core/aspects_plus/scan.py
+++ b/astroengine/core/aspects_plus/scan.py
@@ -1,28 +1,47 @@
 
-"""Aspect scan dataclasses for search/ranking pipelines."""
+"""Aspect scan dataclasses and helpers used by Plus endpoints."""
 
 
 from __future__ import annotations
 
 from dataclasses import dataclass
 
-from datetime import datetime
-from typing import Any, Mapping, MutableMapping, Optional
+from datetime import datetime, timedelta
+from itertools import combinations
+from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+from .harmonics import BASE_ASPECTS, combined_angles
+
+
+PositionProvider = Callable[[datetime], Mapping[str, float]]
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    """Closed interval used to scan for aspect hits."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:  # pragma: no cover - pydantic already enforces in API
+        if self.end <= self.start:
+            raise ValueError("end must be after start")
+
+    def clamp(self, ts: datetime) -> bool:
+        """Return ``True`` if ``ts`` lies inside the window (inclusive)."""
+
+        return self.start <= ts <= self.end
+
+    @property
+    def span(self) -> timedelta:
+        """Duration of the window."""
+
+        return self.end - self.start
 
 
 @dataclass(slots=True)
 class Hit:
-    """Raw aspect hit emitted by scanning routines.
-
-    Attributes:
-        a: Primary actor identifier (planet/body name).
-        b: Secondary actor identifier.
-        aspect_angle: Exact aspect angle in degrees.
-        exact_time: Timestamp of the aspect hit (timezone-aware preferred).
-        orb: Absolute orb distance in degrees.
-        orb_limit: Maximum orb allowed for this aspect pairing.
-        meta: Optional mutable mapping for downstream annotations.
-    """
+    """Raw aspect hit emitted by scanning routines."""
 
     a: str
     b: str
@@ -33,8 +52,6 @@ class Hit:
     meta: Optional[MutableMapping[str, Any]] = None
 
     def as_mapping(self) -> Mapping[str, Any]:
-        """Return a shallow mapping representation of this hit."""
-
         base = {
             "a": self.a,
             "b": self.b,
@@ -46,4 +63,199 @@ class Hit:
         if self.meta:
             base.update(self.meta)
         return base
+
+
+def _normalize_angle(angle: float) -> float:
+    return float(angle) % 360.0
+
+
+def _signed_sep(delta: float, target: float) -> float:
+    """Return signed difference between ``delta`` and ``target`` in degrees."""
+
+    return ((_normalize_angle(delta) - target + 180.0) % 360.0) - 180.0
+
+
+def _pair_delta(provider: PositionProvider, ts: datetime, primary: str, secondary: str) -> float:
+    positions = provider(ts)
+    if primary not in positions or secondary not in positions:
+        missing = [name for name in (primary, secondary) if name not in positions]
+        raise KeyError(f"position provider missing objects: {missing!r}")
+    return _normalize_angle(positions[primary] - positions[secondary])
+
+
+def _aspect_name_for_angle(angle: float) -> Optional[str]:
+    for name, base_angle in BASE_ASPECTS.items():
+        if abs(base_angle - angle) <= 1e-6:
+            return name
+    return None
+
+
+def _orb_limit(
+    angle: float,
+    orb_policy: Mapping[str, Any] | None,
+    primary: str,
+    secondary: str,
+) -> float:
+    if orb_policy is None:
+        return 3.0
+    limit: Optional[float] = None
+    per_aspect = orb_policy.get("per_aspect") if isinstance(orb_policy, Mapping) else None
+    name = _aspect_name_for_angle(angle)
+    if isinstance(per_aspect, Mapping) and name and name in per_aspect:
+        try:
+            limit = float(per_aspect[name])
+        except (TypeError, ValueError):  # pragma: no cover - defensive
+            limit = None
+    if limit is None:
+        per_object = orb_policy.get("per_object") if isinstance(orb_policy, Mapping) else None
+        object_limits: List[float] = []
+        if isinstance(per_object, Mapping):
+            for key in (primary, secondary):
+                if key in per_object:
+                    try:
+                        object_limits.append(float(per_object[key]))
+                    except (TypeError, ValueError):
+                        continue
+        if object_limits:
+            limit = max(object_limits)
+    return float(limit if limit is not None else 3.0)
+
+
+def _refine_hit(
+    provider: PositionProvider,
+    primary: str,
+    secondary: str,
+    angle: float,
+    t0: datetime,
+    t1: datetime,
+    d0: float,
+    d1: float,
+) -> Tuple[datetime, float]:
+    a, b = t0, t1
+    fa, fb = d0, d1
+    for _ in range(24):
+        mid = a + (b - a) / 2
+        fm = _signed_sep(_pair_delta(provider, mid, primary, secondary), angle)
+        if abs(fm) <= 1e-5 or (b - a).total_seconds() <= 30:
+            return mid, fm
+        if fa == 0.0:
+            return a, fa
+        if fb == 0.0:
+            return b, fb
+        if fa * fm <= 0:
+            b, fb = mid, fm
+        else:
+            a, fa = mid, fm
+    return mid, fm
+
+
+def scan_pair_time_range(
+    primary: str,
+    secondary: str,
+    window: TimeWindow,
+    position_provider: PositionProvider,
+    aspect_angles: Sequence[float],
+    orb_policy: Mapping[str, Any] | None = None,
+    step_minutes: int = 60,
+) -> List[Hit]:
+    """Scan ``primary``/``secondary`` pair for aspect hits within ``window``."""
+
+    if window.end <= window.start:
+        return []
+    if not aspect_angles:
+        return []
+
+    step = timedelta(minutes=max(1, int(step_minutes)))
+    aspect_angles = sorted({round(float(a), 6) for a in aspect_angles})
+    previous: dict[float, tuple[Optional[datetime], Optional[float]]] = {
+        angle: (None, None) for angle in aspect_angles
+    }
+    hits: List[Hit] = []
+    recorded: set[tuple[str, str, float, datetime]] = set()
+
+    current = window.start
+    while current <= window.end:
+        delta = _pair_delta(position_provider, current, primary, secondary)
+        for angle in aspect_angles:
+            diff = _signed_sep(delta, angle)
+            prev_time, prev_diff = previous[angle]
+            if prev_time is not None and prev_diff is not None:
+                if prev_diff == 0.0 and abs(diff) <= abs(prev_diff):
+                    continue
+                if prev_diff * diff <= 0 or abs(diff) < 1e-2:
+                    hit_time, hit_diff = _refine_hit(
+                        position_provider, primary, secondary, angle, prev_time, current, prev_diff, diff
+                    )
+                    if window.clamp(hit_time):
+                        limit = _orb_limit(angle, orb_policy, primary, secondary)
+                        if abs(hit_diff) <= limit:
+                            key = (primary, secondary, angle, hit_time.replace(second=0, microsecond=0))
+                            if key not in recorded:
+                                hits.append(
+                                    Hit(
+                                        a=primary,
+                                        b=secondary,
+                                        aspect_angle=angle,
+                                        exact_time=hit_time,
+                                        orb=abs(hit_diff),
+                                        orb_limit=limit,
+                                        meta={"pair": (primary, secondary)},
+                                    )
+                                )
+                                recorded.add(key)
+            previous[angle] = (current, diff)
+        current += step
+
+    hits.sort(key=lambda h: h.exact_time)
+    return hits
+
+
+def scan_time_range(
+    *,
+    objects: Sequence[str],
+    window: TimeWindow,
+    position_provider: PositionProvider,
+    aspects: Iterable[str],
+    harmonics: Iterable[int] | None = None,
+    orb_policy: Mapping[str, Any] | None = None,
+    pairs: Sequence[Tuple[str, str]] | None = None,
+    step_minutes: int = 60,
+) -> List[Hit]:
+    """Scan all requested pairs for aspect hits within ``window``."""
+
+    if not objects:
+        return []
+    aspect_angles = combined_angles(aspects, harmonics or [])
+    if not aspect_angles:
+        return []
+
+    if pairs:
+        pair_list = [(a, b) for a, b in pairs]
+    else:
+        pair_list = list(combinations(objects, 2))
+
+    hits: List[Hit] = []
+    for primary, secondary in pair_list:
+        hits.extend(
+            scan_pair_time_range(
+                primary,
+                secondary,
+                window,
+                position_provider,
+                aspect_angles,
+                orb_policy=orb_policy,
+                step_minutes=step_minutes,
+            )
+        )
+
+    hits.sort(key=lambda h: h.exact_time)
+    return hits
+
+
+__all__ = [
+    "TimeWindow",
+    "Hit",
+    "scan_pair_time_range",
+    "scan_time_range",
+]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,9 @@ ics>=0.7
 # QA / property-based testing (used by tests)
 hypothesis>=6.112
 # Optional groups (comment in as needed):
-# fastapi>=0.115
+fastapi>=0.115
+# Required for FastAPI TestClient
+httpx>=0.27
 # uvicorn[standard]>=0.30
 # matplotlib>=3.8
 # pyproj>=3.6

--- a/tests/test_openapi_examples.py
+++ b/tests/test_openapi_examples.py
@@ -1,0 +1,76 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.aspects import router as aspects_router
+from app.routers.policies import router as policies_router
+from app.routers.transits import router as transits_router
+
+
+def build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(aspects_router)
+    app.include_router(transits_router)
+    app.include_router(policies_router)
+    return app
+
+
+def test_openapi_has_examples():
+    app = build_app()
+    client = TestClient(app)
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+    spec = response.json()
+
+    components = spec["components"]["schemas"]
+
+    aspect_req_example = components["AspectSearchRequest"]["example"]
+    assert aspect_req_example["objects"] == ["Sun", "Moon", "Mars", "Venus"]
+    assert aspect_req_example["window"]["end"] == "2025-03-01T00:00:00Z"
+
+    aspect_resp_example = components["AspectSearchResponse"]["example"]
+    assert aspect_resp_example["hits"][0]["aspect"] == "sextile"
+
+    score_examples_raw = components["ScoreSeriesRequest"].get("examples", {})
+    if isinstance(score_examples_raw, list):
+        scan_example = next(
+            (ex for ex in score_examples_raw if isinstance(ex, dict) and "scan" in ex.get("value", {})),
+            None,
+        )
+        hits_example = next(
+            (ex for ex in score_examples_raw if isinstance(ex, dict) and "hits" in ex.get("value", {})),
+            None,
+        )
+    else:
+        scan_example = score_examples_raw.get("scan") if isinstance(score_examples_raw, dict) else None
+        hits_example = score_examples_raw.get("hits") if isinstance(score_examples_raw, dict) else None
+
+    assert scan_example is not None and hits_example is not None
+    assert scan_example["value"]["scan"]["objects"] == ["Mars", "Venus"]
+    assert hits_example["value"]["hits"][0]["severity"] == 0.6
+
+    score_resp_example = components["ScoreSeriesResponse"]["example"]
+    assert score_resp_example["daily"][0]["score"] == 0.62
+
+    policy_create_example = components["OrbPolicyCreate"]["example"]
+    assert policy_create_example["per_aspect"]["square"] == 6.0
+
+    policy_out_example = components["OrbPolicyOut"]["example"]
+    assert policy_out_example["id"] == 1
+
+    policy_list_example = components["OrbPolicyListOut"]["example"]
+    assert policy_list_example["paging"]["limit"] == 50
+
+    aspects_post = spec["paths"]["/aspects/search"]["post"]
+    assert aspects_post["summary"].lower().startswith("search aspects")
+    assert aspects_post["operationId"] == "plus_aspects_search"
+
+    score_post = spec["paths"]["/transits/score-series"]["post"]
+    assert score_post["summary"].lower().startswith("daily")
+    assert score_post["operationId"] == "plus_score_series"
+
+    policies_get = spec["paths"]["/policies"]["get"]
+    assert policies_get["operationId"] == "plus_list_policies"
+    assert policies_get["summary"].lower().startswith("list orb policies")
+
+    policies_post = spec["paths"]["/policies"]["post"]
+    assert policies_post["operationId"] == "plus_create_policy"


### PR DESCRIPTION
## Summary
- ensure FastAPI and httpx are declared so Plus routers and tests resolve their imports
- implement aspect scanning utilities that drive the Plus search endpoints and expose orb-aware hits
- align schema examples and the OpenAPI regression test with the validated FastAPI schema format

## Testing
- pytest -q tests/test_openapi_examples.py

------
https://chatgpt.com/codex/tasks/task_e_68d81982638483249dab8a598f27b821