### PR TITLE
Add Arabic lots engine with catalog and unit tests

### DIFF
--- a/core/lots_plus/__init__.py
+++ b/core/lots_plus/__init__.py
@@ -1,0 +1,28 @@
+"""Arabic Lots engine and catalog utilities."""
+
+from .engine import eval_formula, norm360, deg_add, deg_sub
+from .catalog import (
+    LotDef,
+    Sect,
+    BUILTIN,
+    REGISTRY,
+    compute_lot,
+    compute_lots,
+    register_lot,
+    unregister_lot,
+)
+
+__all__ = [
+    "eval_formula",
+    "norm360",
+    "deg_add",
+    "deg_sub",
+    "LotDef",
+    "Sect",
+    "BUILTIN",
+    "REGISTRY",
+    "compute_lot",
+    "compute_lots",
+    "register_lot",
+    "unregister_lot",
+]

--- a/core/lots_plus/catalog.py
+++ b/core/lots_plus/catalog.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Iterable, Optional, Set
+
+from core.lots_plus.engine import eval_formula
+
+
+@dataclass
+class LotDef:
+    name: str
+    day: str  # expression for day sect
+    night: str  # expression for night sect
+    description: str = ""
+
+
+# Built-in catalog (ecliptic longitudes)
+# Conventional formulas (Hellenistic/medieval):
+#  Fortune  (Tyche):   day = Asc + Moon - Sun ; night = Asc + Sun - Moon
+#  Spirit   (Daimon):  day = Asc + Sun - Moon ; night = Asc + Moon - Sun
+#  Eros                day = Asc + Venus - Spirit ; night = Asc + Spirit - Venus
+#  Necessity           day = Asc + Spirit - Mercury ; night = Asc + Mercury - Spirit
+#  Victory (Nike)      day = Asc + Jupiter - Spirit ; night = Asc + Spirit - Jupiter
+BUILTIN: Dict[str, LotDef] = {
+    "Fortune": LotDef("Fortune", day="Asc + Moon - Sun", night="Asc + Sun - Moon", description="Part of Fortune (Tyche)"),
+    "Spirit": LotDef("Spirit", day="Asc + Sun - Moon", night="Asc + Moon - Sun", description="Part of Spirit (Daimon)"),
+    "Eros": LotDef("Eros", day="Asc + Venus - Spirit", night="Asc + Spirit - Venus", description="Part of Eros"),
+    "Necessity": LotDef("Necessity", day="Asc + Spirit - Mercury", night="Asc + Mercury - Spirit", description="Part of Necessity"),
+    "Victory": LotDef("Victory", day="Asc + Jupiter - Spirit", night="Asc + Spirit - Jupiter", description="Part of Victory (Nike)"),
+}
+
+# Runtime registry (starts with BUILTIN; can be extended)
+REGISTRY: Dict[str, LotDef] = dict(BUILTIN)
+
+
+def register_lot(defn: LotDef, overwrite: bool = False) -> None:
+    key = defn.name
+    if not overwrite and key in REGISTRY:
+        raise KeyError(f"Lot already exists: {key}")
+    REGISTRY[key] = defn
+
+
+def unregister_lot(name: str) -> None:
+    REGISTRY.pop(name, None)
+
+
+class Sect:
+    DAY = "day"
+    NIGHT = "night"
+
+
+def _extract_symbols(expr: str) -> Set[str]:
+    symbols: Set[str] = set()
+    for raw in expr.replace('+', ' ').replace('-', ' ').split():
+        token = raw.strip()
+        if not token:
+            continue
+        try:
+            float(token)
+        except ValueError:
+            if token.replace('_', '').isalnum():
+                symbols.add(token)
+    return symbols
+
+
+def compute_lot(name: str, pos: Dict[str, float], sect: str, _stack: Optional[Set[str]] = None) -> float:
+    if sect not in (Sect.DAY, Sect.NIGHT):
+        raise ValueError(f"Invalid sect: {sect}")
+    if name not in REGISTRY:
+        raise KeyError(f"Unknown lot: {name}")
+
+    stack = set() if _stack is None else set(_stack)
+    if name in stack:
+        raise ValueError(f"Circular lot dependency detected: {' -> '.join(list(stack) + [name])}")
+    stack.add(name)
+
+    lot = REGISTRY[name]
+    expr = lot.day if sect == Sect.DAY else lot.night
+
+    # Prepare a working copy of positions so we can inject dependent lot values.
+    working_pos = dict(pos)
+    for symbol in _extract_symbols(expr):
+        if symbol in working_pos or symbol == name:
+            continue
+        if symbol in REGISTRY:
+            working_pos[symbol] = compute_lot(symbol, pos, sect, stack)
+
+    return eval_formula(expr, working_pos)
+
+
+def compute_lots(names: Iterable[str], pos: Dict[str, float], sect: str) -> Dict[str, float]:
+    out: Dict[str, float] = {}
+    for n in names:
+        out[n] = compute_lot(n, pos, sect)
+    return out
+
+
+__all__ = [
+    "LotDef",
+    "BUILTIN",
+    "REGISTRY",
+    "register_lot",
+    "unregister_lot",
+    "Sect",
+    "compute_lot",
+    "compute_lots",
+]

