### PR TITLE
Add fixed star catalog, aspects, and paran detection

### DIFF
--- a/astroengine/core/stars_plus/__init__.py
+++ b/astroengine/core/stars_plus/__init__.py
@@ -1,0 +1,34 @@
+"""Fixed-star utilities for AstroEngine."""
+
+from __future__ import annotations
+
+from .catalog import Star, load_catalog
+from .aspects import star_longitudes, find_star_aspects
+from .parans import Location, ParanPair, ParanEvent, detect_parans
+from .geometry import (
+    approximate_transit_times,
+    gmst_deg,
+    lst_deg,
+    mean_obliquity_deg,
+    norm360,
+    radec_to_ecliptic_lon_deg,
+    rise_set_hour_angle_deg,
+)
+
+__all__ = [
+    "Star",
+    "load_catalog",
+    "star_longitudes",
+    "find_star_aspects",
+    "Location",
+    "ParanPair",
+    "ParanEvent",
+    "detect_parans",
+    "approximate_transit_times",
+    "gmst_deg",
+    "lst_deg",
+    "mean_obliquity_deg",
+    "norm360",
+    "radec_to_ecliptic_lon_deg",
+    "rise_set_hour_angle_deg",
+]

--- a/astroengine/core/stars_plus/aspects.py
+++ b/astroengine/core/stars_plus/aspects.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+
+from astroengine.core.aspects_plus.harmonics import BASE_ASPECTS
+from astroengine.core.aspects_plus.matcher import angular_sep_deg
+from astroengine.core.aspects_plus.orb_policy import orb_limit
+
+from .catalog import Star
+from .geometry import mean_obliquity_deg, radec_to_ecliptic_lon_deg
+
+
+def star_longitudes(ts: datetime, stars: Dict[str, Star]) -> Dict[str, float]:
+    eps = mean_obliquity_deg(ts.astimezone(timezone.utc))
+    out: Dict[str, float] = {}
+    for name, s in stars.items():
+        out[name] = radec_to_ecliptic_lon_deg(s.ra_deg, s.dec_deg, eps)
+    return out
+
+
+def find_star_aspects(
+    ts: datetime,
+    planet_lons: Dict[str, float],
+    stars: Dict[str, Star],
+    aspects: Iterable[str],
+    policy: Dict,
+    mag_max: float = 2.5,
+    orb_per_star: Optional[Dict[str, float]] = None,
+) -> List[Dict]:
+    """Return star–planet hits at time ts.
+
+    `orb_per_star` overrides the policy orb limit per star (conjunction family, etc.).
+    """
+    star_lons = star_longitudes(ts, stars)
+    hits: List[Dict] = []
+    for sname, slon in star_lons.items():
+        s = stars[sname]
+        if s.vmag > mag_max:
+            continue
+        for bname, blon in planet_lons.items():
+            delta = angular_sep_deg(slon, blon)
+            best = None
+            for asp in aspects:
+                ang = BASE_ASPECTS.get(asp.lower())
+                if ang is None:
+                    continue
+                orb = abs(delta - float(ang))
+                # Prefer explicit star orb override, else fallback to policy
+                if orb_per_star and sname in orb_per_star:
+                    limit = float(orb_per_star[sname])
+                else:
+                    limit = orb_limit(sname, bname, asp.lower(), policy)
+                if orb <= limit + 1e-9:
+                    cand = {"star": sname, "vmag": s.vmag, "planet": bname, "aspect": asp.lower(), "angle": float(ang), "delta": float(delta), "orb": float(orb), "limit": float(limit)}
+                    if best is None or cand["orb"] < best["orb"]:
+                        best = cand
+            if best:
+                hits.append(best)
+    hits.sort(key=lambda h: (h["orb"], h["star"], h["planet"]))
+    return hits

