### PR TITLE
Add composite and synastry primitives

### DIFF
--- a/astroengine/core/rel_plus/__init__.py
+++ b/astroengine/core/rel_plus/__init__.py
@@ -1,0 +1,12 @@
+"""Relationship-oriented composite and synastry helpers."""
+
+from .composite import circular_midpoint, composite_midpoint_positions, davison_positions
+from .synastry import synastry_grid, synastry_interaspects
+
+__all__ = [
+    "circular_midpoint",
+    "composite_midpoint_positions",
+    "davison_positions",
+    "synastry_interaspects",
+    "synastry_grid",
+]

--- a/astroengine/core/rel_plus/composite.py
+++ b/astroengine/core/rel_plus/composite.py
@@ -1,0 +1,55 @@
+"""Composite and Davison chart utilities."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, Mapping
+
+
+def _norm360(x: float) -> float:
+    """Normalize an angle to the [0°, 360°) range."""
+    v = x % 360.0
+    return v + 360.0 if v < 0.0 else v
+
+
+def _wrap_minus180_to_180(x: float) -> float:
+    """Wrap an angle to the (-180°, 180°] range."""
+    return ((x + 180.0) % 360.0) - 180.0
+
+
+def circular_midpoint(a_deg: float, b_deg: float) -> float:
+    """Return the circular midpoint along the shortest arc between two angles."""
+    a = float(a_deg)
+    b = float(b_deg)
+    d = _wrap_minus180_to_180(b - a)
+    return _norm360(a + d / 2.0)
+
+
+def composite_midpoint_positions(
+    pos_a: Mapping[str, float],
+    pos_b: Mapping[str, float],
+    objects: Iterable[str],
+) -> Dict[str, float]:
+    """Compute midpoints for objects present in both position dictionaries."""
+    out: Dict[str, float] = {}
+    for name in objects:
+        if name in pos_a and name in pos_b:
+            out[name] = circular_midpoint(pos_a[name], pos_b[name])
+    return out
+
+
+PositionProvider = Callable[[datetime], Mapping[str, float]]
+
+
+def davison_positions(
+    objects: Iterable[str],
+    dt_a: datetime,
+    dt_b: datetime,
+    provider: PositionProvider,
+) -> Dict[str, float]:
+    """Return Davison longitudes at the UTC midpoint between two datetimes."""
+    a = dt_a.astimezone(timezone.utc)
+    b = dt_b.astimezone(timezone.utc)
+    mid = a + (b - a) / 2
+    pos = provider(mid)
+    return {name: _norm360(float(pos[name])) for name in objects if name in pos}

--- a/astroengine/core/rel_plus/synastry.py
+++ b/astroengine/core/rel_plus/synastry.py
@@ -1,0 +1,70 @@
+"""Synastry helpers for inter-chart aspect detection."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List, Optional
+
+from astroengine.core.aspects_plus.harmonics import BASE_ASPECTS
+from astroengine.core.aspects_plus.matcher import angular_sep_deg
+from astroengine.core.aspects_plus.orb_policy import orb_limit
+
+EPS = 1e-9
+
+
+def _best_aspect_for_delta(
+    a_name: str,
+    b_name: str,
+    delta: float,
+    aspects: Iterable[str],
+    policy: Dict,
+) -> Optional[dict]:
+    best: Optional[dict] = None
+    for asp in aspects:
+        key = asp.lower()
+        angle = BASE_ASPECTS.get(key)
+        if angle is None:
+            continue
+        orb = abs(delta - angle)
+        limit = orb_limit(a_name, b_name, key, policy)
+        if orb <= limit + EPS:
+            candidate = {
+                "a_obj": a_name,
+                "b_obj": b_name,
+                "aspect": key,
+                "angle": float(angle),
+                "delta": float(delta),
+                "orb": float(orb),
+                "orb_limit": float(limit),
+            }
+            if best is None or candidate["orb"] < best["orb"]:
+                best = candidate
+    return best
+
+
+def synastry_interaspects(
+    pos_a: Dict[str, float],
+    pos_b: Dict[str, float],
+    aspects: Iterable[str],
+    policy: Dict,
+) -> List[Dict]:
+    """Return best inter-aspect matches for each A×B pair within the orb policy."""
+    hits: List[Dict] = []
+    for a_name, a_lon in pos_a.items():
+        for b_name, b_lon in pos_b.items():
+            delta = angular_sep_deg(a_lon, b_lon)
+            match = _best_aspect_for_delta(a_name, b_name, delta, aspects, policy)
+            if match:
+                hits.append(match)
+    hits.sort(key=lambda h: (h["orb"], h["a_obj"], h["b_obj"]))
+    return hits
+
+
+def synastry_grid(hits: List[Dict]) -> Dict[str, Dict[str, int]]:
+    """Build a grid of counts per A-object × B-object using best aspects only."""
+    grid: Dict[str, Dict[str, int]] = {}
+    for hit in hits:
+        a_name = hit["a_obj"]
+        b_name = hit["b_obj"]
+        row = grid.setdefault(a_name, {})
+        row[b_name] = row.get(b_name, 0) + 1
+    return grid

