### PR TITLE
Add event detector API endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-from app.routers import aspects_router, policies_router, rel_router, transits_router
+from app.routers import (
+    aspects_router,
+    events_router,
+    policies_router,
+    rel_router,
+    transits_router,
+)
 
 app = FastAPI(title="AstroEngine Plus API")
 app.include_router(aspects_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
 app.include_router(rel_router)
+app.include_router(events_router)
 
 
 __all__ = ["app"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -2,12 +2,14 @@
 """API routers for AstroEngine Plus services."""
 
 from .aspects import router as aspects_router
+from .events import router as events_router
 from .policies import router as policies_router
 from .rel import router as rel_router
 from .transits import router as transits_router
 
 __all__ = [
     "aspects_router",
+    "events_router",
     "policies_router",
     "rel_router",
     "transits_router",

--- a/app/routers/events.py
+++ b/app/routers/events.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from datetime import timezone
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+
+from app.routers import aspects as aspects_module
+from app.schemas.aspects import TimeWindow
+from app.schemas.events import (
+    CombustCazimiRequest,
+    EventIntervalOut,
+    ReturnsRequest,
+    VoCMoonRequest,
+)
+from core.events_plus.detectors import (
+    CombustCfg,
+    detect_combust_cazimi,
+    detect_returns,
+    detect_voc_moon,
+)
+
+try:  # Optional DB repo for orb policy id
+    from app.db.session import session_scope  # type: ignore
+    from app.repo.orb_policies import OrbPolicyRepo  # type: ignore
+except Exception:  # pragma: no cover
+    session_scope = None  # type: ignore
+    OrbPolicyRepo = None  # type: ignore
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+DEFAULT_POLICY: Dict[str, Any] = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 3.0,
+        "quincunx": 3.0,
+    },
+    "adaptive_rules": {},
+}
+
+
+def _resolve_policy_inline_or_id(inline, pid) -> Dict[str, Any]:
+    if inline is not None:
+        return inline.model_dump()
+    if pid is not None:
+        if OrbPolicyRepo is None or session_scope is None:
+            raise HTTPException(
+                status_code=400,
+                detail="orb_policy_id requires DB; provide orb_policy_inline instead",
+            )
+        with session_scope() as db:
+            rec = OrbPolicyRepo().get(db, pid)
+            if not rec:
+                raise HTTPException(status_code=404, detail="orb policy not found")
+            return {
+                "per_object": rec.per_object or {},
+                "per_aspect": rec.per_aspect or {},
+                "adaptive_rules": rec.adaptive_rules or {},
+            }
+    return DEFAULT_POLICY
+
+
+@router.post(
+    "/events/voc-moon",
+    response_model=List[EventIntervalOut],
+    summary="Void-of-Course Moon intervals",
+    description=(
+        "Returns intervals where the Moon makes no selected aspects to chosen bodies before sign ingress."
+    ),
+)
+def voc_moon(req: VoCMoonRequest):
+    provider = aspects_module._get_provider()
+    policy = _resolve_policy_inline_or_id(req.orb_policy_inline, req.orb_policy_id)
+    win = TimeWindow(
+        start=req.window.start.astimezone(timezone.utc),
+        end=req.window.end.astimezone(timezone.utc),
+    )
+    intervals = detect_voc_moon(
+        win,
+        provider,
+        req.aspects,
+        policy,
+        req.other_objects,
+        step_minutes=req.step_minutes,
+    )
+    return [
+        EventIntervalOut(kind=i.kind, start=i.start, end=i.end, meta=i.meta) for i in intervals
+    ]
+
+
+@router.post(
+    "/events/combust-cazimi",
+    response_model=List[EventIntervalOut],
+    summary="Combust / Cazimi / Under-beams intervals",
+    description=(
+        "Returns disjoint intervals for cazimi (⊂ combust) and under-beams based on Sun–planet separation thresholds."
+    ),
+)
+def combust_cazimi(req: CombustCazimiRequest):
+    provider = aspects_module._get_provider()
+    cfg = CombustCfg(
+        cazimi_deg=req.cfg.cazimi_deg,
+        combust_deg=req.cfg.combust_deg,
+        under_beams_deg=req.cfg.under_beams_deg,
+    )
+    win = TimeWindow(
+        start=req.window.start.astimezone(timezone.utc),
+        end=req.window.end.astimezone(timezone.utc),
+    )
+    intervals = detect_combust_cazimi(
+        win,
+        provider,
+        planet=req.planet,
+        cfg=cfg,
+        step_minutes=req.step_minutes,
+    )
+    return [
+        EventIntervalOut(kind=i.kind, start=i.start, end=i.end, meta=i.meta) for i in intervals
+    ]
+
+
+@router.post(
+    "/events/returns",
+    response_model=List[EventIntervalOut],
+    summary="Return events (points)",
+    description="Emits point events when a body returns to its natal longitude within the given window.",
+)
+def returns(req: ReturnsRequest):
+    provider = aspects_module._get_provider()
+    win = TimeWindow(
+        start=req.window.start.astimezone(timezone.utc),
+        end=req.window.end.astimezone(timezone.utc),
+    )
+    intervals = detect_returns(
+        win,
+        provider,
+        body=req.body,
+        target_lon=req.target_lon,
+        step_minutes=req.step_minutes,
+    )
+    return [
+        EventIntervalOut(kind=i.kind, start=i.start, end=i.end, meta=i.meta) for i in intervals
+    ]

--- a/app/schemas/events.py
+++ b/app/schemas/events.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.aspects import AspectName, OrbPolicyInline, TimeWindow
+
+
+class EventIntervalOut(BaseModel):
+    kind: Literal["voc_moon", "cazimi", "combust", "under_beams", "return"]
+    start: datetime
+    end: datetime
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class VoCMoonRequest(BaseModel):
+    window: TimeWindow
+    aspects: List[AspectName] = Field(
+        ..., description="Aspect set to consider for VoC determination"
+    )
+    other_objects: List[str] = Field(
+        ..., description="Bodies Moon may aspect (e.g., Sun,Mercury,...) not including Moon"
+    )
+    step_minutes: int = Field(60, ge=1, le=720)
+
+    orb_policy_id: Optional[int] = None
+    orb_policy_inline: Optional[OrbPolicyInline] = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "window": {
+                    "start": "2025-01-01T00:00:00Z",
+                    "end": "2025-01-04T00:00:00Z",
+                },
+                "aspects": [
+                    "conjunction",
+                    "sextile",
+                    "square",
+                    "trine",
+                    "opposition",
+                ],
+                "other_objects": [
+                    "Sun",
+                    "Mercury",
+                    "Venus",
+                    "Mars",
+                    "Jupiter",
+                    "Saturn",
+                ],
+                "step_minutes": 60,
+                "orb_policy_inline": {
+                    "per_aspect": {
+                        "conjunction": 8.0,
+                        "sextile": 3.0,
+                        "square": 6.0,
+                        "trine": 6.0,
+                        "opposition": 7.0,
+                    }
+                },
+            }
+        }
+    )
+
+
+class CombustCfgIn(BaseModel):
+    cazimi_deg: float = 0.2667
+    combust_deg: float = 8.0
+    under_beams_deg: float = 15.0
+
+
+class CombustCazimiRequest(BaseModel):
+    window: TimeWindow
+    planet: str = Field(..., description="Planet to test against Sun")
+    step_minutes: int = Field(10, ge=1, le=1440)
+    cfg: CombustCfgIn = Field(default_factory=CombustCfgIn)
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "window": {
+                    "start": "2025-01-01T00:00:00Z",
+                    "end": "2025-01-20T00:00:00Z",
+                },
+                "planet": "Mercury",
+                "step_minutes": 10,
+                "cfg": {
+                    "cazimi_deg": 0.2667,
+                    "combust_deg": 8.0,
+                    "under_beams_deg": 15.0,
+                },
+            }
+        }
+    )
+
+
+class ReturnsRequest(BaseModel):
+    window: TimeWindow
+    body: str
+    target_lon: float
+    step_minutes: int = Field(720, ge=1, le=1440)
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "window": {
+                    "start": "2025-01-01T00:00:00Z",
+                    "end": "2026-02-01T00:00:00Z",
+                },
+                "body": "Sun",
+                "target_lon": 10.0,
+                "step_minutes": 720,
+            }
+        }
+    )

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,3 +1,3 @@
 """AstroEngine Plus compatibility shims for lightweight API services."""
 