--- a/core/lots_plus/engine.py
+++ b/core/lots_plus/engine.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, List, Tuple, Union
+
+Number = Union[int, float]
+
+# --------------------------- Angle utils -----------------------------------
+
+def norm360(x: float) -> float:
+    v = x % 360.0
+    return v + 360.0 if v < 0 else v
+
+
+def deg_add(a: float, b: float) -> float:
+    return norm360(float(a) + float(b))
+
+
+def deg_sub(a: float, b: float) -> float:
+    return norm360(float(a) - float(b))
+
+
+# --------------------------- Formula parser --------------------------------
+# Minimal DSL: tokens separated by space. Allowed tokens:
+#   - Symbol names: [A-Za-z0-9_]+ (e.g., Asc, Sun, Moon, Lot_Foo)
+#   - Numbers: 0..360 (floats allowed)
+#   - Operators: '+' '-'
+# Grammar: Expr := Term { ('+'|'-') Term }*
+# Term  := Symbol | Number
+
+@dataclass
+class Term:
+    kind: str  # 'sym' or 'num'
+    value: Union[str, float]
+
+
+def _tokenize(expr: str) -> List[str]:
+    # Allow arbitrary whitespace
+    parts = expr.replace("\t", " ").strip().split()
+    if not parts:
+        raise ValueError("Empty formula expression")
+    return parts
+
+
+def _parse(expr: str) -> List[Tuple[str, Term]]:
+    toks = _tokenize(expr)
+    out: List[Tuple[str, Term]] = []
+    op = '+'  # implicit leading '+'
+    expect_term = True
+    for tk in toks:
+        if expect_term:
+            # term
+            try:
+                val = float(tk)
+                term = Term('num', float(val))
+            except ValueError:
+                # symbol
+                if not tk.replace('_', '').isalnum():
+                    raise ValueError(f"Invalid symbol: {tk}")
+                term = Term('sym', tk)
+            out.append((op, term))
+            expect_term = False
+        else:
+            # operator
+            if tk not in ('+', '-'):
+                raise ValueError(f"Expected operator '+/-', got: {tk}")
+            op = tk
+            expect_term = True
+    if expect_term:
+        raise ValueError("Formula ended with operator; missing term")
+    return out
+
+
+def eval_formula(expr: str, pos: Dict[str, float]) -> float:
+    """Evaluate an expression at positions `pos`.
+    Unknown symbols raise KeyError.
+    """
+    seq = _parse(expr)
+    acc = 0.0
+    for op, term in seq:
+        if term.kind == 'num':
+            val = float(term.value)
+        else:
+            name = str(term.value)
+            if name not in pos:
+                raise KeyError(f"Missing symbol in positions: {name}")
+            val = float(pos[name])
+        acc = deg_add(acc, val) if op == '+' else deg_sub(acc, val)
+    return norm360(acc)
+
+
+__all__ = [
+    "Number",
+    "norm360",
+    "deg_add",
+    "deg_sub",
+    "Term",
+    "eval_formula",
+]

