### PR TITLE
Add electional search API endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 
 from app.routers import (
     aspects_router,
+    electional_router,
     events_router,
     policies_router,
     rel_router,
@@ -16,6 +17,7 @@ from app.routers import (
 
 app = FastAPI(title="AstroEngine Plus API")
 app.include_router(aspects_router)
+app.include_router(electional_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
 app.include_router(rel_router)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,18 +1,46 @@
-
 """API routers for AstroEngine Plus services."""
 
-from .aspects import router as aspects_router
-from .events import router as events_router
-from .policies import router as policies_router
+from __future__ import annotations
 
-from .transits import router as transits_router
-
+from typing import Any
 
 __all__ = [
     "aspects_router",
+    "electional_router",
     "events_router",
     "policies_router",
     "rel_router",
     "transits_router",
 ]
 
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampoline
+    if name == "aspects_router":
+        from .aspects import router as aspects_router
+
+        return aspects_router
+    if name == "electional_router":
+        from .electional import router as electional_router
+
+        return electional_router
+    if name == "events_router":
+        from .events import router as events_router
+
+        return events_router
+    if name == "policies_router":
+        from .policies import router as policies_router
+
+        return policies_router
+    if name == "rel_router":
+        from .rel import router as rel_router
+
+        return rel_router
+    if name == "transits_router":
+        from .transits import router as transits_router
+
+        return transits_router
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - introspection helper
+    return sorted(__all__)

--- a/app/routers/electional.py
+++ b/app/routers/electional.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+from typing import Any, Dict
+from datetime import timezone
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.electional import (
+    ElectionalSearchRequest,
+    ElectionalSearchResponse,
+    WindowOut,
+    InstantOut,
+    InstantMatch,
+    InstantViolation,
+)
+from app.schemas.aspects import TimeWindow
+
+from core.electional_plus.engine import (
+    ElectionalRules,
+    AspectRule,
+    ForbiddenRule,
+    search_best_windows,
+)
+
+# Optional DB orb policy
+try:
+    from app.repo.orb_policies import OrbPolicyRepo  # type: ignore
+    from app.db.session import session_scope  # type: ignore
+except Exception:  # pragma: no cover
+    OrbPolicyRepo = None  # type: ignore
+    session_scope = None  # type: ignore
+
+# Provider injection reused from aspects
+from app.routers import aspects as aspects_module
+
+router = APIRouter(prefix="", tags=["Plus"])  # group under Plus
+
+DEFAULT_POLICY: Dict[str, Any] = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 3.0,
+    },
+    "adaptive_rules": {},
+}
+
+
+def _resolve_policy(inline, pid) -> Dict[str, Any]:
+    if inline is not None:
+        return inline.model_dump()
+    if pid is not None:
+        if OrbPolicyRepo is None or session_scope is None:
+            raise HTTPException(status_code=400, detail="orb_policy_id requires DB; provide orb_policy_inline instead")
+        with session_scope() as db:
+            rec = OrbPolicyRepo().get(db, pid)
+            if not rec:
+                raise HTTPException(status_code=404, detail="orb policy not found")
+            return {
+                "per_object": rec.per_object or {},
+                "per_aspect": rec.per_aspect or {},
+                "adaptive_rules": rec.adaptive_rules or {},
+            }
+    return DEFAULT_POLICY
+
+
+@router.post(
+    "/electional/search",
+    response_model=ElectionalSearchResponse,
+    summary="Search best electional windows",
+    description="Sliding‑window optimizer that ranks time windows by rules (required/forbidden aspects, VoC avoidance, time filters).",
+)
+def electional_search(req: ElectionalSearchRequest):
+    provider = aspects_module._get_provider()
+    policy = _resolve_policy(req.orb_policy_inline, req.orb_policy_id)
+
+    rules = ElectionalRules(
+        window=TimeWindow(start=req.window.start.astimezone(timezone.utc), end=req.window.end.astimezone(timezone.utc)),
+        window_minutes=req.window_minutes,
+        step_minutes=req.step_minutes,
+        top_k=req.top_k,
+        avoid_voc_moon=req.avoid_voc_moon,
+        allowed_weekdays=req.allowed_weekdays,
+        allowed_utc_ranges=req.allowed_utc_ranges,
+        orb_policy=policy,
+        required_aspects=[AspectRule(**r.model_dump()) for r in req.required_aspects],
+        forbidden_aspects=[ForbiddenRule(**r.model_dump()) for r in req.forbidden_aspects],
+    )
+
+    results = search_best_windows(rules, provider)
+
+    def _map_instant(I) -> InstantOut:
+        if isinstance(I, dict):
+            data = I
+        else:
+            data = {
+                "ts": getattr(I, "ts"),
+                "score": getattr(I, "score", 0.0),
+                "reason": getattr(I, "reason", None),
+                "matches": getattr(I, "matches", []),
+                "violations": getattr(I, "violations", []),
+            }
+        return InstantOut(
+            ts=data.get("ts"),
+            score=data.get("score", 0.0),
+            reason=data.get("reason"),
+            matches=[InstantMatch(**m) for m in data.get("matches", [])],
+            violations=[InstantViolation(**v) for v in data.get("violations", [])],
+        )
+
+    windows = [
+        WindowOut(
+            start=R.start,
+            end=R.end,
+            score=R.score,
+            samples=R.samples,
+            avg_score=R.avg_score,
+            top_instants=[_map_instant(i) for i in R.top_instants],
+            breakdown=R.breakdown,
+        )
+        for R in results
+    ]
+
+    return ElectionalSearchResponse(windows=windows, meta={"count": len(windows)})

--- a/app/schemas/electional.py
+++ b/app/schemas/electional.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from app.schemas.aspects import TimeWindow, OrbPolicyInline
+
+
+class AspectRuleIn(BaseModel):
+    a: str
+    b: str
+    aspects: List[str]
+    weight: float = 1.0
+    orb_override: Optional[float] = None
+
+
+class ForbiddenRuleIn(BaseModel):
+    a: str
+    b: str
+    aspects: List[str]
+    penalty: float = 1.0
+    orb_override: Optional[float] = None
+
+
+class ElectionalSearchRequest(BaseModel):
+    window: TimeWindow
+    window_minutes: int = Field(..., ge=15, le=60 * 24 * 14, description="Candidate window size in minutes")
+    step_minutes: int = Field(60, ge=1, le=720)
+    top_k: int = Field(3, ge=1, le=20)
+
+    avoid_voc_moon: bool = False
+    allowed_weekdays: Optional[List[int]] = Field(None, description="0=Mon .. 6=Sun")
+    allowed_utc_ranges: Optional[List[Tuple[str, str]]] = Field(None, description='e.g., [["08:00","22:00"]]')
+
+    orb_policy_id: Optional[int] = None
+    orb_policy_inline: Optional[OrbPolicyInline] = None
+
+    required_aspects: List[AspectRuleIn] = Field(default_factory=list)
+    forbidden_aspects: List[ForbiddenRuleIn] = Field(default_factory=list)
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "window": {"start": "2025-01-01T00:00:00Z", "end": "2025-03-01T00:00:00Z"},
+                "window_minutes": 24 * 60,
+                "step_minutes": 60,
+                "top_k": 3,
+                "avoid_voc_moon": True,
+                "allowed_weekdays": [0, 1, 2, 3, 4],
+                "allowed_utc_ranges": [["08:00", "22:00"]],
+                "orb_policy_inline": {"per_aspect": {"sextile": 3.0, "trine": 6.0, "conjunction": 8.0}},
+                "required_aspects": [
+                    {"a": "Mars", "b": "Venus", "aspects": ["sextile", "trine"], "weight": 1.0}
+                ],
+                "forbidden_aspects": [
+                    {"a": "Moon", "b": "Saturn", "aspects": ["square", "opposition"], "penalty": 1.0}
+                ],
+            }
+        }
+
+
+class InstantMatch(BaseModel):
+    pair: str
+    aspect: str
+    orb: float
+    limit: float
+    score: Optional[float] = None
+
+
+class InstantViolation(BaseModel):
+    pair: str
+    aspect: str
+    orb: float
+    limit: float
+    penalty: Optional[float] = None
+
+
+class InstantOut(BaseModel):
+    ts: datetime
+    score: float
+    reason: Optional[str] = None
+    matches: List[InstantMatch] = Field(default_factory=list)
+    violations: List[InstantViolation] = Field(default_factory=list)
+
+
+class WindowOut(BaseModel):
+    start: datetime
+    end: datetime
+    score: float
+    samples: int
+    avg_score: float
+    top_instants: List[InstantOut]
+    breakdown: Dict[str, Any]
+
+
+class ElectionalSearchResponse(BaseModel):
+    windows: List[WindowOut]
+    meta: Dict[str, Any] = Field(default_factory=dict)

