### PR TITLE
Add synastry and composite API endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,12 +5,13 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import aspects_router, policies_router, transits_router
+from app.routers import aspects_router, policies_router, rel_router, transits_router
 
 app = FastAPI(title="AstroEngine Plus API")
 app.include_router(aspects_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
+app.include_router(rel_router)
 
 
 __all__ = ["app"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -3,6 +3,12 @@
 
 from .aspects import router as aspects_router
 from .policies import router as policies_router
+from .rel import router as rel_router
 from .transits import router as transits_router
 
-__all__ = ["aspects_router", "policies_router", "transits_router"]
+__all__ = [
+    "aspects_router",
+    "policies_router",
+    "rel_router",
+    "transits_router",
+]

--- a/app/routers/rel.py
+++ b/app/routers/rel.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+from datetime import timezone
+from importlib import util
+from typing import Any, Dict
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.rel import (
+    SynastryRequest,
+    SynastryResponse,
+    SynastryHit,
+    SynastryGrid,
+    CompositeMidpointRequest,
+    CompositeDavisonRequest,
+    CompositeResponse,
+)
+from core.rel_plus.synastry import synastry_interaspects, synastry_grid
+from core.rel_plus.composite import composite_midpoint_positions, davison_positions
+
+if util.find_spec("app.repo.orb_policies") and util.find_spec("app.db.session"):
+    from app.repo.orb_policies import OrbPolicyRepo  # type: ignore
+    from app.db.session import session_scope  # type: ignore
+else:  # pragma: no cover - optional dependency path
+    OrbPolicyRepo = None  # type: ignore
+    session_scope = None  # type: ignore
+
+from app.routers import aspects as aspects_module
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+DEFAULT_POLICY: Dict[str, Any] = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 4.0,
+        "quincunx": 3.0,
+        "semisquare": 2.0,
+        "sesquisquare": 2.0,
+        "quintile": 2.0,
+        "biquintile": 2.0,
+    },
+    "adaptive_rules": {
+        "luminaries_factor": 0.9,
+        "outers_factor": 1.1,
+        "minor_aspect_factor": 0.9,
+    },
+}
+
+
+def _resolve_orb_policy(req: SynastryRequest) -> Dict[str, Any]:
+    if req.orb_policy_inline is not None:
+        return req.orb_policy_inline.model_dump()
+    if req.orb_policy_id is not None:
+        if OrbPolicyRepo is None or session_scope is None:
+            raise HTTPException(
+                status_code=400,
+                detail="orb_policy_id requires DB; provide orb_policy_inline instead",
+            )
+        with session_scope() as db:
+            rec = OrbPolicyRepo().get(db, req.orb_policy_id)
+            if not rec:
+                raise HTTPException(status_code=404, detail="orb policy not found")
+            return {
+                "per_object": rec.per_object or {},
+                "per_aspect": rec.per_aspect or {},
+                "adaptive_rules": rec.adaptive_rules or {},
+            }
+    return DEFAULT_POLICY
+
+
+@router.post(
+    "/synastry/compute",
+    response_model=SynastryResponse,
+    summary="Compute inter‑aspects between Chart A and B",
+    description=(
+        "Returns best aspect per A×B pair with orb & limits, plus a pair grid of counts."
+    ),
+)
+def synastry_compute(req: SynastryRequest):
+    policy = _resolve_orb_policy(req)
+    hits_list = synastry_interaspects(req.pos_a, req.pos_b, req.aspects, policy)
+    hits = [SynastryHit(**h) for h in hits_list]
+    grid = SynastryGrid(counts=synastry_grid(hits_list))
+    return SynastryResponse(hits=hits, grid=grid)
+
+
+@router.post(
+    "/composites/midpoint",
+    response_model=CompositeResponse,
+    summary="Midpoint Composite positions",
+    description="Circular midpoints of longitudes for the requested objects.",
+)
+def composites_midpoint(req: CompositeMidpointRequest):
+    pos = composite_midpoint_positions(req.pos_a, req.pos_b, req.objects)
+    return CompositeResponse(positions=pos, meta={"method": "midpoint"})
+
+
+@router.post(
+    "/composites/davison",
+    response_model=CompositeResponse,
+    summary="Davison Composite positions (time midpoint)",
+    description=(
+        "Computes body longitudes at the UTC time midpoint between two datetimes using the configured ephemeris provider."
+    ),
+)
+def composites_davison(req: CompositeDavisonRequest):
+    provider = aspects_module._get_provider()
+    pos = davison_positions(req.objects, req.dt_a, req.dt_b, provider)
+    mid_a = req.dt_a.astimezone(timezone.utc)
+    mid_b = req.dt_b.astimezone(timezone.utc)
+    midpoint = mid_a + (mid_b - mid_a) / 2
+    return CompositeResponse(
+        positions=pos,
+        meta={"method": "davison", "midpoint_time": midpoint.isoformat()},
+    )

