### PR TITLE
Improve plus models compatibility and stabilize scans

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import enum
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Any
+from typing import Any, Dict, Optional
 
 from sqlalchemy import (
     Boolean,
@@ -103,6 +103,13 @@ class ExportType(str, enum.Enum):
 
 
 
+def _render_orb_policy_name(profile_key: str, body: str | None, aspect: str | None) -> str:
+    parts = [profile_key or "default"]
+    parts.append((body or "any").lower())
+    parts.append((aspect or "custom").lower())
+    return ":".join(parts)
+
+
 class OrbPolicy(ModuleScopeMixin, TimestampMixin, Base):
     """Aggregate orb policy definitions exposed via the Plus API."""
 
@@ -120,6 +127,43 @@ class OrbPolicy(ModuleScopeMixin, TimestampMixin, Base):
     per_object: Mapped[dict[str, float]] = mapped_column(JSON, nullable=False, default=dict)
     per_aspect: Mapped[dict[str, float]] = mapped_column(JSON, nullable=False, default=dict)
     adaptive_rules: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    profile_key: Mapped[str] = mapped_column(String(64), nullable=False, default="default")
+    body: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    aspect: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    orb_degrees: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    def __init__(self, **kwargs: Any) -> None:
+        profile_key = kwargs.pop("profile_key", None)
+        body = kwargs.pop("body", None)
+        aspect = kwargs.pop("aspect", None)
+        orb_degrees = kwargs.pop("orb_degrees", None)
+
+        per_object: Dict[str, float] = dict(kwargs.pop("per_object", {}) or {})
+        per_aspect: Dict[str, float] = dict(kwargs.pop("per_aspect", {}) or {})
+        adaptive_rules: Dict[str, Any] = dict(kwargs.pop("adaptive_rules", {}) or {})
+
+        orb_value: Optional[float] = None
+        if orb_degrees is not None:
+            try:
+                orb_value = float(orb_degrees)
+            except (TypeError, ValueError):
+                orb_value = None
+        if orb_value is not None:
+            if body:
+                per_object.setdefault(str(body), orb_value)
+            if aspect:
+                per_aspect.setdefault(str(aspect).lower(), orb_value)
+
+        kwargs.setdefault("name", _render_orb_policy_name(profile_key or "default", body, aspect))
+        kwargs["per_object"] = per_object
+        kwargs["per_aspect"] = per_aspect
+        kwargs["adaptive_rules"] = adaptive_rules
+        kwargs["profile_key"] = profile_key or "default"
+        kwargs["body"] = body
+        kwargs["aspect"] = aspect.lower() if isinstance(aspect, str) else aspect
+        kwargs["orb_degrees"] = orb_value
+
+        super().__init__(**kwargs)
 
 
 class SeverityProfile(ModuleScopeMixin, TimestampMixin, Base):
@@ -133,11 +177,22 @@ class SeverityProfile(ModuleScopeMixin, TimestampMixin, Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     name: Mapped[str] = mapped_column(String(64), nullable=False)
+    profile_key: Mapped[str] = mapped_column(String(64), nullable=False, default="default")
     weights: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     modifiers: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     events: Mapped[list["Event"]] = relationship(back_populates="severity_profile")
+
+    def __init__(self, **kwargs: Any) -> None:
+        profile_key = kwargs.pop("profile_key", None)
+        weights = kwargs.pop("weights", None)
+        if profile_key is not None:
+            kwargs["profile_key"] = profile_key
+        if weights is not None:
+            kwargs["weights"] = weights
+        kwargs.setdefault("name", f"{kwargs.get('profile_key', 'default')}_severity")
+        super().__init__(**kwargs)
 
 
 class Chart(ModuleScopeMixin, TimestampMixin, Base):
@@ -173,6 +228,31 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
         cascade="all, delete-orphan",
     )
 
+    def __init__(self, **kwargs: Any) -> None:
+        profile_key = kwargs.pop("profile_key", None)
+        if profile_key is not None:
+            kwargs["profile_key"] = profile_key
+        data = kwargs.pop("data", None)
+        if data is not None:
+            kwargs["data"] = data
+            if "kind" not in kwargs and isinstance(data, dict):
+                kind_value = data.get("kind")
+                if isinstance(kind_value, str):
+                    try:
+                        kwargs["kind"] = ChartKind(kind_value)
+                    except ValueError:
+                        try:
+                            kwargs["kind"] = ChartKind[kind_value]
+                        except Exception:
+                            kwargs["kind"] = ChartKind.custom
+        if "kind" not in kwargs:
+            kwargs["kind"] = ChartKind.custom
+        if "dt_utc" not in kwargs or kwargs["dt_utc"] is None:
+            kwargs["dt_utc"] = datetime.now(timezone.utc)
+        kwargs.setdefault("lat", 0.0)
+        kwargs.setdefault("lon", 0.0)
+        super().__init__(**kwargs)
+
 
 class RuleSetVersion(ModuleScopeMixin, TimestampMixin, Base):
     """Versioned rulesets linking scans to reproducible logic bundles."""
@@ -199,6 +279,21 @@ class RuleSetVersion(ModuleScopeMixin, TimestampMixin, Base):
     )
 
     events: Mapped[list["Event"]] = relationship(back_populates="ruleset_version")
