### PR TITLE
Add SVG chart wheel renderer and aspect grid helpers

### DIFF
--- a/core/viz_plus/__init__.py
+++ b/core/viz_plus/__init__.py
@@ -1,0 +1,12 @@
+"""Visualization utilities for SVG-based chart wheels and aspect grids."""
+
+from .wheel_svg import render_chart_wheel, build_aspect_hits, WheelOptions
+from .aspect_grid import render_aspect_grid, aspect_grid_symbols
+
+__all__ = [
+    "render_chart_wheel",
+    "build_aspect_hits",
+    "WheelOptions",
+    "render_aspect_grid",
+    "aspect_grid_symbols",
+]

--- a/core/viz_plus/aspect_grid.py
+++ b/core/viz_plus/aspect_grid.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from typing import Dict, Iterable, List
+
+from core.viz_plus.wheel_svg import build_aspect_hits
+
+ASPECT_SYMBOLS = {
+    "conjunction": "☌",
+    "opposition": "☍",
+    "trine": "△",
+    "square": "□",
+    "sextile": "✶",
+    "quincunx": "⚻",
+}
+
+
+def render_aspect_grid(hits: List[Dict]) -> Dict[str, Dict[str, str]]:
+    grid: Dict[str, Dict[str, str]] = {}
+    for h in hits:
+        a = h["a"]
+        b = h["b"]
+        grid.setdefault(a, {})[b] = h["aspect"]
+    return grid
+
+
+def aspect_grid_symbols(positions: Dict[str, float], aspects: Iterable[str], policy: Dict) -> Dict[str, Dict[str, str]]:
+    hits = build_aspect_hits(positions, aspects, policy)
+    grid: Dict[str, Dict[str, str]] = {}
+    for h in hits:
+        a, b, asp = h["a"], h["b"], h["aspect"]
+        grid.setdefault(a, {})[b] = ASPECT_SYMBOLS.get(asp, asp)
+    return grid