--- a/app/schemas/rel.py
+++ b/app/schemas/rel.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, ConfigDict
+
+from app.schemas.aspects import AspectName, OrbPolicyInline
+
+
+class SynastryRequest(BaseModel):
+    pos_a: Dict[str, float] = Field(..., description="Chart A longitudes (deg)")
+    pos_b: Dict[str, float] = Field(..., description="Chart B longitudes (deg)")
+    aspects: List[AspectName] = Field(..., description="Aspect names to evaluate")
+
+    orb_policy_id: Optional[int] = None
+    orb_policy_inline: Optional[OrbPolicyInline] = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "pos_a": {"Mars": 10.0, "Sun": 0.0},
+                "pos_b": {"Venus": 70.0, "Moon": 180.0},
+                "aspects": ["sextile", "trine", "square", "conjunction"],
+                "orb_policy_inline": {
+                    "per_aspect": {"sextile": 3.0, "square": 6.0}
+                },
+            }
+        }
+    )
+
+
+class SynastryHit(BaseModel):
+    a_obj: str
+    b_obj: str
+    aspect: AspectName
+    angle: float
+    delta: float
+    orb: float
+    orb_limit: float
+
+
+class SynastryGrid(BaseModel):
+    counts: Dict[str, Dict[str, int]]
+
+
+class SynastryResponse(BaseModel):
+    hits: List[SynastryHit]
+    grid: SynastryGrid
+
+
+class CompositeMidpointRequest(BaseModel):
+    pos_a: Dict[str, float]
+    pos_b: Dict[str, float]
+    objects: List[str]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "pos_a": {"Sun": 10.0, "Moon": 200.0},
+                "pos_b": {"Sun": 50.0, "Moon": 220.0},
+                "objects": ["Sun", "Moon"],
+            }
+        }
+    )
+
+
+class CompositeDavisonRequest(BaseModel):
+    objects: List[str]
+    dt_a: datetime
+    dt_b: datetime
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "objects": ["Sun", "Venus"],
+                "dt_a": "2025-01-01T00:00:00Z",
+                "dt_b": "2025-01-11T00:00:00Z",
+            }
+        }
+    )
+
+
+class CompositeResponse(BaseModel):
+    positions: Dict[str, float]
+    meta: Dict[str, Any] = Field(default_factory=dict)

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,3 @@
+"""AstroEngine Plus compatibility shims for lightweight API services."""
+
+__all__ = ["rel_plus"]

--- a/core/rel_plus/__init__.py
+++ b/core/rel_plus/__init__.py
@@ -1,0 +1,11 @@
+"""Synastry and composite helpers for the lightweight Plus API layer."""
+
+from .synastry import synastry_interaspects, synastry_grid
+from .composite import composite_midpoint_positions, davison_positions
+
+__all__ = [
+    "synastry_interaspects",
+    "synastry_grid",
+    "composite_midpoint_positions",
+    "davison_positions",
+]

