### PR TITLE
Add Arabic lots API endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,25 +5,26 @@ from __future__ import annotations
 
 from fastapi import FastAPI
 
-
 from app.routers import (
     aspects_router,
-
     electional_router,
     events_router,
-
+    lots_router,
     policies_router,
-
+    transits_router,
+)
+from app.routers.aspects import (  # re-exported for convenience
+    clear_position_provider,
+    configure_position_provider,
 )
 
 app = FastAPI(title="AstroEngine Plus API")
 app.include_router(aspects_router)
 app.include_router(electional_router)
+app.include_router(events_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
-
-app.include_router(aspects_router)
-
+app.include_router(lots_router)
 
 
 __all__ = ["app", "configure_position_provider", "clear_position_provider"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "events_router",
 
     "policies_router",
+    "lots_router",
     "configure_position_provider",
     "clear_position_provider",
 ]
@@ -29,6 +30,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .events import router as events_router
 
         return events_router
+    if name == "lots_router":
+        from .lots import router as lots_router
+
+        return lots_router
     if name == "policies_router":
         from .policies import router as policies_router
 

--- a/app/routers/lots.py
+++ b/app/routers/lots.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.lots import (
+    LotDefIn,
+    LotDefOut,
+    LotsCatalogResponse,
+    LotsComputeRequest,
+    LotsComputeResponse,
+)
+from core.lots_plus.catalog import (
+    REGISTRY,
+    LotDef,
+    Sect,
+    compute_lots,
+    register_lot,
+)
+
+router = APIRouter(prefix="", tags=["Plus"])
+
+
+@router.get("/lots/catalog", response_model=LotsCatalogResponse, summary="List Arabic Lots catalog")
+def lots_catalog():
+    items: List[LotDefOut] = []
+    for name, lot in REGISTRY.items():
+        items.append(
+            LotDefOut(
+                name=name,
+                day=lot.day,
+                night=lot.night,
+                description=lot.description or "",
+            )
+        )
+    items.sort(key=lambda x: x.name.lower())
+    return LotsCatalogResponse(lots=items, meta={"count": len(items)})
+
+
+def _persist_custom_lots(custom_lots: List[LotDefIn]) -> Dict[str, LotDef]:
+    """Register inline lots without committing them to the runtime registry."""
+
+    temp_registry: Dict[str, LotDef] = {}
+    for c in custom_lots:
+        if not c.name or not c.day or not c.night:
+            raise HTTPException(
+                status_code=400,
+                detail="custom_lots entries require name/day/night",
+            )
+        definition = LotDef(
+            name=c.name,
+            day=c.day,
+            night=c.night,
+            description=c.description or "",
+        )
+        if c.register:
+            try:
+                register_lot(definition, overwrite=False)
+            except KeyError as exc:  # duplicate names
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+        else:
+            temp_registry[definition.name] = definition
+    return temp_registry
+
+
+@router.post(
+    "/lots/compute",
+    response_model=LotsComputeResponse,
+    summary="Compute Arabic Lots (built-in + optional custom)",
+    description=(
+        "Evaluates requested Lots with sect-aware formulas. Optionally include inline "
+        "custom lots; set register=true to add to the runtime catalog."
+    ),
+)
+def lots_compute(req: LotsComputeRequest):
+    temp_defs: Dict[str, LotDef] = {}
+    custom_names: List[str] = []
+
+    if req.custom_lots:
+        temp_defs = _persist_custom_lots(req.custom_lots)
+        custom_names = [c.name for c in req.custom_lots]
+
+    names = list(dict.fromkeys([*(req.lots or []), *custom_names]))
+    if not names:
+        raise HTTPException(status_code=400, detail="No lots requested")
+
+    to_cleanup: List[str] = []
+    for name, definition in temp_defs.items():
+        if name in REGISTRY:
+            raise HTTPException(status_code=400, detail=f"Lot already exists: {name}")
+        REGISTRY[name] = definition
+        to_cleanup.append(name)
+
+    try:
+        sect = Sect.DAY if req.sect == "day" else Sect.NIGHT
+        vals = compute_lots(names, req.positions, sect)
+    except (KeyError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    finally:
+        for name in to_cleanup:
+            REGISTRY.pop(name, None)
+
+    return LotsComputeResponse(positions=vals, meta={"sect": req.sect, "count": len(vals)})
+

--- a/app/schemas/lots.py
+++ b/app/schemas/lots.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class LotDefIn(BaseModel):
+    name: str
+    day: str
+    night: str
+    description: Optional[str] = ""
+    register_flag: bool = Field(default=False, alias="register")
+    model_config = ConfigDict(populate_by_name=True)
+
+    @property
+    def register(self) -> bool:
+        return self.register_flag
+
+
+class LotsComputeRequest(BaseModel):
+    positions: Dict[str, float] = Field(
+        ..., description="Symbol → longitude deg; include Asc, Sun, Moon as needed"
+    )
+    lots: List[str] = Field(default_factory=lambda: ["Fortune", "Spirit"])
+    sect: Literal["day", "night"]
+    custom_lots: Optional[List[LotDefIn]] = None
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "positions": {
+                    "Asc": 100.0,
+                    "Sun": 10.0,
+                    "Moon": 70.0,
+                    "Venus": 20.0,
+                    "Jupiter": 200.0,
+                },
+                "lots": ["Fortune", "Spirit", "Eros"],
+                "sect": "day",
+                "custom_lots": [
+                    {
+                        "name": "LotOfTest",
+                        "day": "Asc + 15 - Sun",
+                        "night": "Asc + 15 - Sun",
+                        "register": False,
+                    }
+                ],
+            }
+        }
+    )
+
+
+class LotsComputeResponse(BaseModel):
+    positions: Dict[str, float]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class LotDefOut(BaseModel):
+    name: str
+    day: str
+    night: str
+    description: str = ""
+
+
+class LotsCatalogResponse(BaseModel):
+    lots: List[LotDefOut]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+