+
+    def __init__(self, **kwargs: Any) -> None:
+        ruleset_key = kwargs.pop("ruleset_key", None)
+        definition = kwargs.pop("definition", None)
+        if ruleset_key is not None and "key" not in kwargs:
+            kwargs["key"] = str(ruleset_key)
+        if definition is not None and "definition_json" not in kwargs:
+            kwargs["definition_json"] = definition
+        version_value = kwargs.get("version")
+        if isinstance(version_value, str):
+            try:
+                kwargs["version"] = int(float(version_value))
+            except ValueError:
+                pass
+        super().__init__(**kwargs)
 
 
 class Event(ModuleScopeMixin, TimestampMixin, Base):
@@ -237,7 +332,6 @@ class Event(ModuleScopeMixin, TimestampMixin, Base):
     objects: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
 
     score: Mapped[float | None] = mapped_column(Float, nullable=True)
-    objects: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     payload: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     status: Mapped[str] = mapped_column(
         String(32),
@@ -254,6 +348,29 @@ class Event(ModuleScopeMixin, TimestampMixin, Base):
     ruleset_version: Mapped[RuleSetVersion | None] = relationship(back_populates="events")
     severity_profile: Mapped[SeverityProfile | None] = relationship(back_populates="events")
     export_jobs: Mapped[list["ExportJob"]] = relationship(back_populates="event")
+
+    def __init__(self, **kwargs: Any) -> None:
+        event_time = kwargs.pop("event_time", None)
+        if event_time is not None and "start_ts" not in kwargs:
+            kwargs["start_ts"] = event_time
+        event_type = kwargs.pop("event_type", None)
+        if event_type is not None and "type" not in kwargs:
+            if isinstance(event_type, EventType):
+                kwargs["type"] = event_type
+            else:
+                try:
+                    kwargs["type"] = EventType(event_type)
+                except ValueError:
+                    try:
+                        kwargs["type"] = EventType[event_type]
+                    except Exception:
+                        kwargs["type"] = EventType.custom
+        if "objects" not in kwargs:
+            payload = kwargs.get("payload")
+            if isinstance(payload, dict) and "objects" in payload:
+                kwargs["objects"] = payload["objects"]
+        kwargs.setdefault("objects", {})
+        super().__init__(**kwargs)
 
 
 class AsteroidMeta(ModuleScopeMixin, TimestampMixin, Base):
@@ -273,6 +390,23 @@ class AsteroidMeta(ModuleScopeMixin, TimestampMixin, Base):
     attributes: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
     orbit_class: Mapped[str | None] = mapped_column(String(64), nullable=True)
     source_catalog: Mapped[str | None] = mapped_column(String(128), nullable=True)
+
+    def __init__(self, **kwargs: Any) -> None:
+        asteroid_id = kwargs.pop("asteroid_id", None)
+        common_name = kwargs.pop("common_name", None)
+        if asteroid_id is not None and "designation" not in kwargs:
+            kwargs["designation"] = str(asteroid_id)
+        if common_name is not None and "name" not in kwargs:
+            kwargs["name"] = str(common_name)
+        super().__init__(**kwargs)
+
+    @property
+    def common_name(self) -> str | None:
+        return self.name
+
+    @common_name.setter
+    def common_name(self, value: str | None) -> None:
+        self.name = value if value is not None else self.name
 
 
 class ExportJob(ModuleScopeMixin, TimestampMixin, Base):
@@ -316,6 +450,40 @@ class ExportJob(ModuleScopeMixin, TimestampMixin, Base):
 
     event: Mapped[Event | None] = relationship(back_populates="export_jobs")
 
+    def __init__(self, **kwargs: Any) -> None:
+        job_type = kwargs.pop("job_type", None)
+        if job_type is not None and "type" not in kwargs:
+            if isinstance(job_type, ExportType):
+                kwargs["type"] = job_type
+            else:
+                try:
+                    kwargs["type"] = ExportType(job_type)
+                except ValueError:
+                    try:
+                        kwargs["type"] = ExportType[job_type]
+                    except Exception:
+                        kwargs["type"] = ExportType.json
+        payload = kwargs.pop("payload", None)
+        if payload is not None and "params" not in kwargs:
+            kwargs["params"] = payload
+        super().__init__(**kwargs)
+
+    @property
+    def job_type(self) -> str:
+        return self.type.value
+
+    @job_type.setter
+    def job_type(self, value: str) -> None:
+        self.type = ExportType(value)
+
+    @property
+    def payload(self) -> dict[str, Any]:
+        return self.params
+
+    @payload.setter
+    def payload(self, value: dict[str, Any]) -> None:
+        self.params = value
+
 
 __all__ = [
     "AsteroidMeta",
@@ -333,6 +501,6 @@ __all__ = [
 ]
 
 # Backwards compatible alias retained for legacy imports
-RuleSetVersion = RulesetVersion
+RulesetVersion = RuleSetVersion
 
-__all__.append("RuleSetVersion")
+__all__.append("RulesetVersion")

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -22,6 +22,17 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .aspects import router as aspects_router
 
         return aspects_router
+    if name in {"configure_position_provider", "clear_position_provider"}:
+        from .aspects import (
+            clear_position_provider,
+            configure_position_provider,
+        )
+
+        return (
+            configure_position_provider
+            if name == "configure_position_provider"
+            else clear_position_provider
+        )
     if name == "electional_router":
         from .electional import router as electional_router
 

--- a/app/routers/transits.py
+++ b/app/routers/transits.py
@@ -85,6 +85,7 @@ def _resolve_orb_policy_inline_or_id(
     "/transits/score-series",
     response_model=ScoreSeriesResponse,
     summary="Daily & monthly composite severity",
+    operation_id="plus_score_series",
 )
 def score_series(req: ScoreSeriesRequest):
     if req.hits:

--- a/app/schemas/series.py
+++ b/app/schemas/series.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.schemas.aspects import AspectName, TimeWindow, OrbPolicyInline
 
@@ -34,6 +34,47 @@ class ScoreSeriesRequest(BaseModel):
     scan: Optional[ScanInput] = None
     hits: Optional[List[HitIn]] = None
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "examples": [
+                {
+                    "summary": "Scan inputs with inline policy overrides",
+                    "value": {
+                        "scan": {
+                            "objects": ["Mars", "Venus"],
+                            "aspects": ["sextile", "trine"],
+                            "harmonics": [5],
+                            "window": {
+                                "start": "2025-02-01T00:00:00Z",
+                                "end": "2025-02-15T00:00:00Z",
+                            },
+                            "step_minutes": 60,
+                            "orb_policy_inline": {
+                                "per_aspect": {"sextile": 3.0, "trine": 6.0},
+                            },
+                        }
+                    },
+                },
+                {
+                    "summary": "Precomputed hits for scoring",
+                    "value": {
+                        "hits": [
+                            {
+                                "a": "Sun",
+                                "b": "Moon",
+                                "aspect": "sextile",
+                                "exact_time": "2025-02-14T08:12:00Z",
+                                "orb": 0.12,
+                                "orb_limit": 3.0,
+                                "severity": 0.6,
+                            }
+                        ]
+                    },
+                },
+            ]
+        }
+    )
+
     @model_validator(mode="after")
     def _one_of_scan_or_hits(self) -> "ScoreSeriesRequest":
         if (self.scan is None and not self.hits) or (self.scan is not None and self.hits):
