### PR TITLE
Add composite and Davison relationship chart utilities

### DIFF
--- a/core/relationship_plus/__init__.py
+++ b/core/relationship_plus/__init__.py
@@ -1,0 +1,23 @@
+"""Relationship-focused composite and Davison chart utilities."""
+
+from .composite import (
+    Geo,
+    PositionProvider,
+    composite_positions,
+    davison_midpoints,
+    davison_positions,
+    midpoint_angle,
+    norm360,
+    delta_short,
+)
+
+__all__ = [
+    "Geo",
+    "PositionProvider",
+    "composite_positions",
+    "davison_midpoints",
+    "davison_positions",
+    "midpoint_angle",
+    "norm360",
+    "delta_short",
+]

--- a/core/relationship_plus/composite.py
+++ b/core/relationship_plus/composite.py
@@ -1,0 +1,172 @@
+"""Composite and Davison chart helpers.
+
+This module keeps the math utilities pure so they can be reused by API or UI
+layers without extra dependencies. All functions assume degrees for angles and
+UTC-aware datetimes when timestamps are provided.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Dict, Iterable, Tuple
+import math
+
+PositionProvider = Callable[[datetime], Dict[str, float]]
+
+
+# --------------------------- Angle utils -----------------------------------
+
+def norm360(value: float) -> float:
+    """Normalize an angle to the ``[0, 360)`` range."""
+
+    v = float(value) % 360.0
+    return v + 360.0 if v < 0 else v
+
+
+def delta_short(a: float, b: float) -> float:
+    """Signed smallest angular difference ``b - a`` in degrees in ``(-180, 180]``."""
+
+    d = (float(b) - float(a) + 540.0) % 360.0 - 180.0
+    # When ``a`` and ``b`` are exactly opposite, the modulo arithmetic produces
+    # ``-180``. For midpoint work we prefer the positive orientation so the
+    # midpoint lands halfway along the +180° arc.
+    if d <= -180.0:
+        return 180.0
+    return d
+
+
+def midpoint_angle(a: float, b: float) -> float:
+    """Circular midpoint along the shortest arc between ``a`` and ``b``."""
+
+    a = float(a)
+    d = delta_short(a, b)  # ``b`` relative to ``a``
+    return norm360(a + 0.5 * d)
+
+
+# --------------------------- Composite positions ---------------------------
+
+def composite_positions(
+    pos_a: Dict[str, float],
+    pos_b: Dict[str, float],
+    bodies: Iterable[str] | None = None,
+) -> Dict[str, float]:
+    """Return midpoint longitudes for bodies shared between ``pos_a`` and ``pos_b``.
+
+    Parameters
+    ----------
+    pos_a, pos_b:
+        Mappings from body name to ecliptic longitude in degrees.
+    bodies:
+        Optional iterable restricting which bodies to consider. Only entries
+        present in both position dictionaries are included in the result.
+    """
+
+    if bodies is None:
+        common = set(pos_a.keys()) & set(pos_b.keys())
+    else:
+        common = {key for key in bodies if key in pos_a and key in pos_b}
+
+    out: Dict[str, float] = {}
+    for key in sorted(common):
+        out[key] = midpoint_angle(pos_a[key], pos_b[key])
+    return out
+
+
+# --------------------------- Davison midpoints ------------------------------
+
+
+@dataclass(frozen=True)
+class Geo:
+    """Simple container for geographic latitude and longitude in degrees."""
+
+    lat_deg: float
+    lon_deg_east: float
+
+
+def _to_vec(lat_deg: float, lon_deg_east: float) -> Tuple[float, float, float]:
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg_east)
+    x = math.cos(lat) * math.cos(lon)
+    y = math.cos(lat) * math.sin(lon)
+    z = math.sin(lat)
+    return x, y, z
+
+
+def _from_vec(x: float, y: float, z: float) -> Tuple[float, float]:
+    hyp = math.hypot(x, y)
+    lat = math.degrees(math.atan2(z, hyp))
+    lon = math.degrees(math.atan2(y, x))
+    return lat, lon
+
+
+def spherical_midpoint(lat1: float, lon1: float, lat2: float, lon2: float) -> Tuple[float, float]:
+    """Return the great-circle midpoint on the unit sphere."""
+
+    x1, y1, z1 = _to_vec(lat1, lon1)
+    x2, y2, z2 = _to_vec(lat2, lon2)
+    xm, ym, zm = (x1 + x2) / 2.0, (y1 + y2) / 2.0, (z1 + z2) / 2.0
+
+    if xm == 0.0 and ym == 0.0 and zm == 0.0:
+        # Antipodal pair (or floating point degenerate) falls back to linear mean.
+        return (lat1 + lat2) / 2.0, (lon1 + lon2) / 2.0
+
+    return _from_vec(xm, ym, zm)
+
+
+def time_midpoint_utc(dt_a: datetime, dt_b: datetime) -> datetime:
+    """Return the midpoint between ``dt_a`` and ``dt_b`` expressed in UTC."""
+
+    a = dt_a.astimezone(timezone.utc) if dt_a.tzinfo else dt_a.replace(tzinfo=timezone.utc)
+    b = dt_b.astimezone(timezone.utc) if dt_b.tzinfo else dt_b.replace(tzinfo=timezone.utc)
+    t = (a.timestamp() + b.timestamp()) / 2.0
+    return datetime.fromtimestamp(t, tz=timezone.utc)
+
+
+def davison_midpoints(
+    dt_a: datetime,
+    loc_a: Geo,
+    dt_b: datetime,
+    loc_b: Geo,
+) -> Tuple[datetime, float, float]:
+    """Return the Davison midpoint timestamp, latitude, and longitude."""
+
+    mid_dt = time_midpoint_utc(dt_a, dt_b)
+    mid_lat, mid_lon = spherical_midpoint(
+        loc_a.lat_deg,
+        loc_a.lon_deg_east,
+        loc_b.lat_deg,
+        loc_b.lon_deg_east,
+    )
+    return mid_dt, mid_lat, mid_lon
+
+
+def davison_positions(
+    provider: PositionProvider,
+    dt_a: datetime,
+    loc_a: Geo,
+    dt_b: datetime,
+    loc_b: Geo,
+    bodies: Iterable[str] | None = None,
+) -> Dict[str, float]:
+    """Return body longitudes for the Davison chart at the time midpoint."""
+
+    mid_dt, _, _ = davison_midpoints(dt_a, loc_a, dt_b, loc_b)
+    positions = provider(mid_dt)
+    if bodies is None:
+        return dict(positions)
+    return {key: positions[key] for key in bodies if key in positions}
+
+
+__all__ = [
+    "Geo",
+    "PositionProvider",
+    "composite_positions",
+    "davison_midpoints",
+    "davison_positions",
+    "delta_short",
+    "midpoint_angle",
+    "norm360",
+    "spherical_midpoint",
+    "time_midpoint_utc",
+]

--- a/tests/test_relationship_composite.py
+++ b/tests/test_relationship_composite.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timezone, timedelta
+
+from core.relationship_plus.composite import (
+    Geo,
+    composite_positions,
+    davison_midpoints,
+    davison_positions,
+    delta_short,
+    midpoint_angle,
+    norm360,
+)
+
+
+class LinearEphemeris:
+    """Synthetic ephemeris used to validate Davison positions deterministically."""
+
+    def __init__(self, t0, base, rates):
+        self.t0 = t0
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            name: (self.base.get(name, 0.0) + self.rates.get(name, 0.0) * dt_days) % 360.0
+            for name in self.base
+        }
+
+
+def test_midpoint_wrap_short_arc():
+    # 350° and 10° midpoint should be 0°
+    m = midpoint_angle(350.0, 10.0)
+    assert abs(m - 0.0) < 1e-9
+    # 10° and 190° midpoint on shortest arc is 100° (Δ=+180 pick +180 by convention → 100)
+    m2 = midpoint_angle(10.0, 190.0)
+    assert abs(m2 - 100.0) < 1e-9
+
+
+def test_composite_positions_common_bodies():
+    pos_a = {"Sun": 350.0, "Moon": 20.0, "Mars": 100.0}
+    pos_b = {"Sun": 10.0, "Moon": 80.0, "Venus": 200.0}
+    composite = composite_positions(pos_a, pos_b)
+    assert set(composite.keys()) == {"Sun", "Moon"}
+    assert abs(composite["Sun"] - 0.0) < 1e-9  # wrap midpoint
+
+
+def test_davison_midpoints_and_positions():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    a_time = t0
+    b_time = t0 + timedelta(days=10)
+    a_loc = Geo(10.0, 20.0)
+    b_loc = Geo(-10.0, 40.0)
+
+    mid_dt, mid_lat, mid_lon = davison_midpoints(a_time, a_loc, b_time, b_loc)
+    assert mid_dt == t0 + timedelta(days=5)
+    # mid lat/lon should be finite numbers
+    assert abs(mid_lat) <= 90
+    assert abs(mid_lon) <= 180
+
+    eph = LinearEphemeris(
+        t0,
+        base={"Sun": 10.0, "Venus": 40.0},
+        rates={"Sun": 1.0, "Venus": 1.2},
+    )
+    pos = davison_positions(eph, a_time, a_loc, b_time, b_loc, bodies=["Sun", "Venus"])
+    # At mid_dt = t0+5d → Sun = 15°, Venus = 46°
+    assert abs(pos["Sun"] - 15.0) < 1e-9
+    assert abs(pos["Venus"] - 46.0) < 1e-9


### PR DESCRIPTION
## Summary
- add a dedicated `relationship_plus` package that exposes composite and Davison helpers
- implement midpoint, composite, and Davison calculations with pure-Python utilities
- cover the new helpers with deterministic unit tests backed by a synthetic linear ephemeris

## Testing
- pytest -q tests/test_relationship_composite.py

------
https://chatgpt.com/codex/tasks/task_e_68d830f5071c8324a080db85a1bf0102