--- a/core/rel_plus/composite.py
+++ b/core/rel_plus/composite.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable
+
+import math
+
+Positions = Dict[str, float]
+PositionProvider = Callable[[datetime], Dict[str, float]]
+
+
+def _norm360(value: float) -> float:
+    v = float(value) % 360.0
+    return v + 360.0 if v < 0 else v
+
+
+def _circular_midpoint(a: float, b: float) -> float:
+    a_n = _norm360(a)
+    b_n = _norm360(b)
+    ax = math.cos(math.radians(a_n))
+    ay = math.sin(math.radians(a_n))
+    bx = math.cos(math.radians(b_n))
+    by = math.sin(math.radians(b_n))
+    x = ax + bx
+    y = ay + by
+    if abs(x) < 1e-9 and abs(y) < 1e-9:
+        return (a_n + b_n) / 2.0 % 360.0
+    ang = math.degrees(math.atan2(y, x)) % 360.0
+    return ang
+
+
+def composite_midpoint_positions(pos_a: Positions, pos_b: Positions, objects: Iterable[str]) -> Positions:
+    """Return circular midpoints for the requested objects."""
+
+    result: Positions = {}
+    missing: list[str] = []
+    for name in objects:
+        if name not in pos_a or name not in pos_b:
+            missing.append(name)
+            continue
+        result[name] = _circular_midpoint(pos_a[name], pos_b[name])
+    if missing:
+        raise ValueError(f"Missing positions for: {', '.join(sorted(missing))}")
+    return result
+
+
+def _utc(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _midpoint_time(dt_a: datetime, dt_b: datetime) -> datetime:
+    ua = _utc(dt_a)
+    ub = _utc(dt_b)
+    return ua + (ub - ua) / 2
+
+
+def davison_positions(objects: Iterable[str], dt_a: datetime, dt_b: datetime, provider: PositionProvider) -> Positions:
+    """Return Davison composite positions at the time midpoint."""
+
+    midpoint = _midpoint_time(dt_a, dt_b)
+    state = provider(midpoint)
+    if not isinstance(state, dict):
+        raise TypeError("position provider must return a mapping of positions")
+    missing = [name for name in objects if name not in state]
+    if missing:
+        raise ValueError(f"Provider missing positions for: {', '.join(sorted(missing))}")
+    return {name: float(state[name]) for name in objects}
+
+
+__all__ = [
+    "composite_midpoint_positions",
+    "davison_positions",
+]

--- a/core/rel_plus/synastry.py
+++ b/core/rel_plus/synastry.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+from astroengine.core.aspects_plus.matcher import match_pair
+
+
+def synastry_interaspects(
+    pos_a: Dict[str, float],
+    pos_b: Dict[str, float],
+    aspects: Iterable[str],
+    policy: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    """Return best aspect matches for each A↔B pair."""
+
+    hits: List[Dict[str, Any]] = []
+    for a_name, lon_a in pos_a.items():
+        if lon_a is None:
+            continue
+        for b_name, lon_b in pos_b.items():
+            if lon_b is None:
+                continue
+            match = match_pair(a_name, b_name, float(lon_a), float(lon_b), aspects, policy)
+            if not match:
+                continue
+            hits.append(
+                {
+                    "a_obj": match["a"],
+                    "b_obj": match["b"],
+                    "aspect": match["aspect"],
+                    "angle": float(match["angle"]),
+                    "delta": float(match["delta"]),
+                    "orb": float(match["orb"]),
+                    "orb_limit": float(match["orb_limit"]),
+                }
+            )
+    hits.sort(key=lambda h: (h["a_obj"], h["b_obj"], h["orb"], h["aspect"]))
+    return hits
+
+
+def synastry_grid(hits: Iterable[Dict[str, Any]]) -> Dict[str, Dict[str, int]]:
+    """Build a count grid keyed by (A object → B object)."""
+
+    grid: Dict[str, Dict[str, int]] = {}
+    for hit in hits:
+        a_name = hit["a_obj"]
+        b_name = hit["b_obj"]
+        row = grid.setdefault(a_name, {})
+        row[b_name] = row.get(b_name, 0) + 1
+    return grid

--- a/tests/test_api_synastry_composites.py
+++ b/tests/test_api_synastry_composites.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.rel import router as rel_router
+from app.routers import aspects as aspects_module
+
+
+class LinearEphemeris:
+    def __init__(self, t0, base, rates):
+        self.t0 = t0
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            k: (self.base.get(k, 0.0) + self.rates.get(k, 0.0) * dt_days) % 360.0
+            for k in self.base
+        }
+
+
+def build_app(provider=None):
+    app = FastAPI()
+    if provider is not None:
+        aspects_module.position_provider = provider
+        if hasattr(aspects_module, "_cached"):
+            aspects_module._cached = None  # type: ignore[attr-defined]
+    app.include_router(rel_router)
+    return app
+
+
+def test_synastry_compute_basic():
+    app = build_app()
+    client = TestClient(app)
+
+    payload = {
+        "pos_a": {"Mars": 10.0, "Sun": 0.0},
+        "pos_b": {"Venus": 70.0, "Moon": 180.0},
+        "aspects": ["sextile", "trine", "square", "conjunction"],
+        "orb_policy_inline": {
+            "per_aspect": {
+                "sextile": 3.0,
+                "square": 6.0,
+                "trine": 6.0,
+                "conjunction": 8.0,
+            }
+        },
+    }
+
+    r = client.post("/synastry/compute", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert any(
+        h["a_obj"] == "Mars" and h["b_obj"] == "Venus" and h["aspect"] == "sextile"
+        for h in data["hits"]
+    )
+    assert data["grid"]["counts"]["Mars"]["Venus"] == 1
+
+
+def test_composites_midpoint_and_davison():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(t0, base={"Sun": 0.0, "Venus": 20.0}, rates={"Sun": 1.0, "Venus": 1.2})
+    app = build_app(eph)
+    client = TestClient(app)
+
+    r = client.post(
+        "/composites/midpoint",
+        json={
+            "pos_a": {"Sun": 10.0, "Moon": 200.0},
+            "pos_b": {"Sun": 50.0, "Moon": 220.0},
+            "objects": ["Sun", "Moon"],
+        },
+    )
+    assert r.status_code == 200
+    cm = r.json()
+    assert abs(cm["positions"]["Sun"] - 30.0) < 1e-9
+    assert abs(cm["positions"]["Moon"] - 210.0) < 1e-9
+
+    dt_a = t0
+    dt_b = t0 + timedelta(days=10)
+    r = client.post(
+        "/composites/davison",
+        json={
+            "objects": ["Sun", "Venus"],
+            "dt_a": dt_a.isoformat(),
+            "dt_b": dt_b.isoformat(),
+        },
+    )
+    assert r.status_code == 200
+    dv = r.json()
+    assert abs(dv["positions"]["Sun"] - 5.0) < 1e-6
+    assert abs(dv["positions"]["Venus"] - 26.0) < 1e-6


### PR DESCRIPTION
## Summary
- add synastry and composite DTOs and router wiring for the Plus API
- implement lightweight rel_plus helpers for midpoint and Davison computations using existing aspect matching utilities
- cover the new endpoints with FastAPI client tests, including policy handling and ephemeris injection

## Testing
- pytest -q tests/test_api_synastry_composites.py

------
https://chatgpt.com/codex/tasks/task_e_68d81db66ba88324afffde86711d6327