--- a/tests/test_lots_engine.py
+++ b/tests/test_lots_engine.py
@@ -1,0 +1,64 @@
+from core.lots_plus.engine import eval_formula, norm360
+from core.lots_plus.catalog import compute_lot, compute_lots, LotDef, register_lot, Sect
+
+
+def test_eval_formula_basic_and_wrap():
+    pos = {"Asc": 350.0, "Sun": 10.0, "Moon": 20.0}
+    # 350 + 20 - 10 = 360 → 0
+    val = eval_formula("Asc + Moon - Sun", pos)
+    assert abs(val - 0.0) < 1e-9
+
+
+def test_fortune_and_spirit_day_night():
+    pos = {"Asc": 100.0, "Sun": 10.0, "Moon": 70.0}
+    # Day: Fortune = 100 + 70 - 10 = 160
+    f_day = compute_lot("Fortune", pos, Sect.DAY)
+    assert abs(f_day - 160.0) < 1e-9
+    # Night: Fortune = 100 + 10 - 70 = 40
+    f_night = compute_lot("Fortune", pos, Sect.NIGHT)
+    assert abs(f_night - 40.0) < 1e-9
+
+    # Spirit swaps Sun/Moon relative to Fortune
+    s_day = compute_lot("Spirit", pos, Sect.DAY)   # 100 + 10 - 70 = 40
+    s_night = compute_lot("Spirit", pos, Sect.NIGHT)  # 100 + 70 - 10 = 160
+    assert abs(s_day - 40.0) < 1e-9 and abs(s_night - 160.0) < 1e-9
+
+
+def test_dependent_lot_resolution():
+    # Eros references Spirit; ensure dependency resolves once
+    pos = {"Asc": 100.0, "Sun": 10.0, "Moon": 70.0, "Venus": 20.0}
+    # Spirit(day) = 100 + 10 - 70 = 40 ; Eros(day) = 100 + 20 - Spirit = 80
+    val = compute_lot("Eros", pos, Sect.DAY)
+    assert abs(val - 80.0) < 1e-9
+
+
+def test_compute_lots_batch():
+    pos = {"Asc": 210.0, "Sun": 120.0, "Moon": 300.0}
+    results = compute_lots(["Fortune", "Spirit"], pos, Sect.DAY)
+    assert set(results.keys()) == {"Fortune", "Spirit"}
+    assert abs(results["Fortune"] - 30.0) < 1e-9
+    assert abs(results["Spirit"] - 30.0) < 1e-9
+
+
+def test_custom_lot_registration():
+    # Lot of Test := Asc + 15 - Sun
+    from core.lots_plus.catalog import REGISTRY
+
+    name = "LotOfTest"
+    if name in REGISTRY:
+        REGISTRY.pop(name)
+    register_lot(LotDef(name=name, day="Asc + 15 - Sun", night="Asc + 15 - Sun", description="Test lot"))
+
+    pos = {"Asc": 200.0, "Sun": 10.0}
+    val = compute_lot(name, pos, Sect.DAY)
+    assert abs(val - 205.0) < 1e-9
+
+
+def test_invalid_sect_raises():
+    pos = {"Asc": 100.0, "Sun": 10.0, "Moon": 70.0}
+    try:
+        compute_lot("Fortune", pos, "dawn")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for invalid sect")


### PR DESCRIPTION
## Summary
- add a reusable lots_plus module that evaluates Arabic lot formulas
- provide a built-in catalog with sect-aware Fortune, Spirit, and related lots plus registration utilities
- cover the engine with unit tests for formula wrap-around, dependencies, and custom registrations

## Testing
- pytest -q tests/test_lots_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68d827c8ed6c83248065b38ad9aa25bc