--- a/astroengine/core/stars_plus/catalog.py
+++ b/astroengine/core/stars_plus/catalog.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Dict, Optional
+import csv
+
+@dataclass
+class Star:
+    name: str
+    ra_deg: float   # ICRS/J2000 RA in degrees
+    dec_deg: float  # ICRS/J2000 Dec in degrees
+    vmag: float
+    alias: Optional[str] = None
+
+# Minimal built-in catalog (J2000 approx)
+BUILTIN_STARS: Dict[str, Star] = {
+    "Sirius":   Star("Sirius",   ra_deg=101.2875, dec_deg=-16.7161, vmag=-1.46, alias="Alpha Canis Majoris"),
+    "Regulus":  Star("Regulus",  ra_deg=152.0933, dec_deg= 11.9672, vmag=1.35,  alias="Alpha Leonis"),
+    "Spica":    Star("Spica",    ra_deg=201.2983, dec_deg=-11.1614, vmag=1.04,  alias="Alpha Virginis"),
+    "Aldebaran":Star("Aldebaran",ra_deg= 68.9800, dec_deg= 16.5093, vmag=0.86,  alias="Alpha Tauri"),
+    "Antares":  Star("Antares",  ra_deg=247.3519, dec_deg=-26.4320, vmag=1.06,  alias="Alpha Scorpii"),
+    "Algol":    Star("Algol",    ra_deg= 47.0422, dec_deg= 40.9556, vmag=2.12,  alias="Beta Persei"),
+}
+
+
+def load_catalog(csv_path: Optional[str] = None) -> Dict[str, Star]:
+    if not csv_path:
+        return dict(BUILTIN_STARS)
+    out: Dict[str, Star] = {}
+    with open(csv_path, "r", newline="", encoding="utf-8") as f:
+        for row in csv.DictReader(f):
+            name = row.get("name") or row.get("Name")
+            ra = float(row.get("ra_deg") or row.get("ra"))
+            dec = float(row.get("dec_deg") or row.get("dec"))
+            vmag = float(row.get("vmag") or row.get("Vmag") or 99.9)
+            alias = row.get("alias") or row.get("Alias")
+            out[name] = Star(name=name, ra_deg=ra, dec_deg=dec, vmag=vmag, alias=alias)
+    return out

--- a/astroengine/core/stars_plus/geometry.py
+++ b/astroengine/core/stars_plus/geometry.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+import math
+from datetime import datetime, timedelta, timezone
+from typing import Dict
+
+# --------------------------- Angles & time ---------------------------------
+
+def norm360(x: float) -> float:
+    v = x % 360.0
+    return v + 360.0 if v < 0 else v
+
+
+def mean_obliquity_deg(ts: datetime) -> float:
+    # IAU 2006 approximation; good to <0.01° over modern times
+    # Source numeric: ε = 23°26′21.448″ − 46.8150″T − 0.00059″T^2 + 0.001813″T^3, T centuries from J2000
+    # We implement in degrees.
+    J2000 = datetime(2000, 1, 1, 12, tzinfo=timezone.utc)
+    T = (ts - J2000).total_seconds() / (36525.0 * 86400.0)
+    arcsec = 21.448 - 46.8150*T - 0.00059*(T**2) + 0.001813*(T**3)
+    deg = 23 + 26/60 + arcsec/3600.0
+    return deg
+
+
+# --------------------------- Coord transforms ------------------------------
+
+def radec_to_ecliptic_lon_deg(ra_deg: float, dec_deg: float, epsilon_deg: float) -> float:
+    ra = math.radians(ra_deg)
+    dec = math.radians(dec_deg)
+    eps = math.radians(epsilon_deg)
+    # tan λ = (sin α cos ε + tan δ sin ε) / cos α
+    num = math.sin(ra)*math.cos(eps) + math.tan(dec)*math.sin(eps)
+    den = math.cos(ra)
+    lam = math.degrees(math.atan2(num, den))
+    return norm360(lam)
+
+
+# --------------------------- Sidereal time ---------------------------------
+
+def gmst_deg(ts: datetime) -> float:
+    # Vallado-ish approximation for GMST in degrees
+    # Convert to Julian Date
+    def jd(dt: datetime) -> float:
+        y = dt.year; m = dt.month; d = dt.day
+        hr = dt.hour + dt.minute/60 + dt.second/3600 + dt.microsecond/3.6e9
+        if m <= 2:
+            y -= 1; m += 12
+        A = int(y/100); B = 2 - A + int(A/4)
+        JD = int(365.25*(y+4716)) + int(30.6001*(m+1)) + d + B - 1524.5 + hr/24.0
+        return JD
+    JD = jd(ts)
+    D = JD - 2451545.0
+    T = D / 36525.0
+    GMST = 280.46061837 + 360.98564736629*D + 0.000387933*T*T - (T*T*T)/38710000.0
+    return norm360(GMST)
+
+
+def lst_deg(ts: datetime, lon_deg_east: float) -> float:
+    return norm360(gmst_deg(ts) + lon_deg_east)
+
+
+# --------------------------- Rise/Set/Culmination --------------------------
+
+def rise_set_hour_angle_deg(phi_deg: float, dec_deg: float) -> float | None:
+    # cos H0 = -tan φ tan δ ; if |cosH0|>1: never rises/sets
+    phi = math.radians(phi_deg)
+    dec = math.radians(dec_deg)
+    cosH0 = -math.tan(phi) * math.tan(dec)
+    if abs(cosH0) > 1.0:
+        return None
+    H0 = math.degrees(math.acos(cosH0))
+    return H0  # in degrees; rising at -H0, setting at +H0
+
+
+def event_lst_deg(ra_deg: float, H_deg: float) -> float:
+    # LST = α + H (deg)
+    return norm360(ra_deg + H_deg)
+
+
+def refine_event_time(ts_guess: datetime, lon_east: float, target_lst_deg: float, max_iter: int = 6) -> datetime:
+    # Simple fixed-point iteration: LST(ts) ≈ target
+    ts = ts_guess
+    for _ in range(max_iter):
+        cur = lst_deg(ts, lon_east)
+        # convert difference (deg) to seconds using dLST/dt ≈ 360.9856°/sidereal day
+        delta_deg = (target_lst_deg - cur + 540) % 360 - 180
+        sec = delta_deg / 360.98564736629 * 86164.0905
+        ts = ts + timedelta(seconds=sec)
+    return ts
+
+
+def approximate_transit_times(date_utc: datetime, lon_east: float, ra_deg: float, dec_deg: float, phi_deg: float) -> Dict[str, datetime | None]:
+    # date_utc at 0h is reference. Compute LST0, then get LST targets for rise/set (if possible) and transit.
+    base = date_utc.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=timezone.utc)
+    H0 = rise_set_hour_angle_deg(phi_deg, dec_deg)
+    out: Dict[str, datetime | None] = {"rise": None, "set": None, "culminate": None}
+    # Culmination (upper transit): H=0 → LST=α
+    L_culm = event_lst_deg(ra_deg, 0.0)
+    guess = base + timedelta(hours=12)  # rough
+    out["culminate"] = refine_event_time(guess, lon_east, L_culm)
+    if H0 is not None:
+        # Rising: H = -H0 ; Setting: H = +H0
+        L_rise = event_lst_deg(ra_deg, -H0)
+        L_set = event_lst_deg(ra_deg, +H0)
+        out["rise"] = refine_event_time(base + timedelta(hours=6), lon_east, L_rise)
+        out["set"] = refine_event_time(base + timedelta(hours=18), lon_east, L_set)
+    return out