@@ -55,4 +96,19 @@ class ScoreSeriesResponse(BaseModel):
     daily: List[DailyPoint]
     monthly: List[MonthlyPoint]
     meta: Dict[str, Any]
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {
+                "daily": [
+                    {"date": "2025-02-14", "score": 0.62},
+                    {"date": "2025-02-15", "score": 0.58},
+                ],
+                "monthly": [
+                    {"month": "2025-02", "score": 0.6},
+                ],
+                "meta": {"source": "plus.transits", "module": "plus"},
+            }
+        }
+    )
 

--- a/astroengine/api/routers/scan.py
+++ b/astroengine/api/routers/scan.py
@@ -10,7 +10,7 @@ from typing import Any, Iterable, Literal, Mapping, Sequence
 
 from fastapi import APIRouter, HTTPException
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from ...core.transit_engine import scan_transits
 from ...detectors.directions import solar_arc_directions
@@ -124,11 +124,6 @@ class TimeWindow(BaseModel):
     )
 
     model_config = ConfigDict(extra="ignore")
-
-
-    natal: datetime = Field(validation_alias=AliasChoices("natal_inline", "natal"))
-    start: datetime = Field(validation_alias=AliasChoices("from", "start"))
-    end: datetime = Field(validation_alias=AliasChoices("to", "end"))
 
     @field_validator("natal", "start", "end", mode="before")
     @classmethod