-__all__ = ["rel_plus"]
+__all__ = ["events_plus", "rel_plus"]

--- a/core/events_plus/__init__.py
+++ b/core/events_plus/__init__.py
@@ -1,0 +1,17 @@
+"""Event detectors exposed for API compatibility."""
+
+from .detectors import (
+    CombustCfg,
+    EventInterval,
+    detect_combust_cazimi,
+    detect_returns,
+    detect_voc_moon,
+)
+
+__all__ = [
+    "CombustCfg",
+    "EventInterval",
+    "detect_combust_cazimi",
+    "detect_returns",
+    "detect_voc_moon",
+]

--- a/core/events_plus/detectors.py
+++ b/core/events_plus/detectors.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, Iterable, List, Sequence
+
+PositionProvider = Callable[[datetime], Dict[str, float]]
+
+
+@dataclass(slots=True)
+class EventInterval:
+    """Normalized event interval emitted by detectors."""
+
+    kind: str
+    start: datetime
+    end: datetime
+    meta: Dict[str, Any]
+
+
+@dataclass(slots=True)
+class CombustCfg:
+    """Configuration thresholds for combust / cazimi detection."""
+
+    cazimi_deg: float = 0.2667
+    combust_deg: float = 8.0
+    under_beams_deg: float = 15.0
+
+
+_ASPECT_ANGLES: Dict[str, float] = {
+    "conjunction": 0.0,
+    "opposition": 180.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "sextile": 60.0,
+    "quincunx": 150.0,
+    "semisquare": 45.0,
+    "sesquisquare": 135.0,
+    "quintile": 72.0,
+    "biquintile": 144.0,
+}
+
+
+def _norm360(value: float) -> float:
+    return value % 360.0
+
+
+def _angle_delta(value: float, target: float) -> float:
+    diff = (value - target + 180.0) % 360.0 - 180.0
+    return diff
+
+
+def _angle_distance(value: float, target: float) -> float:
+    return abs(_angle_delta(value, target))
+
+
+def _sample_range(window_start: datetime, window_end: datetime, step_minutes: int) -> Sequence[datetime]:
+    if step_minutes <= 0:
+        raise ValueError("step_minutes must be positive")
+    delta = timedelta(minutes=step_minutes)
+    samples: List[datetime] = [window_start]
+    cursor = window_start
+    while cursor < window_end:
+        next_cursor = cursor + delta
+        if next_cursor >= window_end:
+            if samples[-1] != window_end:
+                samples.append(window_end)
+            break
+        samples.append(next_cursor)
+        cursor = next_cursor
+    if samples[-1] != window_end:
+        samples.append(window_end)
+    return samples
+
+
+def detect_voc_moon(
+    window: Any,
+    provider: PositionProvider,
+    aspects: Iterable[str],
+    orb_policy: Dict[str, Any],
+    other_objects: Iterable[str],
+    *,
+    step_minutes: int = 60,
+) -> List[EventInterval]:
+    """Detect intervals where the Moon forms no aspects to the selected objects."""
+
+    start = window.start
+    end = window.end
+    samples = _sample_range(start, end, step_minutes)
+
+    per_aspect = orb_policy.get("per_aspect", {}) if orb_policy else {}
+    default_orb = float(orb_policy.get("default", 3.0)) if orb_policy else 3.0
+    aspect_list = [name for name in aspects if name in _ASPECT_ANGLES]
+
+    def _is_void(ts: datetime) -> bool:
+        positions = provider(ts)
+        moon_lon = positions.get("Moon")
+        if moon_lon is None:
+            raise KeyError("Moon position missing from provider output")
+        for obj in other_objects:
+            other_lon = positions.get(obj)
+            if other_lon is None:
+                continue
+            separation = _norm360(moon_lon - other_lon)
+            for aspect_name in aspect_list:
+                target = _ASPECT_ANGLES[aspect_name]
+                orb = float(per_aspect.get(aspect_name, default_orb))
+                if _angle_distance(separation, target) <= orb:
+                    return False
+        return True
+
+    states = [_is_void(ts) for ts in samples]
+
+    intervals: List[EventInterval] = []
+    current_start: datetime | None = None
+    for idx, ts in enumerate(samples):
+        state = states[idx]
+        if state and current_start is None:
+            current_start = ts
+        if (not state or idx == len(samples) - 1) and current_start is not None:
+            end_ts = ts if not state else samples[-1]
+            intervals.append(
+                EventInterval(
+                    kind="voc_moon",
+                    start=current_start,
+                    end=end_ts,
+                    meta={"step_minutes": step_minutes},
+                )
+            )
+            current_start = None
+
+    return intervals
+
+
+def detect_combust_cazimi(
+    window: Any,
+    provider: PositionProvider,
+    *,
+    planet: str,
+    cfg: CombustCfg | None = None,
+    step_minutes: int = 10,
+) -> List[EventInterval]:
+    """Detect cazimi / combust / under-beams intervals for a planet relative to the Sun."""
+
+    if cfg is None:
+        cfg = CombustCfg()
+
+    start = window.start
+    end = window.end
+    samples = _sample_range(start, end, step_minutes)
+
+    def _state(ts: datetime) -> str | None:
+        positions = provider(ts)
+        sun = positions.get("Sun")
+        body = positions.get(planet)
+        if sun is None or body is None:
+            raise KeyError("Sun or planet position missing from provider output")
+        separation = abs(_angle_delta(_norm360(body) - _norm360(sun), 0.0))
+        if separation <= cfg.cazimi_deg:
+            return "cazimi"
+        if separation <= cfg.combust_deg:
+            return "combust"
+        if separation <= cfg.under_beams_deg:
+            return "under_beams"
+        return None
+
+    states = [_state(ts) for ts in samples]
+
+    intervals: List[EventInterval] = []
+    current_kind: str | None = None
+    current_start: datetime | None = None
+
+    for idx, ts in enumerate(samples):
+        state = states[idx]
+        if state != current_kind:
+            if current_kind is not None and current_start is not None:
+                intervals.append(
+                    EventInterval(
+                        kind=current_kind,
+                        start=current_start,
+                        end=ts,
+                        meta={"planet": planet},
+                    )
+                )
+            current_kind = state
+            current_start = ts if state is not None else None
+        if idx == len(samples) - 1 and current_kind is not None and current_start is not None:
+            intervals.append(
+                EventInterval(
+                    kind=current_kind,
+                    start=current_start,
+                    end=ts,
+                    meta={"planet": planet},
+                )
+            )
+            current_kind = None
+            current_start = None
+
+    return intervals
+
+
+def detect_returns(
+    window: Any,
+    provider: PositionProvider,
+    *,
+    body: str,
+    target_lon: float,
+    step_minutes: int = 720,
+    tol_seconds: float = 60.0,
+) -> List[EventInterval]:
+    """Detect point events when a body returns to ``target_lon`` within ``window``."""
+
+    start = window.start
+    end = window.end
+    samples = _sample_range(start, end, step_minutes)
+
+    events: List[EventInterval] = []
+    prev_ts: datetime | None = None
+    prev_diff: float | None = None
+
+    def _record_event(moment: datetime, *, include_orb: bool) -> None:
+        if events and abs((moment - events[-1].start).total_seconds()) <= tol_seconds:
+            return
+        meta: Dict[str, Any] = {"body": body, "target_lon": float(target_lon)}
+        if include_orb:
+            meta["orb"] = 0.0
+        events.append(
+            EventInterval(
+                kind="return",
+                start=moment,
+                end=moment,
+                meta=meta,
+            )
+        )
+
+    for ts in samples:
+        positions = provider(ts)
+        lon = positions.get(body)
+        if lon is None:
+            raise KeyError(f"{body} position missing from provider output")
+        diff = _angle_delta(_norm360(lon), _norm360(target_lon))
+        if abs(diff) < 1e-6:
+            _record_event(ts, include_orb=True)
+        elif prev_diff is not None and prev_ts is not None:
+            if (prev_diff <= 0.0 < diff) or (prev_diff >= 0.0 > diff):
+                span = (ts - prev_ts).total_seconds()
+                if span == 0:
+                    exact = ts
+                else:
+                    alpha = prev_diff / (prev_diff - diff)
+                    alpha = max(0.0, min(1.0, alpha))
+                    exact = prev_ts + timedelta(seconds=alpha * span)
+                _record_event(exact, include_orb=False)
+        prev_ts = ts
+        prev_diff = diff
+
+    return events
+
+
+__all__ = [
+    "CombustCfg",
+    "EventInterval",
+    "detect_voc_moon",
+    "detect_combust_cazimi",
+    "detect_returns",
+]

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers import aspects as aspects_module
+from app.routers.events import router as events_router
+
+
+class LinearEphemeris:
+    """Synthetic ephemeris where bodies move linearly in longitude."""
+
+    def __init__(self, t0, base, rates):
+        self.t0 = t0
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            body: (self.base.get(body, 0.0) + self.rates.get(body, 0.0) * dt_days) % 360.0
+            for body in self.base
+        }
+
+
+def build_app(provider):
+    app = FastAPI()
+    aspects_module.position_provider = provider
+    if hasattr(aspects_module, "_cached"):
+        aspects_module._cached = None
+    app.include_router(events_router)
+    return app
+
+
+def test_combust_cazimi_api():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Sun": 0.0, "Mercury": 0.5},
+        rates={"Sun": 0.0, "Mercury": -0.1},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "window": {
+            "start": t0.isoformat(),
+            "end": (t0 + timedelta(days=20)).isoformat(),
+        },
+        "planet": "Mercury",
+        "step_minutes": 10,
+        "cfg": {
+            "cazimi_deg": 0.2667,
+            "combust_deg": 8.0,
+            "under_beams_deg": 15.0,
+        },
+    }
+    r = client.post("/events/combust-cazimi", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    kinds = {iv["kind"] for iv in data}
+    assert "cazimi" in kinds
+
+
+def test_voc_moon_api():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Moon": 2.0, "Sun": 180.0},
+        rates={"Moon": 13.0},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "window": {
+            "start": t0.isoformat(),
+            "end": (t0 + timedelta(days=3)).isoformat(),
+        },
+        "aspects": ["conjunction"],
+        "other_objects": ["Sun"],
+        "step_minutes": 120,
+        "orb_policy_inline": {"per_aspect": {"conjunction": 8.0}},
+    }
+    r = client.post("/events/voc-moon", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert isinstance(data, list) and len(data) >= 1
+    assert data[0]["kind"] == "voc_moon"
+
+
+def test_returns_api():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(t0, base={"Sun": 10.0}, rates={"Sun": 1.0})
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "window": {
+            "start": (t0 + timedelta(hours=1)).isoformat(),
+            "end": (t0 + timedelta(days=380)).isoformat(),
+        },
+        "body": "Sun",
+        "target_lon": 10.0,
+        "step_minutes": 720,
+    }
+    r = client.post("/events/returns", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    expected = t0 + timedelta(days=360)
+    assert any(
+        abs(
+            (
+                datetime.fromisoformat(iv["start"]).replace(tzinfo=timezone.utc)
+                - expected
+            ).total_seconds()
+        )
+        <= 60
+        for iv in data
+    )


### PR DESCRIPTION
## Summary
- add FastAPI router that exposes VoC Moon, combust/cazimi, and return detectors with orb policy resolution and provider injection
- define request/response schemas to drive the new endpoints and register the router with the application
- implement event detector utilities plus API tests using a synthetic ephemeris

## Testing
- pytest -q tests/test_api_events.py

------
https://chatgpt.com/codex/tasks/task_e_68d8202e61a4832490b0f018c2b4803c