--- a/astroengine/core/stars_plus/parans.py
+++ b/astroengine/core/stars_plus/parans.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Iterable, List, Tuple
+
+from .catalog import Star
+from .geometry import approximate_transit_times
+
+PositionProvider = Callable[[datetime], Dict[str, float]]  # returns ecliptic longitudes for planets
+
+@dataclass
+class Location:
+    lat_deg: float
+    lon_east_deg: float  # east-positive
+
+@dataclass
+class ParanPair:
+    star_name: str
+    planet_name: str
+    star_event: str     # 'rise'|'set'|'culminate'
+    planet_event: str   # 'rise'|'set'|'culminate'
+
+@dataclass
+class ParanEvent:
+    kind: str
+    time: datetime
+    meta: Dict[str, object]
+
+
+def detect_parans(
+    date_start: datetime,
+    date_end: datetime,
+    location: Location,
+    stars: Dict[str, Star],
+    provider_radec: Callable[[datetime, str], Tuple[float, float]],  # planet → (RA,Dec) provider
+    pairs: Iterable[ParanPair],
+    tol_minutes: float = 8.0,
+    step_days: int = 1,
+) -> List[ParanEvent]:
+    """Scan dates [start,end] (UTC) for parans matching the `pairs` at `location`.
+
+    MVP: For each UTC date, compute star and planet event times (rise/set/culm) using their RA/Dec
+    and report matches when the absolute time difference ≤ tol_minutes.
+    """
+    out: List[ParanEvent] = []
+    cur = date_start.astimezone(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = date_end.astimezone(timezone.utc)
+
+    while cur <= end:
+        for pair in pairs:
+            star = stars.get(pair.star_name)
+            if not star:
+                continue
+            # Star events for this date
+            st_events = approximate_transit_times(cur, location.lon_east_deg, star.ra_deg, star.dec_deg, location.lat_deg)
+
+            # Planet RA/Dec at midday (approx across day)
+            mid = cur + timedelta(hours=12)
+            pra, pdec = provider_radec(mid, pair.planet_name)
+            pl_events = approximate_transit_times(cur, location.lon_east_deg, pra, pdec, location.lat_deg)
+
+            ts_star = st_events.get(pair.star_event)
+            ts_plan = pl_events.get(pair.planet_event)
+            if ts_star and ts_plan:
+                dt_min = abs((ts_star - ts_plan).total_seconds()) / 60.0
+                if dt_min <= tol_minutes:
+                    out.append(ParanEvent(
+                        kind="paran",
+                        time=ts_star if ts_star < ts_plan else ts_plan,
+                        meta={
+                            "star": pair.star_name,
+                            "planet": pair.planet_name,
+                            "star_event": pair.star_event,
+                            "planet_event": pair.planet_event,
+                            "dt_diff_min": dt_min,
+                        }
+                    ))
+        cur += timedelta(days=step_days)
+
+    out.sort(key=lambda e: e.time)
+    return out

--- a/core/stars_plus/__init__.py
+++ b/core/stars_plus/__init__.py
@@ -1,0 +1,24 @@
+"""Compatibility layer exposing ``astroengine.core.stars_plus`` under the ``core`` namespace."""
+
+from __future__ import annotations
+
+import sys
+from importlib import import_module
+
+_base = import_module("astroengine.core.stars_plus")
+
+for name in getattr(_base, "__all__", []):
+    if hasattr(_base, name):
+        globals()[name] = getattr(_base, name)
+
+for sub in [
+    "catalog",
+    "geometry",
+    "aspects",
+    "parans",
+]:
+    module = import_module(f"astroengine.core.stars_plus.{sub}")
+    sys.modules[f"{__name__}.{sub}"] = module
+    globals().setdefault(sub, module)
+
+__all__ = getattr(_base, "__all__", [])

--- a/tests/test_fixed_stars.py
+++ b/tests/test_fixed_stars.py
@@ -1,0 +1,48 @@
+from datetime import datetime, timedelta, timezone
+
+from core.stars_plus.catalog import load_catalog
+from core.stars_plus.geometry import radec_to_ecliptic_lon_deg, mean_obliquity_deg
+from core.stars_plus.aspects import find_star_aspects
+from core.stars_plus.parans import detect_parans, Location, ParanPair
+
+POLICY = {"per_object": {}, "per_aspect": {"conjunction": 1.0, "opposition": 1.0, "square": 1.0, "trine": 1.0, "sextile": 1.0}, "adaptive_rules": {}}
+
+
+def test_radec_to_ecliptic_basic():
+    ts = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eps = mean_obliquity_deg(ts)
+    # RA=0, Dec=0 → λ≈0
+    lam0 = radec_to_ecliptic_lon_deg(0.0, 0.0, eps)
+    assert abs(lam0 - 0.0) < 1e-6
+    # RA=90, Dec=0 → λ≈90
+    lam90 = radec_to_ecliptic_lon_deg(90.0, 0.0, eps)
+    assert abs(lam90 - 90.0) < 1e-6
+
+
+def test_star_aspect_square_synthetic():
+    ts = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    stars = load_catalog()
+    # Force a star with ecliptic longitude near 90 (use RA=90,Dec=0 by injecting temp star)
+    stars["TestStar"] = type("S", (), {"name":"TestStar","ra_deg":90.0,"dec_deg":0.0,"vmag":1.0})()
+    planet_lons = {"Sun": 0.0}
+    hits = find_star_aspects(ts, planet_lons, stars, aspects=["square"], policy=POLICY, mag_max=2.5)
+    assert any(h["star"] == "TestStar" and h["planet"] == "Sun" and h["aspect"] == "square" for h in hits)
+
+
+def test_paran_rise_culminate_equator_synthetic():
+    # Equator site, star RA=0,Dec=0 (rises at LST=-90°), planet culm when LST=planet RA
+    loc = Location(lat_deg=0.0, lon_east_deg=0.0)
+    stars = {"TestStar": type("S", (), {"name":"TestStar","ra_deg":0.0,"dec_deg":0.0,"vmag":1.0})()}
+
+    # Planet RA chosen so that its culmination coincides with star rising within tolerance
+    def provider_radec(ts, name):
+        return (270.0, 0.0)  # RA=270° so LST=270 matches star rising (α=0,H=-90 → LST=270)
+
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=1)
+    pairs = [ParanPair(star_name="TestStar", planet_name="Mercury", star_event="rise", planet_event="culminate")]
+
+    events = detect_parans(start, end, loc, stars, provider_radec, pairs, tol_minutes=10.0)
+    assert len(events) >= 1
+    e = events[0]
+    assert e.kind == "paran" and e.meta["star"] == "TestStar" and e.meta["planet"] == "Mercury"


### PR DESCRIPTION
## Summary
- add an initial fixed-star catalog with CSV loader and coordinate transforms
- implement star longitude/aspect utilities and basic paran detection APIs
- add unit tests covering ecliptic conversion, aspect matching, and paran timing

## Testing
- pytest -q tests/test_fixed_stars.py

------
https://chatgpt.com/codex/tasks/task_e_68d82d3e6d1c83248b5afa5790efce2b