--- a/tests/test_api_lots.py
+++ b/tests/test_api_lots.py
@@ -1,0 +1,74 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.lots import router as lots_router
+
+
+def build_app():
+    app = FastAPI()
+    app.include_router(lots_router)
+    return app
+
+
+def test_lots_catalog_lists_builtins():
+    app = build_app()
+    client = TestClient(app)
+    response = client.get("/lots/catalog")
+    assert response.status_code == 200
+    data = response.json()
+    names = [item["name"] for item in data["lots"]]
+    assert "Fortune" in names and "Spirit" in names
+
+
+def test_compute_fortune_day_and_custom_inline():
+    app = build_app()
+    client = TestClient(app)
+
+    payload = {
+        "positions": {"Asc": 100.0, "Sun": 10.0, "Moon": 70.0},
+        "lots": ["Fortune", "Spirit"],
+        "sect": "day",
+        "custom_lots": [
+            {
+                "name": "LotOfTest",
+                "day": "Asc + 15 - Sun",
+                "night": "Asc + 15 - Sun",
+                "register": False,
+            }
+        ],
+    }
+
+    response = client.post("/lots/compute", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+
+    assert abs(data["positions"]["Fortune"] - 160.0) < 1e-9
+    assert abs(data["positions"]["Spirit"] - 40.0) < 1e-9
+
+
+def test_register_custom_lot_persists_for_catalog():
+    app = build_app()
+    client = TestClient(app)
+
+    payload = {
+        "positions": {"Asc": 200.0, "Sun": 10.0},
+        "lots": ["LotOfPersist"],
+        "sect": "day",
+        "custom_lots": [
+            {
+                "name": "LotOfPersist",
+                "day": "Asc + 15 - Sun",
+                "night": "Asc + 15 - Sun",
+                "register": True,
+            }
+        ],
+    }
+
+    response = client.post("/lots/compute", json=payload)
+    assert response.status_code == 200
+
+    response_catalog = client.get("/lots/catalog")
+    assert response_catalog.status_code == 200
+    names = [item["name"] for item in response_catalog.json()["lots"]]
+    assert "LotOfPersist" in names
+


### PR DESCRIPTION
## Summary
- add schemas and FastAPI router for Arabic Lots compute and catalog endpoints
- register the lots router in the application and router package exports
- add API tests covering built-in lots, inline custom lots, and runtime registration

## Testing
- pytest -q tests/test_api_lots.py

------
https://chatgpt.com/codex/tasks/task_e_68d828da739c8324b9c42b8a0955f8aa