### PR TITLE
Align scan APIs with updated core and restore pytest

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -255,3 +255,8 @@ __all__ = [
     "TimestampMixin",
 
 ]
+
+# Backwards compatible alias retained for legacy imports
+RuleSetVersion = RulesetVersion
+
+__all__.append("RuleSetVersion")

--- a/app/repo/rulesets.py
+++ b/app/repo/rulesets.py
@@ -11,7 +11,10 @@ class RuleSetRepo(BaseRepo[RuleSetVersion]):
     def get_active(self, db: Session, key: str) -> Optional[RuleSetVersion]:
         return (
             db.query(RuleSetVersion)
-            .filter(RuleSetVersion.key == key, RuleSetVersion.is_active == True)  # noqa: E712
+            .filter(
+                RuleSetVersion.ruleset_key == key,
+                RuleSetVersion.is_active.is_(True),
+            )
             .order_by(RuleSetVersion.version.desc())
             .first()
         )

--- a/astroengine/core/aspects_plus/scan.py
+++ b/astroengine/core/aspects_plus/scan.py
@@ -1,28 +1,46 @@
-
-"""Aspect scan dataclasses for search/ranking pipelines."""
-
+"""Aspect scanning utilities for AstroEngine Plus."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta
+from itertools import combinations
+from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
-from datetime import datetime
-from typing import Any, Mapping, MutableMapping, Optional
+from astroengine.core.aspects_plus.harmonics import BASE_ASPECTS, harmonic_angles
+
+
+@dataclass(slots=True)
+class TimeWindow:
+    """Inclusive start/exclusive end window used for scans."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        if self.end <= self.start:
+            raise ValueError("end must be after start")
+
+    def clamp(self, ts: datetime) -> datetime:
+        if ts < self.start:
+            return self.start
+        if ts > self.end:
+            return self.end
+        return ts
+
+
+@dataclass(frozen=True)
+class AspectSpec:
+    """Normalized definition of an aspect angle to scan for."""
+
+    name: str
+    angle: float
+    harmonic: Optional[int] = None
 
 
 @dataclass(slots=True)
 class Hit:
-    """Raw aspect hit emitted by scanning routines.
-
-    Attributes:
-        a: Primary actor identifier (planet/body name).
-        b: Secondary actor identifier.
-        aspect_angle: Exact aspect angle in degrees.
-        exact_time: Timestamp of the aspect hit (timezone-aware preferred).
-        orb: Absolute orb distance in degrees.
-        orb_limit: Maximum orb allowed for this aspect pairing.
-        meta: Optional mutable mapping for downstream annotations.
-    """
+    """Raw aspect hit emitted by scanning routines."""
 
     a: str
     b: str
@@ -33,8 +51,6 @@ class Hit:
     meta: Optional[MutableMapping[str, Any]] = None
 
     def as_mapping(self) -> Mapping[str, Any]:
-        """Return a shallow mapping representation of this hit."""
-
         base = {
             "a": self.a,
             "b": self.b,
@@ -47,3 +63,274 @@ class Hit:
             base.update(self.meta)
         return base
 
+
+def _separation(
+    provider: Callable[[datetime], Mapping[str, float]],
+    ts: datetime,
+    a: str,
+    b: str,
+) -> Optional[float]:
+    try:
+        positions = provider(ts)
+        lon_a = float(positions[a])
+        lon_b = float(positions[b])
+    except Exception:
+        return None
+    diff = (lon_a - lon_b + 180.0) % 360.0 - 180.0
+    return abs(diff)
+
+
+def _angle_delta(
+    provider: Callable[[datetime], Mapping[str, float]],
+    ts: datetime,
+    a: str,
+    b: str,
+    target_angle: float,
+) -> Optional[float]:
+    sep = _separation(provider, ts, a, b)
+    if sep is None:
+        return None
+    return float(sep) - float(target_angle)
+
+
+def _resolve_orb_limit(
+    orb_policy: Mapping[str, Any] | None,
+    spec: AspectSpec,
+    body_a: str,
+    body_b: str,
+) -> float:
+    policy = orb_policy or {}
+    aspect_limits = policy.get("per_aspect", {}) or {}
+    key = spec.name.lower()
+    limit = aspect_limits.get(key)
+    if limit is None:
+        limit = aspect_limits.get(str(spec.angle))
+    try:
+        limit_val = float(limit) if limit is not None else 0.0
+    except Exception:
+        limit_val = 0.0
+
+    per_object = policy.get("per_object", {}) or {}
+    for obj in (body_a, body_b):
+        try:
+            limit_val = max(limit_val, float(per_object.get(obj, 0.0)))
+        except Exception:
+            continue
+    return max(0.0, limit_val)
+
+
+def _bisect_refine(
+    provider: Callable[[datetime], Mapping[str, float]],
+    a: str,
+    b: str,
+    target_angle: float,
+    left_time: datetime,
+    left_delta: float,
+    right_time: datetime,
+    right_delta: float,
+    limit: float,
+) -> Optional[Tuple[datetime, float]]:
+    best_time = left_time if abs(left_delta) <= abs(right_delta) else right_time
+    best_delta = left_delta if abs(left_delta) <= abs(right_delta) else right_delta
+    for _ in range(40):
+        span = right_time - left_time
+        if span.total_seconds() <= 1:
+            break
+        mid_time = left_time + span / 2
+        mid_delta = _angle_delta(provider, mid_time, a, b, target_angle)
+        if mid_delta is None:
+            break
+        if abs(mid_delta) < abs(best_delta):
+            best_time, best_delta = mid_time, mid_delta
+        if left_delta == 0.0 and right_delta == 0.0:
+            break
+        if left_delta * mid_delta <= 0:
+            right_time, right_delta = mid_time, mid_delta
+        else:
+            left_time, left_delta = mid_time, mid_delta
+    orb = abs(best_delta)
+    if orb <= limit + 1e-6:
+        return best_time, orb
+    return None
+
+
+def _scan_single_spec(
+    body_a: str,
+    body_b: str,
+    window: TimeWindow,
+    provider: Callable[[datetime], Mapping[str, float]],
+    spec: AspectSpec,
+    limit: float,
+    step_minutes: int,
+) -> List[Hit]:
+    if limit <= 0.0:
+        return []
+    step = timedelta(minutes=max(1, int(step_minutes)))
+    hits: List[Hit] = []
+
+    prev_time = window.start
+    prev_delta_opt = _angle_delta(provider, prev_time, body_a, body_b, spec.angle)
+    if prev_delta_opt is None:
+        return hits
+    last_recorded: Optional[datetime] = None
+
+    while prev_time < window.end:
+        next_time = prev_time + step
+        if next_time > window.end:
+            next_time = window.end
+        next_delta_opt = _angle_delta(provider, next_time, body_a, body_b, spec.angle)
+        if next_delta_opt is None:
+            prev_time = next_time
+            prev_delta_opt = None
+            continue
+
+        candidate: Optional[Tuple[datetime, float]] = None
+
+        if prev_delta_opt == 0.0:
+            candidate = (prev_time, 0.0)
+        elif next_delta_opt == 0.0:
+            candidate = (next_time, 0.0)
+        elif prev_delta_opt * next_delta_opt <= 0:
+            refined = _bisect_refine(
+                provider,
+                body_a,
+                body_b,
+                spec.angle,
+                prev_time,
+                prev_delta_opt,
+                next_time,
+                next_delta_opt,
+                limit,
+            )
+            if refined:
+                candidate = refined
+
+        if candidate:
+            hit_time, orb = candidate
+            hit_time = window.clamp(hit_time)
+            if orb <= limit + 1e-6:
+                if last_recorded is None or abs((hit_time - last_recorded).total_seconds()) > 30:
+                    hits.append(
+                        Hit(
+                            a=body_a,
+                            b=body_b,
+                            aspect_angle=spec.angle,
+                            exact_time=hit_time,
+                            orb=orb,
+                            orb_limit=limit,
+                            meta={"aspect": spec.name, "harmonic": spec.harmonic},
+                        )
+                    )
+                    last_recorded = hit_time
+
+        prev_time = next_time
+        prev_delta_opt = next_delta_opt
+
+    return hits
+
+
+def scan_pair_time_range(
+    body_a: str,
+    body_b: str,
+    window: TimeWindow,
+    position_provider: Callable[[datetime], Mapping[str, float]],
+    aspect_specs: Sequence[AspectSpec],
+    orb_policy: Mapping[str, Any] | None,
+    *,
+    step_minutes: int = 60,
+) -> List[Hit]:
+    """Scan a pair of bodies for the provided aspects."""
+
+    hits: List[Hit] = []
+    for spec in aspect_specs:
+        limit = _resolve_orb_limit(orb_policy, spec, body_a, body_b)
+        hits.extend(
+            _scan_single_spec(body_a, body_b, window, position_provider, spec, limit, step_minutes)
+        )
+    hits.sort(key=lambda h: (h.exact_time, h.orb))
+    return hits
+
+
+def _pair_iter(objects: Sequence[str], pairs: Optional[Iterable[Tuple[str, str]]]) -> Iterable[Tuple[str, str]]:
+    if pairs:
+        for p in pairs:
+            if not p or len(p) < 2:
+                continue
+            yield p[0], p[1]
+    else:
+        yield from combinations(objects, 2)
+
+
+def _build_specs(aspects: Sequence[str], harmonics: Sequence[int]) -> List[AspectSpec]:
+    specs: List[AspectSpec] = []
+    seen: set[Tuple[str, float, Optional[int]]] = set()
+
+    for name in aspects:
+        key = (name or "").strip().lower()
+        if key not in BASE_ASPECTS:
+            continue
+        angle = float(BASE_ASPECTS[key])
+        signature = (key, angle, None)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        specs.append(AspectSpec(name=key, angle=angle, harmonic=None))
+
+    for order in harmonics:
+        try:
+            order_int = int(order)
+        except Exception:
+            continue
+        if order_int <= 1:
+            continue
+        for angle in harmonic_angles(order_int):
+            signature = (f"harmonic_{order_int}", float(angle), order_int)
+            if signature in seen:
+                continue
+            seen.add(signature)
+            specs.append(AspectSpec(name=f"harmonic_{order_int}", angle=float(angle), harmonic=order_int))
+
+    return specs
+
+
+def scan_time_range(
+    *,
+    objects: Sequence[str],
+    window: TimeWindow,
+    position_provider: Callable[[datetime], Mapping[str, float]],
+    aspects: Sequence[str],
+    harmonics: Sequence[int],
+    orb_policy: Mapping[str, Any] | None,
+    pairs: Optional[Iterable[Tuple[str, str]]] = None,
+    step_minutes: int = 60,
+) -> List[Hit]:
+    """Scan a set of objects for matching aspect hits."""
+
+    specs = _build_specs(aspects, harmonics)
+    if not specs:
+        return []
+
+    hits: List[Hit] = []
+    for a, b in _pair_iter(objects, pairs):
+        hits.extend(
+            scan_pair_time_range(
+                a,
+                b,
+                window,
+                position_provider,
+                specs,
+                orb_policy,
+                step_minutes=step_minutes,
+            )
+        )
+    hits.sort(key=lambda h: (h.exact_time, h.orb))
+    return hits
+
+
+__all__ = [
+    "AspectSpec",
+    "Hit",
+    "TimeWindow",
+    "scan_pair_time_range",
+    "scan_time_range",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ pyswisseph==2.10.3.2  # ENSURE-LINE
 
 jinja2>=3.1
 fastapi>=0.117
+pydantic>=2.11
 httpx>=0.28
 
 pytest>=8.0.0  # ENSURE-LINE

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,8 @@ jinja2>=3.1
 click>=8.1
 rich>=13.7
 ics>=0.7
+fastapi>=0.117
+pydantic>=2.11
 # QA / property-based testing (used by tests)
 hypothesis>=6.112
 # Optional groups (comment in as needed):

--- a/tests/property/test_timezones.py
+++ b/tests/property/test_timezones.py
@@ -21,8 +21,8 @@ COORDS = st.tuples(
     st.floats(min_value=-179.9, max_value=179.9, allow_nan=False, allow_infinity=False),
 )
 INSTANTS = st.datetimes(
-    min_value=datetime(1970, 1, 1, tzinfo=timezone.utc),
-    max_value=datetime(2035, 12, 31, tzinfo=timezone.utc),
+    min_value=datetime(1970, 1, 1),
+    max_value=datetime(2035, 12, 31),
     timezones=st.just(timezone.utc),
 )
 

--- a/tests/test_models_basic.py
+++ b/tests/test_models_basic.py
@@ -1,28 +1,46 @@
 from datetime import datetime, timezone
 
 from app.db.models import (
-    OrbPolicy,
-    SeverityProfile,
+    AsteroidMeta,
     Chart,
     Event,
-    RuleSetVersion,
-    AsteroidMeta,
     ExportJob,
-    ChartKind,
-    EventType,
-    ExportType,
+    OrbPolicy,
+    RuleSetVersion,
+    RulesetVersion,
+    SeverityProfile,
 )
 
 
 def test_model_instantiation():
-    op = OrbPolicy(name="classic")
-    sp = SeverityProfile(name="default")
-    ch = Chart(kind=ChartKind.natal, dt_utc=datetime.now(timezone.utc), lat=0.0, lon=0.0)
-    rs = RuleSetVersion(key="electional_default")
-    ev = Event(type=EventType.custom, start_ts=datetime.now(timezone.utc), chart=ch)
-    am = AsteroidMeta(name="Chiron", designation="2060")
-    ex = ExportJob(type=ExportType.ics)
+    op = OrbPolicy(profile_key="default", body="Sun", aspect="sextile", orb_degrees=4.0)
+    sp = SeverityProfile(profile_key="default", weights={"sextile": 0.5})
+    ch = Chart(chart_key="chart-1", profile_key="default", data={"kind": "natal"})
+    rs = RulesetVersion(
+        ruleset_key="electional_default",
+        version="1.0",
+        checksum="abc123",
+        definition={"rules": []},
+    )
+    ev = Event(
+        event_key="event-1",
+        chart=ch,
+        ruleset_version=rs,
+        event_time=datetime.now(timezone.utc),
+        event_type="custom",
+        payload={"objects": {"A": "Mars", "B": "Venus"}},
+    )
+    am = AsteroidMeta(
+        asteroid_id="2060",
+        designation="2060",
+        common_name="Chiron",
+        attributes={"alias": "Chiron"},
+    )
+    ex = ExportJob(job_key="job-1", job_type="ics")
 
-    assert op.name == "classic"
-    assert ch.kind == ChartKind.natal
+    assert op.profile_key == "default"
+    assert ch.events == [ev]
     assert ev.chart is ch
+    assert isinstance(rs, RuleSetVersion)
+    assert am.common_name == "Chiron"
+    assert ex.job_type == "ics"

--- a/tests/test_scan_timerange.py
+++ b/tests/test_scan_timerange.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 from astroengine.core.aspects_plus.scan import (
-    Hit,
+    AspectSpec,
     TimeWindow,
     scan_pair_time_range,
     scan_time_range,
@@ -46,7 +46,7 @@ def test_find_single_sextile_with_bisection():
         "Venus",
         win,
         eph,
-        [60.0],
+        [AspectSpec(name="sextile", angle=60.0)],
         POLICY,
         step_minutes=720,
     )

--- a/tests/test_schemas_aspects.py
+++ b/tests/test_schemas_aspects.py
@@ -1,6 +1,13 @@
 from datetime import datetime
+from datetime import datetime
+
 from app.schemas.aspects import (
-    AspectSearchRequest, AspectSearchResponse, AspectHit, DayBin, TimeWindow, Paging
+    AspectSearchRequest,
+    AspectSearchResponse,
+    AspectHit,
+    DayBin,
+    Paging,
+    TimeWindow,
 )
 
 

--- a/ui/streamlit/api.py
+++ b/ui/streamlit/api.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+import os, requests
+from typing import Any, Dict
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
+
+class APIClient:
+    def __init__(self, base_url: str | None = None) -> None:
+        self.base = (base_url or API_BASE_URL).rstrip("/")
+
+    # existing: aspects_search(...)
+    def aspects_search(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base}/aspects/search"
+        r = requests.post(url, json=payload, timeout=60)
+        r.raise_for_status()
+        return r.json()
+
+    # ---- OrbPolicy CRUD ---------------------------------------------------
+    def list_policies(self, limit: int = 100, offset: int = 0) -> Dict[str, Any]:
+        r = requests.get(f"{self.base}/policies", params={"limit": limit, "offset": offset}, timeout=30)
+        r.raise_for_status(); return r.json()
+
+    def get_policy(self, policy_id: int) -> Dict[str, Any]:
+        r = requests.get(f"{self.base}/policies/{policy_id}", timeout=30)
+        r.raise_for_status(); return r.json()
+
+    def create_policy(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        r = requests.post(f"{self.base}/policies", json=payload, timeout=30)
+        r.raise_for_status(); return r.json()
+
+    def update_policy(self, policy_id: int, payload: Dict[str, Any]) -> Dict[str, Any]:
+        r = requests.put(f"{self.base}/policies/{policy_id}", json=payload, timeout=30)
+        r.raise_for_status(); return r.json()
+
+    def delete_policy(self, policy_id: int) -> None:
+        r = requests.delete(f"{self.base}/policies/{policy_id}", timeout=30)
+        if r.status_code not in (200, 204):
+            r.raise_for_status()

--- a/ui/streamlit/pages/03_Orb_Policy_Editor.py
+++ b/ui/streamlit/pages/03_Orb_Policy_Editor.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Dict, Any, Iterable, List
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import streamlit as st
+
+from ui.streamlit.api import APIClient
+
+st.set_page_config(page_title="Orb & Severity Editor", page_icon="⚙️", layout="wide")
+st.title("Orb & Severity Editor ⚙️")
+api = APIClient()
+
+# ------------------------------ Utility -----------------------------------
+
+
+def _allowed_policy_keys(include_name: bool = True) -> Iterable[str]:
+    keys: List[str] = ["description", "per_object", "per_aspect", "adaptive_rules"]
+    if include_name:
+        keys.insert(0, "name")
+    return keys
+
+
+def sanitise_policy(payload: Dict[str, Any], include_name: bool = True) -> Dict[str, Any]:
+    """Return a shallow copy containing only fields accepted by the API."""
+
+    allowed = set(_allowed_policy_keys(include_name=include_name))
+    return {key: payload[key] for key in allowed if key in payload}
+
+# ------------------------------ Helpers ------------------------------------
+DEFAULT_ASPECTS = ["conjunction","opposition","square","trine","sextile","quincunx","semisquare","sesquisquare","quintile","biquintile"]
+DEFAULT_WEIGHTS = {"conjunction":1.0,"opposition":0.95,"square":0.9,"trine":0.8,"sextile":0.6,"quincunx":0.5,"semisquare":0.45,"sesquisquare":0.45,"quintile":0.4,"biquintile":0.4}
+
+# Cosine taper (same shape as backend)
+def taper_by_orb(orb: float, limit: float) -> float:
+    if limit <= 0: return 0.0
+    x = max(0.0, min(1.0, orb/limit))
+    return 0.5 * (1.0 + np.cos(np.pi * x)) if x < 1.0 else 0.0
+
+# Severity proxy in UI (weight × taper). Backend may add modifiers later.
+def sev_ui(aspect: str, orb: float, limit: float, weights: Dict[str, float]) -> float:
+    w = float(weights.get(aspect, DEFAULT_WEIGHTS.get(aspect, 0.5)))
+    return max(0.0, w * taper_by_orb(orb, limit))
+
+# ------------------------------ Sidebar ------------------------------------
+st.sidebar.header("Policies")
+
+# Load list
+try:
+    pol_list = api.list_policies()
+    items = pol_list.get("items", [])
+except Exception as e:
+    st.sidebar.error(f"Failed to load policies: {e}")
+    items = []
+
+id_by_name = {f"{p['name']} (#{p['id']})": p["id"] for p in items}
+options = ["— New Policy —"] + list(id_by_name.keys())
+choice = st.sidebar.selectbox("Select policy", options)
+
+is_new = choice == "— New Policy —"
+policy: Dict[str, Any] = {
+    "name": "classic",
+    "description": "Default classical orbs",
+    "per_object": {"Sun": 8.0, "Moon": 6.0},
+    "per_aspect": {"conjunction": 8.0, "opposition": 7.0, "square": 6.0, "trine": 6.0, "sextile": 4.0, "quincunx": 3.0},
+    "adaptive_rules": {"luminaries_factor": 0.9, "outers_factor": 1.1, "minor_aspect_factor": 0.9},
+}
+
+if not is_new:
+    try:
+        policy = dict(api.get_policy(id_by_name[choice]))
+    except Exception as e:
+        st.sidebar.error(f"Failed to fetch policy: {e}")
+
+# ------------------------------ Form ---------------------------------------
+st.subheader("Edit Policy")
+col1, col2 = st.columns(2)
+with col1:
+    policy["name"] = st.text_input("Name", value=policy.get("name", ""), help="Unique policy name")
+    policy["description"] = st.text_input("Description", value=policy.get("description", ""))
+with col2:
+    with st.expander("Adaptive rules"):
+        ar = policy.get("adaptive_rules", {}) or {}
+        ar["luminaries_factor"] = st.slider("luminaries_factor", 0.5, 1.5, float(ar.get("luminaries_factor", 0.9)), 0.05)
+        ar["outers_factor"] = st.slider("outers_factor", 0.5, 1.5, float(ar.get("outers_factor", 1.1)), 0.05)
+        ar["minor_aspect_factor"] = st.slider("minor_aspect_factor", 0.5, 1.5, float(ar.get("minor_aspect_factor", 0.9)), 0.05)
+        policy["adaptive_rules"] = ar
+
+st.markdown("### Per‑Aspect Orbs (deg)")
+existing_aspects = list(DEFAULT_ASPECTS)
+for asp_name in (policy.get("per_aspect", {}) or {}).keys():
+    if asp_name not in existing_aspects:
+        existing_aspects.append(asp_name)
+
+pa = policy.get("per_aspect", {}) or {}
+for asp in existing_aspects:
+    pa[asp] = st.number_input(
+        f"{asp}",
+        min_value=0.1,
+        max_value=12.0,
+        value=float(pa.get(asp, DEFAULT_WEIGHTS.get(asp, 0.5) * 10)),
+        step=0.1,
+    )
+policy["per_aspect"] = pa
+available_aspects = existing_aspects
+
+with st.expander("Per‑Object Orbs (deg)", expanded=False):
+    po = policy.get("per_object", {}) or {}
+    # Simple add/edit rows
+    new_key = st.text_input("Add/Update object name", value="")
+    new_val = st.number_input("Orb (deg)", min_value=0.1, max_value=12.0, value=6.0, step=0.1)
+    if st.button("Add/Update Object Orb") and new_key.strip():
+        po[new_key.strip()] = float(new_val)
+
+    if po:
+        removal_options = ["—"] + sorted(po)
+        selected_remove = st.selectbox("Remove object", removal_options, index=0)
+        if selected_remove != "—" and st.button("Remove Selected Object"):
+            po.pop(selected_remove, None)
+
+    # Render current mapping
+    if po:
+        df_po = pd.DataFrame({"object": list(po.keys()), "orb": list(po.values())})
+        st.dataframe(df_po, use_container_width=True, hide_index=True)
+    policy["per_object"] = po
+
+# ------------------------------ Actions ------------------------------------
+colA, colB, colC, colD = st.columns(4)
+with colA:
+    if st.button("Save", type="primary"):
+        try:
+            if is_new:
+                res = api.create_policy(sanitise_policy(policy, include_name=True))
+                st.success(f"Created policy #{res['id']}")
+            else:
+                res = api.update_policy(id_by_name[choice], sanitise_policy(policy, include_name=False))
+                st.success("Updated policy")
+        except Exception as e:
+            st.error(f"Save failed: {e}")
+with colB:
+    if not is_new and st.button("Delete", type="secondary"):
+        try:
+            api.delete_policy(id_by_name[choice])
+            st.success("Deleted policy. Reload the page to refresh list.")
+        except Exception as e:
+            st.error(f"Delete failed: {e}")
+with colC:
+    if not is_new and st.button("Duplicate"):
+        try:
+            clone = sanitise_policy(policy, include_name=True)
+            clone["name"] = f"{clone['name']}_copy"
+            res = api.create_policy(clone)
+            st.success(f"Duplicated as #{res['id']}")
+        except Exception as e:
+            st.error(f"Duplicate failed: {e}")
+with colD:
+    # Import/Export JSON
+    exp = json.dumps(sanitise_policy(policy, include_name=True), indent=2).encode("utf-8")
+    st.download_button("Export JSON", exp, file_name=f"orb_policy_{policy.get('name','unnamed')}.json", mime="application/json")
+    up = st.file_uploader("Import JSON", type=["json"], label_visibility="collapsed")
+    if up:
+        try:
+            policy.update(json.load(up))
+            st.experimental_rerun()
+        except Exception as e:
+            st.error(f"Invalid JSON: {e}")
+
+# ------------------------------ Preview: Severity Curve ---------------------
+st.subheader("Preview — Severity vs Orb")
+col1, col2, col3 = st.columns(3)
+default_aspect = "sextile" if "sextile" in available_aspects else available_aspects[0]
+asp = col1.selectbox("Aspect", available_aspects, index=available_aspects.index(default_aspect))
+limit = float(policy.get("per_aspect", {}).get(asp, 3.0))
+weights = DEFAULT_WEIGHTS  # placeholder; you can wire SeverityProfile later
+
+orbs = np.linspace(0.0, max(0.1, limit), 100)
+sevs = [sev_ui(asp, o, limit, weights) for o in orbs]
+fig = px.line(x=orbs, y=sevs, labels={"x":"orb (deg)", "y":"severity"}, title=f"{asp} — severity taper (limit={limit:.2f}°)")
+st.plotly_chart(fig, use_container_width=True, theme="streamlit")
+
+# ------------------------------ Preview: Sample Search ----------------------
+st.subheader("Preview — Sample Aspect Search (optional)")
+with st.expander("Run a quick 14‑day sample to see effect on hit counts/avg severity", expanded=False):
+    objs = st.multiselect("Objects", ["Sun","Moon","Mercury","Venus","Mars"], default=["Sun","Moon","Venus","Mars"])  # small set
+    step_minutes = st.slider("Step (minutes)", 5, 120, 60, 5)
+    if st.button("Run Sample Search"):
+        now = datetime.now(timezone.utc)
+        payload = {
+            "objects": objs,
+            "aspects": [asp],
+            "harmonics": [],
+            "window": {"start": (now).isoformat(), "end": (now + timedelta(days=14)).isoformat()},
+            "step_minutes": step_minutes,
+            "limit": 500,
+            "offset": 0,
+            "order_by": "time",
+            "orb_policy_inline": {
+                "per_object": policy.get("per_object", {}),
+                "per_aspect": policy.get("per_aspect", {}),
+                "adaptive_rules": policy.get("adaptive_rules", {}),
+            },
+        }
+        try:
+            data = api.aspects_search(payload)
+            hits = data.get("hits", [])
+            df = pd.DataFrame(hits)
+            if df.empty:
+                st.info("No hits in the sample window.")
+            else:
+                st.write(f"Found {len(df)} hits.")
+                st.dataframe(df[["exact_time","a","b","aspect","orb","severity"]], use_container_width=True, hide_index=True)
+        except Exception as e:
+            st.error(f"Sample search failed: {e}")


### PR DESCRIPTION
## Summary
- stop including the policy name in update requests from the Streamlit orb policy editor so the payload matches the API expectation
- add FastAPI/Pydantic dependencies and expose a legacy `RuleSetVersion` alias so repositories and tests use the updated ORM fields
- rebuild the aspect scanning core along with scan/synastry routers to emit structured metadata and align the API schema and tests with the new behavior

## Testing
- pytest
- pytest tests/test_api_aspects_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d81616ba9c8324ac1d7133c647a3d5