--- a/astroengine/api/routers/synastry.py
+++ b/astroengine/api/routers/synastry.py
@@ -9,7 +9,7 @@ from typing import Any, Sequence
 
 from fastapi import APIRouter
 
-from pydantic import AliasChoices, BaseModel, ConfigDict, Field, validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from ...chart.natal import DEFAULT_BODIES
 from ...ephemeris.swisseph_adapter import SwissEphemerisAdapter

--- a/astroengine/core/aspects_plus/scan.py
+++ b/astroengine/core/aspects_plus/scan.py
@@ -1,12 +1,10 @@
 
 """Aspect scanning utilities for AstroEngine Plus."""
 
-
 from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-
 from itertools import combinations
 from typing import Any, Callable, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
@@ -41,6 +39,73 @@ class AspectSpec:
     name: str
     angle: float
     harmonic: Optional[int] = None
+
+
+def _resolve_spec_name(angle: float) -> str:
+    for key, base_angle in BASE_ASPECTS.items():
+        if abs(float(base_angle) - float(angle)) < 1e-6:
+            return key
+    return f"{angle:g}"
+
+
+def _coerce_aspect_spec(entry: Any) -> Optional[AspectSpec]:
+    if isinstance(entry, AspectSpec):
+        return entry
+    if isinstance(entry, Mapping):
+        name = entry.get("name") or entry.get("aspect")
+        angle = entry.get("angle")
+        if angle is None and isinstance(name, str):
+            base = BASE_ASPECTS.get(name.strip().lower())
+            if base is not None:
+                angle = float(base)
+        if angle is None and "value" in entry:
+            try:
+                angle = float(entry["value"])
+            except (TypeError, ValueError):
+                angle = None
+        if angle is None and "angle_deg" in entry:
+            try:
+                angle = float(entry["angle_deg"])
+            except (TypeError, ValueError):
+                angle = None
+        if angle is None:
+            return None
+        harmonic = entry.get("harmonic")
+        try:
+            harmonic_int = int(harmonic) if harmonic is not None else None
+        except (TypeError, ValueError):
+            harmonic_int = None
+        if not name:
+            name = _resolve_spec_name(float(angle))
+        return AspectSpec(name=str(name).strip().lower(), angle=float(angle), harmonic=harmonic_int)
+    if isinstance(entry, str):
+        key = entry.strip().lower()
+        if key in BASE_ASPECTS:
+            return AspectSpec(name=key, angle=float(BASE_ASPECTS[key]))
+        try:
+            angle = float(entry)
+        except ValueError:
+            return None
+        return AspectSpec(name=_resolve_spec_name(angle), angle=angle)
+    if isinstance(entry, (int, float)):
+        angle = float(entry)
+        return AspectSpec(name=_resolve_spec_name(angle), angle=angle)
+    return None
+
+
+def _normalize_aspect_specs(entries: Sequence[Any]) -> List[AspectSpec]:
+    specs: List[AspectSpec] = []
+    seen: set[Tuple[str, float, Optional[int]]] = set()
+    for entry in entries:
+        spec = _coerce_aspect_spec(entry)
+        if not spec:
+            continue
+        signature = (spec.name, round(float(spec.angle), 6), spec.harmonic)
+        if signature in seen:
+            continue
+        seen.add(signature)
+        specs.append(spec)
+    return specs
 
 
 