--- a/astroengine/core/electional_plus/__init__.py
+++ b/astroengine/core/electional_plus/__init__.py
@@ -1,0 +1,21 @@
+"""Electional planning utilities exposed under the ``astroengine.core`` namespace."""
+
+from __future__ import annotations
+
+from .engine import (
+    AspectRule,
+    ElectionalRules,
+    ForbiddenRule,
+    InstantResult,
+    WindowResult,
+    search_best_windows,
+)
+
+__all__ = [
+    "AspectRule",
+    "ElectionalRules",
+    "ForbiddenRule",
+    "InstantResult",
+    "WindowResult",
+    "search_best_windows",
+]

--- a/astroengine/core/electional_plus/engine.py
+++ b/astroengine/core/electional_plus/engine.py
@@ -1,0 +1,351 @@
+"""Electional window scoring engine used by REST and UI layers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+PositionProvider = Callable[[datetime], Mapping[str, float]]
+
+_ASPECT_ANGLES: Dict[str, float] = {
+    "conjunction": 0.0,
+    "opposition": 180.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "sextile": 60.0,
+    "quincunx": 150.0,
+    "semisquare": 45.0,
+    "sesquisquare": 135.0,
+    "quintile": 72.0,
+    "biquintile": 144.0,
+}
+
+_MAJOR_ASPECTS: Tuple[str, ...] = (
+    "conjunction",
+    "opposition",
+    "square",
+    "trine",
+    "sextile",
+)
+
+
+def _norm360(value: float) -> float:
+    return value % 360.0
+
+
+def _angle_delta(a: float, b: float) -> float:
+    return (a - b + 180.0) % 360.0 - 180.0
+
+
+def _angle_distance(a: float, b: float) -> float:
+    return abs(_angle_delta(a, b))
+
+
+def _sample_range(start: datetime, end: datetime, step_minutes: int) -> Sequence[datetime]:
+    if step_minutes <= 0:
+        raise ValueError("step_minutes must be positive")
+    samples: List[datetime] = []
+    delta = timedelta(minutes=step_minutes)
+    cursor = start
+    while cursor <= end:
+        samples.append(cursor)
+        cursor = cursor + delta
+    if samples[-1] != end:
+        samples.append(end)
+    return samples
+
+
+def _parse_ranges(ranges: Optional[List[Tuple[str, str]]]) -> List[Tuple[int, int]]:
+    parsed: List[Tuple[int, int]] = []
+    if not ranges:
+        return parsed
+    for start_s, end_s in ranges:
+        sh, sm = [int(part) for part in start_s.split(":", 1)]
+        eh, em = [int(part) for part in end_s.split(":", 1)]
+        parsed.append((sh * 60 + sm, eh * 60 + em))
+    return parsed
+
+
+def _minute_of_day(ts: datetime) -> int:
+    return ts.hour * 60 + ts.minute
+
+
+def _in_ranges(minute: int, ranges: Sequence[Tuple[int, int]]) -> bool:
+    if not ranges:
+        return True
+    for start, end in ranges:
+        if start <= end:
+            if start <= minute < end:
+                return True
+        else:  # Wraps midnight
+            if minute >= start or minute < end:
+                return True
+    return False
+
+
+@dataclass(slots=True)
+class AspectRule:
+    a: str
+    b: str
+    aspects: Sequence[str]
+    weight: float = 1.0
+    orb_override: float | None = None
+
+
+@dataclass(slots=True)
+class ForbiddenRule:
+    a: str
+    b: str
+    aspects: Sequence[str]
+    penalty: float = 1.0
+    orb_override: float | None = None
+
+
+@dataclass(slots=True)
+class ElectionalRules:
+    window: Any
+    window_minutes: int
+    step_minutes: int
+    top_k: int
+    avoid_voc_moon: bool = False
+    allowed_weekdays: Optional[Sequence[int]] = None
+    allowed_utc_ranges: Optional[List[Tuple[str, str]]] = None
+    orb_policy: Optional[Dict[str, Any]] = None
+    required_aspects: Sequence[AspectRule] = field(default_factory=list)
+    forbidden_aspects: Sequence[ForbiddenRule] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class InstantResult:
+    ts: datetime
+    score: float
+    reason: str | None = None
+    matches: List[Dict[str, Any]] = field(default_factory=list)
+    violations: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class WindowResult:
+    start: datetime
+    end: datetime
+    score: float
+    samples: int
+    avg_score: float
+    top_instants: List[InstantResult]
+    breakdown: Dict[str, Any] = field(default_factory=dict)
+
+
+def _gather_objects(rules: ElectionalRules) -> List[str]:
+    objs: set[str] = set()
+    for rule in list(rules.required_aspects) + list(rules.forbidden_aspects):
+        objs.add(rule.a)
+        objs.add(rule.b)
+    objs.add("Moon")
+    return sorted(objs)
+
+
+def _is_voc(positions: Mapping[str, float], per_aspect: Mapping[str, float], default_orb: float, others: Iterable[str]) -> bool:
+    moon = positions.get("Moon")
+    if moon is None:
+        raise KeyError("Moon position missing from provider output")
+    for obj in others:
+        if obj == "Moon":
+            continue
+        other_pos = positions.get(obj)
+        if other_pos is None:
+            continue
+        separation = _norm360(moon - other_pos)
+        for aspect_name in _MAJOR_ASPECTS:
+            angle = _ASPECT_ANGLES.get(aspect_name)
+            if angle is None:
+                continue
+            orb = float(per_aspect.get(aspect_name, default_orb))
+            if _angle_distance(separation, angle) <= orb:
+                return False
+    return True
+
+
+def _evaluate_required(
+    rule: AspectRule,
+    positions: Mapping[str, float],
+    per_aspect: Mapping[str, float],
+    default_orb: float,
+) -> Tuple[float, List[Dict[str, Any]]]:
+    pa = positions.get(rule.a)
+    pb = positions.get(rule.b)
+    if pa is None or pb is None:
+        return 0.0, []
+    separation = _norm360(pa - pb)
+    best_score = 0.0
+    best: Dict[str, Any] | None = None
+    for aspect_name in rule.aspects:
+        angle = _ASPECT_ANGLES.get(aspect_name)
+        if angle is None:
+            continue
+        orb_limit = rule.orb_override if rule.orb_override is not None else float(per_aspect.get(aspect_name, default_orb))
+        if orb_limit <= 0:
+            continue
+        delta = _angle_distance(separation, angle)
+        if delta <= orb_limit:
+            closeness = max(0.0, 1.0 - delta / orb_limit)
+            score = rule.weight * closeness
+            if score > best_score:
+                best_score = score
+                best = {
+                    "pair": f"{rule.a}-{rule.b}",
+                    "aspect": aspect_name,
+                    "orb": delta,
+                    "limit": orb_limit,
+                    "score": score,
+                }
+    if best is None:
+        return 0.0, []
+    return best_score, [best]
+
+
+def _evaluate_forbidden(
+    rule: ForbiddenRule,
+    positions: Mapping[str, float],
+    per_aspect: Mapping[str, float],
+    default_orb: float,
+) -> Tuple[float, List[Dict[str, Any]]]:
+    pa = positions.get(rule.a)
+    pb = positions.get(rule.b)
+    if pa is None or pb is None:
+        return 0.0, []
+    separation = _norm360(pa - pb)
+    total_penalty = 0.0
+    hits: List[Dict[str, Any]] = []
+    for aspect_name in rule.aspects:
+        angle = _ASPECT_ANGLES.get(aspect_name)
+        if angle is None:
+            continue
+        orb_limit = rule.orb_override if rule.orb_override is not None else float(per_aspect.get(aspect_name, default_orb))
+        if orb_limit <= 0:
+            continue
+        delta = _angle_distance(separation, angle)
+        if delta <= orb_limit:
+            closeness = max(0.0, 1.0 - delta / orb_limit)
+            penalty = rule.penalty * closeness
+            total_penalty += penalty
+            hits.append(
+                {
+                    "pair": f"{rule.a}-{rule.b}",
+                    "aspect": aspect_name,
+                    "orb": delta,
+                    "limit": orb_limit,
+                    "penalty": penalty,
+                }
+            )
+    return total_penalty, hits
+
+
+def search_best_windows(rules: ElectionalRules, provider: PositionProvider) -> List[WindowResult]:
+    start = rules.window.start
+    end = rules.window.end
+    if start >= end:
+        return []
+
+    window_delta = timedelta(minutes=rules.window_minutes)
+    step_delta = timedelta(minutes=rules.step_minutes)
+    allowed_ranges = _parse_ranges(list(rules.allowed_utc_ranges) if rules.allowed_utc_ranges else None)
+    allowed_weekdays = set(rules.allowed_weekdays) if rules.allowed_weekdays is not None else None
+
+    per_aspect = (rules.orb_policy or {}).get("per_aspect", {})
+    default_orb = float((rules.orb_policy or {}).get("default", 3.0))
+
+    tracked_objects = _gather_objects(rules)
+
+    windows: List[WindowResult] = []
+
+    cursor = start
+    while cursor + window_delta <= end:
+        window_start = cursor
+        window_end = cursor + window_delta
+        samples = _sample_range(window_start, window_end, rules.step_minutes)
+
+        instants: List[InstantResult] = []
+        total_score = 0.0
+        match_count = 0
+        violation_count = 0
+
+        for ts in samples:
+            reason: str | None = None
+            if allowed_weekdays is not None and ts.weekday() not in allowed_weekdays:
+                reason = "weekday_filtered"
+
+            minute = _minute_of_day(ts)
+            if reason is None and not _in_ranges(minute, allowed_ranges):
+                reason = "utc_range_filtered"
+
+            positions = provider(ts)
+
+            if reason is None and rules.avoid_voc_moon:
+                if _is_voc(positions, per_aspect, default_orb, tracked_objects):
+                    reason = "void_of_course_moon"
+
+            matches: List[Dict[str, Any]] = []
+            violations: List[Dict[str, Any]] = []
+            score = 0.0
+
+            if reason is None:
+                for rule in rules.required_aspects:
+                    contribution, hits = _evaluate_required(rule, positions, per_aspect, default_orb)
+                    if hits:
+                        matches.extend(hits)
+                        score += contribution
+                for rule in rules.forbidden_aspects:
+                    penalty, hits = _evaluate_forbidden(rule, positions, per_aspect, default_orb)
+                    if hits:
+                        violations.extend(hits)
+                        score -= penalty
+                match_count += len(matches)
+                violation_count += len(violations)
+            else:
+                score = 0.0
+
+            instant = InstantResult(ts=ts, score=score, reason=reason, matches=matches, violations=violations)
+            instants.append(instant)
+            total_score += score
+
+        samples_count = len(instants)
+        avg_score = total_score / samples_count if samples_count else 0.0
+        top_sorted = sorted(instants, key=lambda item: item.score, reverse=True)
+        top_instants = top_sorted[: min(5, len(top_sorted))]
+        breakdown = {
+            "required_matches": match_count,
+            "forbidden_violations": violation_count,
+            "filters": {
+                "allowed_weekdays": sorted(allowed_weekdays) if allowed_weekdays is not None else None,
+                "allowed_utc_ranges": rules.allowed_utc_ranges,
+                "avoid_voc_moon": rules.avoid_voc_moon,
+            },
+        }
+
+        windows.append(
+            WindowResult(
+                start=window_start,
+                end=window_end,
+                score=total_score,
+                samples=samples_count,
+                avg_score=avg_score,
+                top_instants=top_instants,
+                breakdown=breakdown,
+            )
+        )
+
+        cursor += step_delta
+
+    windows.sort(key=lambda w: (-w.score, w.start))
+    return windows[: rules.top_k]
+
+
+__all__ = [
+    "AspectRule",
+    "ForbiddenRule",
+    "ElectionalRules",
+    "InstantResult",
+    "WindowResult",
+    "search_best_windows",
+]

--- a/core/electional_plus/__init__.py
+++ b/core/electional_plus/__init__.py
@@ -1,0 +1,16 @@
+"""Compatibility shim exposing :mod:`astroengine.core.electional_plus`."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+
+_base = import_module("astroengine.core.electional_plus")
+
+for name in getattr(_base, "__all__", []):
+    if hasattr(_base, name):
+        globals()[name] = getattr(_base, name)
+
+sys.modules[f"{__name__}.engine"] = import_module("astroengine.core.electional_plus.engine")
+
+__all__ = getattr(_base, "__all__", [])