--- a/tests/test_composite_synastry.py
+++ b/tests/test_composite_synastry.py
@@ -1,0 +1,85 @@
+"""Tests for composite, Davison, and synastry helpers."""
+
+from datetime import datetime, timedelta, timezone
+
+from astroengine.core.rel_plus.composite import (
+    circular_midpoint,
+    composite_midpoint_positions,
+    davison_positions,
+)
+from astroengine.core.rel_plus.synastry import synastry_grid, synastry_interaspects
+
+
+class LinearEphemeris:
+    """Simple linear ephemeris for deterministic testing."""
+
+    def __init__(self, t0, base, rates):
+        self.t0 = t0
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            key: (self.base.get(key, 0.0) + self.rates.get(key, 0.0) * dt_days) % 360.0
+            for key in self.base
+        }
+
+
+POLICY = {
+    "per_object": {},
+    "per_aspect": {
+        "sextile": 3.0,
+        "trine": 6.0,
+        "square": 6.0,
+        "conjunction": 8.0,
+    },
+    "adaptive_rules": {},
+}
+
+
+def test_circular_midpoint_wrap():
+    assert abs(circular_midpoint(350.0, 10.0) - 0.0) < 1e-9
+    assert abs(circular_midpoint(10.0, 350.0) - 0.0) < 1e-9
+
+
+def test_composite_midpoint_positions():
+    pos_a = {"Sun": 10.0, "Moon": 200.0}
+    pos_b = {"Sun": 50.0, "Moon": 220.0}
+    out = composite_midpoint_positions(pos_a, pos_b, ["Sun", "Moon", "Mars"])
+    assert abs(out["Sun"] - 30.0) < 1e-9
+    assert abs(out["Moon"] - 210.0) < 1e-9
+
+
+def test_davison_positions_time_midpoint():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(days=10)
+    eph = LinearEphemeris(
+        t0,
+        base={"Sun": 0.0, "Venus": 20.0},
+        rates={"Sun": 1.0, "Venus": 1.2},
+    )
+    pos = davison_positions(["Sun", "Venus"], t0, t1, eph)
+    assert abs(pos["Sun"] - 5.0) < 1e-9
+    assert abs(pos["Venus"] - (20.0 + 6.0)) < 1e-9
+
+
+def test_synastry_interaspects_and_grid():
+    pos_a = {"Mars": 10.0, "Sun": 0.0}
+    pos_b = {"Venus": 70.0, "Moon": 180.0}
+
+    hits = synastry_interaspects(
+        pos_a,
+        pos_b,
+        ["sextile", "trine", "square", "conjunction"],
+        POLICY,
+    )
+    assert any(
+        hit["a_obj"] == "Mars"
+        and hit["b_obj"] == "Venus"
+        and hit["aspect"] == "sextile"
+        for hit in hits
+    )
+
+    grid = synastry_grid(hits)
+    assert grid["Mars"]["Venus"] == 1


### PR DESCRIPTION
## Summary
- add relationship utilities for composite midpoints, Davison midpoint timing, and synastry aspect matching
- expose helpers via rel_plus package for reuse by future API and UI layers
- cover functionality with unit tests verifying wraparound, Davison timing, and synastry grids

## Testing
- pytest -q tests/test_composite_synastry.py

------
https://chatgpt.com/codex/tasks/task_e_68d81d02b9e08324849732031e653e7f