--- a/core/viz_plus/wheel_svg.py
+++ b/core/viz_plus/wheel_svg.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional, Tuple
+import math
+
+from core.aspects_plus.harmonics import BASE_ASPECTS
+from core.aspects_plus.matcher import angular_sep_deg
+from core.aspects_plus.orb_policy import orb_limit
+
+# --------------------------- Helpers ---------------------------------------
+
+def _norm360(x: float) -> float:
+    v = x % 360.0
+    return v + 360.0 if v < 0 else v
+
+
+def _pol2cart(angle_deg: float, r: float, cx: float, cy: float) -> Tuple[float, float]:
+    # SVG 0° points to the right (x+), positive angles go **counterclockwise**
+    a = math.radians(angle_deg)
+    return cx + r * math.cos(a), cy - r * math.sin(a)
+
+
+def _lon_to_angle_svg(lon: float) -> float:
+    # Place 0° Aries at +X axis; increase CCW. Common in wheels.
+    return _norm360(0.0 - lon)
+
+
+@dataclass
+class WheelOptions:
+    size: int = 800
+    margin: int = 20
+    ring_outer: float = 0.48  # fraction of size
+    ring_inner: float = 0.36
+    show_degree_ticks: bool = True
+    show_house_lines: bool = True
+    show_aspects: bool = True
+    aspects: Iterable[str] = ("conjunction", "opposition", "square", "trine", "sextile")
+    policy: Optional[Dict] = None
+
+
+# --------------------------- Aspects (public helper) -----------------------
+
+def build_aspect_hits(positions: Dict[str, float], aspects: Iterable[str], policy: Dict) -> List[Dict]:
+    names = list(positions.keys())
+    hits: List[Dict] = []
+    for i, a in enumerate(names):
+        for j in range(i + 1, len(names)):
+            b = names[j]
+            delta = angular_sep_deg(positions[a], positions[b])
+            best = None
+            for asp in aspects:
+                ang = BASE_ASPECTS.get(asp.lower())
+                if ang is None:
+                    continue
+                orb = abs(delta - float(ang))
+                limit = orb_limit(a, b, asp.lower(), policy)
+                if orb <= limit + 1e-9:
+                    cand = {
+                        "a": a,
+                        "b": b,
+                        "aspect": asp.lower(),
+                        "angle": float(ang),
+                        "delta": float(delta),
+                        "orb": float(orb),
+                        "limit": float(limit),
+                    }
+                    if best is None or cand["orb"] < best["orb"]:
+                        best = cand
+            if best:
+                hits.append(best)
+    hits.sort(key=lambda h: (h["orb"], h["a"], h["b"]))
+    return hits
+
+
+# --------------------------- SVG wheel -------------------------------------
+
+def render_chart_wheel(
+    positions: Dict[str, float],
+    houses: Optional[List[float]] = None,
+    options: Optional[WheelOptions] = None,
+    aspects_hits: Optional[List[Dict]] = None,
+) -> str:
+    """Return an SVG string for a basic chart wheel.
+
+    - `positions`: name → longitude (deg)
+    - `houses`: list of 12 house cusp longitudes (optional)
+    - `options`: layout & visibility toggles
+    - `aspects_hits`: precomputed aspects (optional); if None and show_aspects=True, compute using options.aspects & options.policy
+    """
+    opt = options or WheelOptions()
+    size = opt.size
+    cx = cy = size / 2
+    outer_r = opt.ring_outer * size
+    inner_r = opt.ring_inner * size
+
+    svg: List[str] = []
+    def add(el: str):
+        svg.append(el)
+
+    add(f"<svg xmlns='http://www.w3.org/2000/svg' width='{size}' height='{size}' viewBox='0 0 {size} {size}'>")
+    add("<defs>\n<style><![CDATA[text{font-family:Inter,Arial,sans-serif;font-size:12px;dominant-baseline:middle}]]></style>\n</defs>")
+
+    # Outer/inner rings
+    add(f"<circle cx='{cx}' cy='{cy}' r='{outer_r}' fill='none' stroke='black' stroke-width='2' />")
+    add(f"<circle cx='{cx}' cy='{cy}' r='{inner_r}' fill='none' stroke='black' stroke-width='1' />")
+
+    # 12 signs (every 30 deg) and degree ticks
+    for k in range(12):
+        lon = k * 30.0
+        ang = _lon_to_angle_svg(lon)
+        x1, y1 = _pol2cart(ang, inner_r, cx, cy)
+        x2, y2 = _pol2cart(ang, outer_r, cx, cy)
+        add(f"<line x1='{x1:.2f}' y1='{y1:.2f}' x2='{x2:.2f}' y2='{y2:.2f}' stroke='black' stroke-width='1' />")
+        # Label (♈︎ .. labels omitted for simplicity; show 0°,30°,... instead)
+        lx, ly = _pol2cart(ang, outer_r + 16, cx, cy)
+        add(f"<text x='{lx:.2f}' y='{ly:.2f}' text-anchor='middle'>{int(lon)}°</text>")
+
+    if opt.show_degree_ticks:
+        for deg in range(0, 360, 5):
+            ang = _lon_to_angle_svg(deg)
+            r1 = outer_r - (8 if deg % 30 == 0 else 4)
+            x1, y1 = _pol2cart(ang, r1, cx, cy)
+            x2, y2 = _pol2cart(ang, outer_r, cx, cy)
+            add(f"<line x1='{x1:.2f}' y1='{y1:.2f}' x2='{x2:.2f}' y2='{y2:.2f}' stroke='black' stroke-width='0.5' opacity='0.6' />")
+
+    # House lines (if provided)
+    if opt.show_house_lines and houses and len(houses) >= 12:
+        for lon in houses[:12]:
+            ang = _lon_to_angle_svg(lon)
+            x1, y1 = _pol2cart(ang, inner_r, cx, cy)
+            x2, y2 = _pol2cart(ang, 0.05 * size, cx, cy)
+            add(f"<line x1='{x1:.2f}' y1='{y1:.2f}' x2='{x2:.2f}' y2='{y2:.2f}' stroke='gray' stroke-width='1' opacity='0.6' />")
+
+    # Aspect lines (optional)
+    if opt.show_aspects:
+        if aspects_hits is None:
+            policy = opt.policy or {
+                "per_object": {},
+                "per_aspect": {
+                    "conjunction": 8.0,
+                    "opposition": 7.0,
+                    "square": 6.0,
+                    "trine": 6.0,
+                    "sextile": 4.0,
+                },
+                "adaptive_rules": {},
+            }
+            aspects_hits = build_aspect_hits(positions, opt.aspects, policy)
+        for h in aspects_hits or []:
+            a_ang = _lon_to_angle_svg(positions[h["a"]])
+            b_ang = _lon_to_angle_svg(positions[h["b"]])
+            ax, ay = _pol2cart(a_ang, (inner_r + outer_r) / 2, cx, cy)
+            bx, by = _pol2cart(b_ang, (inner_r + outer_r) / 2, cx, cy)
+            add(f"<line x1='{ax:.2f}' y1='{ay:.2f}' x2='{bx:.2f}' y2='{by:.2f}' stroke='black' stroke-width='1' opacity='0.5' />")
+
+    # Planet markers (text labels on the outer ring)
+    for name, lon in positions.items():
+        ang = _lon_to_angle_svg(float(lon))
+        tx, ty = _pol2cart(ang, outer_r + 6, cx, cy)
+        add(f"<text x='{tx:.2f}' y='{ty:.2f}' text-anchor='middle'>{name}</text>")
+
+    add("</svg>")
+    return "".join(svg)