--- a/tests/test_api_electional.py
+++ b/tests/test_api_electional.py
@@ -1,0 +1,87 @@
+from datetime import datetime, timedelta, timezone
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.electional import router as electional_router
+from app.routers import aspects as aspects_module
+
+
+# Synthetic ephemeris: linear motion
+class LinearEphemeris:
+    def __init__(self, t0, base, rates):
+        self.t0, self.base, self.rates = t0, base, rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {k: (self.base.get(k, 0.0) + self.rates.get(k, 0.0) * dt_days) % 360.0 for k in self.base}
+
+
+def build_app(provider=None):
+    app = FastAPI()
+    if provider is not None:
+        aspects_module.position_provider = provider
+        if hasattr(aspects_module, "_cached"):
+            aspects_module._cached = None
+    app.include_router(electional_router)
+    return app
+
+
+def test_electional_search_basic():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Mars": 10.0, "Venus": 70.0, "Moon": 0.0, "Sun": 0.0},
+        rates={"Mars": 0.2, "Venus": 1.0, "Moon": 13.0},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "window": {"start": t0.isoformat(), "end": (t0 + timedelta(days=40)).isoformat()},
+        "window_minutes": 24 * 60,  # 1 day
+        "step_minutes": 60,
+        "top_k": 2,
+        "avoid_voc_moon": False,
+        "allowed_weekdays": None,
+        "allowed_utc_ranges": [["06:00", "23:00"]],
+        "orb_policy_inline": {"per_aspect": {"sextile": 3.0, "trine": 6.0, "conjunction": 8.0}},
+        "required_aspects": [{"a": "Mars", "b": "Venus", "aspects": ["sextile"], "weight": 1.0}],
+        "forbidden_aspects": [],
+    }
+
+    r = client.post("/electional/search", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert "windows" in data and len(data["windows"]) >= 1
+    w0 = data["windows"][0]
+    for key in ("start", "end", "score", "avg_score", "samples", "top_instants", "breakdown"):
+        assert key in w0
+
+
+def test_electional_search_forbidden_penalty_and_voc_toggle():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Sun": 0.0, "Saturn": 180.0, "Moon": 0.0, "Mars": 10.0, "Venus": 70.0},
+        rates={"Sun": 0.0, "Saturn": 0.0, "Moon": 13.0},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "window": {"start": t0.isoformat(), "end": (t0 + timedelta(days=5)).isoformat()},
+        "window_minutes": 12 * 60,
+        "step_minutes": 120,
+        "top_k": 1,
+        "avoid_voc_moon": True,
+        "allowed_weekdays": None,
+        "allowed_utc_ranges": None,
+        "orb_policy_inline": {"per_aspect": {"opposition": 7.0, "conjunction": 8.0, "sextile": 3.0, "trine": 6.0}},
+        "required_aspects": [{"a": "Mars", "b": "Venus", "aspects": ["sextile", "trine"], "weight": 0.5}],
+        "forbidden_aspects": [{"a": "Moon", "b": "Saturn", "aspects": ["opposition"], "penalty": 1.0}],
+    }
+
+    r = client.post("/electional/search", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["windows"]) == 1


### PR DESCRIPTION
## Summary
- implement Pydantic DTOs for electional electional window scoring requests and responses
- add a FastAPI router for `/electional/search` that resolves orb policies and streams engine results
- provide the electional engine module plus compatibility shim and API tests covering the new endpoint

## Testing
- pytest -q tests/test_api_electional.py

------
https://chatgpt.com/codex/tasks/task_e_68d82593c50083249efb1922abb2c2ed