@@ -123,6 +188,18 @@ def _resolve_orb_limit(
             limit_val = max(limit_val, float(per_object.get(obj, 0.0)))
         except Exception:
             continue
+
+    if limit_val <= 0.0:
+        default_limit = policy.get("default")
+        if default_limit is None:
+            default_limit = policy.get("default_orb_deg")
+        try:
+            limit_val = float(default_limit)
+        except (TypeError, ValueError):
+            limit_val = 1.0
+        if limit_val <= 0.0:
+            limit_val = 1.0
+
     return max(0.0, limit_val)
 
 
@@ -241,15 +318,19 @@ def scan_pair_time_range(
     body_b: str,
     window: TimeWindow,
     position_provider: Callable[[datetime], Mapping[str, float]],
-    aspect_specs: Sequence[AspectSpec],
+    aspect_specs: Sequence[Any],
     orb_policy: Mapping[str, Any] | None,
     *,
     step_minutes: int = 60,
 ) -> List[Hit]:
     """Scan a pair of bodies for the provided aspects."""
 
+    specs = _normalize_aspect_specs(aspect_specs)
+    if not specs:
+        return []
+
     hits: List[Hit] = []
-    for spec in aspect_specs:
+    for spec in specs:
         limit = _resolve_orb_limit(orb_policy, spec, body_a, body_b)
         hits.extend(
             _scan_single_spec(body_a, body_b, window, position_provider, spec, limit, step_minutes)

--- a/astroengine/plugins/runtime.py
+++ b/astroengine/plugins/runtime.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from importlib.metadata import entry_points
+from importlib import import_module
+from importlib.metadata import EntryPoint, entry_points
+import importlib
+import sys
+from typing import Callable
 
 
 class Registry:
@@ -23,12 +27,32 @@ class Registry:
         self.providers[name] = obj
 
 
+def _ensure_entry_point_importable(ep: EntryPoint) -> Callable[..., object]:
+    """Load an entry point, retrying after fixing sys.path for editable installs."""
+
+    try:
+        return ep.load()
+    except ModuleNotFoundError:
+        module_name = getattr(ep, "module", "") or ""
+        dist = getattr(ep, "dist", None)
+        if dist:
+            location = dist.locate_file("")
+            if location:
+                location_str = str(location)
+                if location_str not in sys.path:
+                    sys.path.append(location_str)
+                    importlib.invalidate_caches()
+        if module_name:
+            import_module(module_name)
+        return ep.load()
+
+
 def load_plugins(registry: Registry) -> list[str]:
     """Load plugin entry points and allow them to self-register."""
 
     names: list[str] = []
     for ep in entry_points(group="astroengine.plugins"):
-        fn = ep.load()
+        fn = _ensure_entry_point_importable(ep)
         fn(registry)
         names.append(ep.name)
     return sorted(names)
@@ -39,7 +63,7 @@ def load_providers(registry: Registry) -> list[str]:
 
     names: list[str] = []
     for ep in entry_points(group="astroengine.providers"):
-        fn = ep.load()
+        fn = _ensure_entry_point_importable(ep)
         prov_name, prov_obj = fn()
         registry.register_provider(prov_name, prov_obj)
         names.append(ep.name)

--- a/core/viz_plus/aspect_grid.py
+++ b/core/viz_plus/aspect_grid.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 
 from core.viz_plus.wheel_svg import build_aspect_hits
 
@@ -14,18 +14,39 @@ ASPECT_SYMBOLS = {
 
 
 def render_aspect_grid(hits: List[Dict]) -> Dict[str, Dict[str, str]]:
+    """Return an aspect grid keyed by object with mirrored pairs."""
+
     grid: Dict[str, Dict[str, str]] = {}
-    for h in hits:
-        a = h["a"]
-        b = h["b"]
-        grid.setdefault(a, {})[b] = h["aspect"]
+    for hit in hits:
+        a = hit["a"]
+        b = hit["b"]
+        aspect = hit["aspect"]
+        grid.setdefault(a, {})[b] = aspect
+        grid.setdefault(b, {})[a] = aspect
     return grid
 
 
-def aspect_grid_symbols(positions: Dict[str, float], aspects: Iterable[str], policy: Dict) -> Dict[str, Dict[str, str]]:
-    hits = build_aspect_hits(positions, aspects, policy)
+def aspect_grid_symbols(
+    positions: Optional[Dict[str, float]] = None,
+    aspects: Optional[Iterable[str]] = None,
+    policy: Optional[Dict] = None,
+    hits: Optional[List[Dict]] = None,
+) -> Dict[str, Dict[str, str]]:
+    """Return a mirrored aspect grid populated with glyphs.
+
+    When ``hits`` are provided they take precedence, ensuring that symbol grids
+    rendered alongside tabular hits reuse the exact same matches.
+    """
+
+    if hits is None:
+        if positions is None or aspects is None or policy is None:
+            raise ValueError("positions, aspects, and policy are required when hits are not provided")
+        hits = build_aspect_hits(positions, aspects, policy)
+
     grid: Dict[str, Dict[str, str]] = {}
-    for h in hits:
-        a, b, asp = h["a"], h["b"], h["aspect"]
-        grid.setdefault(a, {})[b] = ASPECT_SYMBOLS.get(asp, asp)
+    for hit in hits:
+        a, b, asp = hit["a"], hit["b"], hit["aspect"]
+        symbol = ASPECT_SYMBOLS.get(asp, asp)
+        grid.setdefault(a, {})[b] = symbol
+        grid.setdefault(b, {})[a] = symbol
     return grid

--- a/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
+++ b/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+import json
+from typing import Dict, List
+
+import pandas as pd
+import streamlit as st
+
+from core.viz_plus.wheel_svg import WheelOptions, build_aspect_hits, render_chart_wheel
+from core.viz_plus.aspect_grid import aspect_grid_symbols, render_aspect_grid
+from core.aspects_plus.harmonics import BASE_ASPECTS
+
+st.set_page_config(page_title="Chart Wheel & Aspectarian", page_icon="🎡", layout="wide")
+st.title("Chart Wheel & Aspectarian 🎡")
+
+# --------------------------- Defaults --------------------------------------
+DEFAULT_POSITIONS = {
+    "Sun": 0.0,
+    "Moon": 90.0,
+    "Mercury": 15.0,
+    "Venus": 70.0,
+    "Mars": 180.0,
+    "Jupiter": 220.0,
+    "Saturn": 300.0,
+}
+DEFAULT_POLICY = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 4.0,
+    },
+    "adaptive_rules": {},
+}
+DEFAULT_ASPECTS = ["conjunction", "opposition", "square", "trine", "sextile"]
+AVAILABLE_ASPECTS = sorted(BASE_ASPECTS.keys())
+
+wheel_tab, aspectarian_tab = st.tabs(["Wheel", "Aspectarian"])
+
+# --------------------------- Sidebar inputs --------------------------------
+with st.sidebar:
+    st.header("Inputs")
+    positions_txt = st.text_area(
+        "Positions JSON (name → longitude°)",
+        value=json.dumps(DEFAULT_POSITIONS, indent=2),
+        height=220,
+    )
+    try:
+        positions: Dict[str, float] = {
+            str(name): float(lon)
+            for name, lon in (json.loads(positions_txt) if positions_txt.strip() else {}).items()
+        }
+    except Exception as exc:  # pragma: no cover - UI error path
+        st.error(f"Invalid positions JSON: {exc}")
+        positions = {}
+
+    houses_txt = st.text_area(
+        "Houses JSON (12 longitudes, optional)",
+        value="",
+        height=80,
+        help="e.g., [100,130,...] (length 12)",
+    )
+    houses: List[float] | None = None
+    if houses_txt.strip():
+        try:
+            houses = [float(x) for x in json.loads(houses_txt)]
+            if len(houses) != 12:
+                st.warning("Provide exactly 12 house cusp longitudes.")
+                houses = None
+        except Exception as exc:  # pragma: no cover - UI error path
+            st.warning(f"Invalid houses JSON: {exc}")
+            houses = None
+
+    st.divider()
+    st.header("Aspects & Orbs")
+    aspects = st.multiselect(
+        "Aspect set",
+        options=AVAILABLE_ASPECTS,
+        default=[a for a in DEFAULT_ASPECTS if a in AVAILABLE_ASPECTS],
+    )
+
+    selected_aspects = aspects or [a for a in DEFAULT_ASPECTS if a in AVAILABLE_ASPECTS]
+
+    policy_per_aspect: Dict[str, float] = {}
+    if selected_aspects:
+        st.caption("Orb overrides (degrees)")
+    for asp in selected_aspects:
+        default_orb = DEFAULT_POLICY["per_aspect"].get(asp, 3.0)
+        policy_per_aspect[asp] = st.number_input(
+            f"{asp}",
+            min_value=0.1,
+            max_value=15.0,
+            value=float(default_orb),
+            step=0.1,
+            key=f"orb_{asp}",
+        )
+
+    orb_policy = {
+        "per_object": {},
+        "per_aspect": policy_per_aspect or DEFAULT_POLICY["per_aspect"].copy(),
+        "adaptive_rules": {},
+    }
+
+
+# --------------------------- Wheel Tab -------------------------------------
+with wheel_tab:
+    st.subheader("SVG Chart Wheel")
+    size = st.slider("Size (px)", min_value=400, max_value=1200, value=800, step=50)
+    show_ticks = st.toggle("Show degree ticks", value=True)
+    show_houses = st.toggle("Show house lines", value=True)
+    show_aspects = st.toggle("Draw aspect lines", value=True)
+
+    if st.button("Render Wheel", type="primary"):
+        if not positions:
+            st.warning("Please provide valid positions JSON.")
+            st.stop()
+
+        options = WheelOptions(
+            size=int(size),
+            show_degree_ticks=bool(show_ticks),
+            show_house_lines=bool(show_houses),
+            show_aspects=bool(show_aspects),
+            aspects=selected_aspects,
+            policy=orb_policy,
+        )
+        svg = render_chart_wheel(positions, houses=houses, options=options)
+        st.components.v1.html(svg, height=int(size) + 40, scrolling=False)
+        st.download_button(
+            "Download SVG",
+            svg.encode("utf-8"),
+            file_name="chart_wheel.svg",
+            mime="image/svg+xml",
+        )
+
+
+# --------------------------- Aspectarian Tab -------------------------------
+with aspectarian_tab:
+    st.subheader("Aspectarian")
+    if st.button("Compute Aspects", type="primary"):
+        if not positions:
+            st.warning("Please provide valid positions JSON.")
+            st.stop()
+
+        hits = build_aspect_hits(positions, aspects=selected_aspects, policy=orb_policy)
+        if hits:
+            df = pd.DataFrame(hits)
+            st.dataframe(df, use_container_width=True, hide_index=True)
+            st.download_button(
+                "Download Hits CSV",
+                df.to_csv(index=False).encode("utf-8"),
+                file_name="aspect_hits.csv",
+                mime="text/csv",
+            )
+            st.download_button(
+                "Download Hits JSON",
+                json.dumps(hits, indent=2).encode("utf-8"),
+                file_name="aspect_hits.json",
+                mime="application/json",
+            )
+        else:
+            st.info("No matched aspects with current policy.")
+
+        grid = render_aspect_grid(hits)
+        symbol_grid = aspect_grid_symbols(
+            positions,
+            aspects=selected_aspects,
+            policy=orb_policy,
+            hits=hits,
+        )
+
+        if grid:
+            st.subheader("Aspect Grid (names)")
+            grid_names_df = pd.DataFrame(grid).fillna("").T
+            st.dataframe(grid_names_df, use_container_width=True)
+            st.download_button(
+                "Download Grid (names) JSON",
+                json.dumps(grid, indent=2).encode("utf-8"),
+                file_name="aspect_grid_names.json",
+                mime="application/json",
+            )
+
+        if symbol_grid:
+            st.subheader("Aspect Grid (symbols)")
+            grid_df = pd.DataFrame(symbol_grid).fillna("").T
+            st.dataframe(grid_df, use_container_width=True)
+            st.download_button(
+                "Download Grid CSV",
+                grid_df.to_csv().encode("utf-8"),
+                file_name="aspect_grid.csv",
+                mime="text/csv",
+            )
+            st.download_button(
+                "Download Grid JSON",
+                json.dumps(symbol_grid, indent=2).encode("utf-8"),
+                file_name="aspect_grid.json",
+                mime="application/json",
+            )
+
+        if not grid and not symbol_grid:
+            st.caption("Grid empty — no aspects matched.")


### PR DESCRIPTION
## Summary
- restore the Plus ORM constructors so legacy keyword arguments populate the new JSON-backed fields while adding defaults for charts, events, asteroids, and export jobs
- harden the aspect scan helpers to normalize loose specifications, add sensible orb fallbacks, and retry editable plugin entry points
- document score-series request/response examples and restore the explicit operation id expected by the OpenAPI contract

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d82b1e943c8324a52e4a6724bf1df3