--- a/tests/test_chart_wheel_svg.py
+++ b/tests/test_chart_wheel_svg.py
@@ -1,0 +1,35 @@
+from core.viz_plus.wheel_svg import render_chart_wheel, build_aspect_hits, WheelOptions
+
+POLICY = {
+    "per_object": {},
+    "per_aspect": {
+        "square": 6.0,
+        "trine": 6.0,
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "sextile": 4.0,
+    },
+    "adaptive_rules": {},
+}
+
+
+def test_svg_wheel_basic_and_labels():
+    pos = {"Sun": 0.0, "Moon": 90.0, "Mars": 180.0}
+    svg = render_chart_wheel(pos, options=WheelOptions(show_aspects=False))
+    assert svg.startswith("<svg") and svg.endswith("</svg>")
+    assert "Sun" in svg and "Moon" in svg and "Mars" in svg
+    # check sign tick for 0° label exists
+    assert ">0°<" in svg
+
+
+def test_aspect_detection_square():
+    pos = {"Sun": 0.0, "Moon": 90.0}
+    hits = build_aspect_hits(pos, aspects=["square", "trine", "sextile"], policy=POLICY)
+    assert any(h["a"] == "Sun" and h["b"] == "Moon" and h["aspect"] == "square" for h in hits)
+
+
+def test_svg_with_aspect_lines():
+    pos = {"Sun": 0.0, "Moon": 90.0}
+    svg = render_chart_wheel(pos, options=WheelOptions(show_aspects=True, aspects=["square"], policy=POLICY))
+    # Should contain at least one line segment for an aspect
+    assert "opacity='0.5'" in svg


### PR DESCRIPTION
## Summary
- implement an SVG chart wheel renderer with optional aspect and house lines
- expose aspect matching helpers and grid renderers for downstream viewers
- add unit tests covering SVG output and aspect detection

## Testing
- pytest -q tests/test_chart_wheel_svg.py

------
https://chatgpt.com/codex/tasks/task_e_68d82a4a654c8324811fcd0a59f8de3e