### PR TITLE
Add relationship API endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -11,6 +11,7 @@ from app.routers import (
     events_router,
     lots_router,
     policies_router,
+    relationship_router,
     transits_router,
 )
 from app.routers.aspects import (  # re-exported for convenience
@@ -25,6 +26,7 @@ app.include_router(events_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
 app.include_router(lots_router)
+app.include_router(relationship_router)
 
 
 __all__ = ["app", "configure_position_provider", "clear_position_provider"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -12,6 +12,7 @@ __all__ = [
 
     "policies_router",
     "lots_router",
+    "relationship_router",
     "configure_position_provider",
     "clear_position_provider",
 ]
@@ -34,6 +35,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .lots import router as lots_router
 
         return lots_router
+    if name == "relationship_router":
+        from .relationship import router as relationship_router
+
+        return relationship_router
     if name == "policies_router":
         from .policies import router as policies_router
 

--- a/app/routers/relationship.py
+++ b/app/routers/relationship.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import APIRouter
+
+from app.schemas.relationship import (
+    SynastryRequest,
+    SynastryResponse,
+    SynastryHitOut,
+    CompositeRequest,
+    CompositeResponse,
+    DavisonRequest,
+    DavisonResponse,
+)
+from app.schemas.aspects import OrbPolicyInline
+
+from core.relationship_plus.synastry import (
+    synastry_hits,
+    synastry_grid,
+    overlay_positions,
+    synastry_score,
+)
+from core.relationship_plus.composite import (
+    composite_positions,
+    davison_positions,
+    davison_midpoints,
+    Geo,
+)
+
+from app.routers import aspects as aspects_module
+
+router = APIRouter(prefix="/relationship", tags=["Relationship"])
+
+DEFAULT_POLICY: Dict[str, Any] = {
+    "per_object": {},
+    "per_aspect": {
+        "conjunction": 8.0,
+        "opposition": 7.0,
+        "square": 6.0,
+        "trine": 6.0,
+        "sextile": 3.0,
+    },
+    "adaptive_rules": {},
+}
+
+
+def _resolve_policy(inline: OrbPolicyInline | None) -> Dict[str, Any]:
+    return inline.model_dump() if inline is not None else DEFAULT_POLICY
+
+
+@router.post("/synastry", response_model=SynastryResponse, summary="Synastry inter-aspect analysis")
+def api_synastry(req: SynastryRequest):
+    policy = _resolve_policy(req.orb_policy_inline)
+    hits = synastry_hits(
+        req.posA,
+        req.posB,
+        aspects=req.aspects,
+        policy=policy,
+        per_aspect_weight=req.per_aspect_weight,
+        per_pair_weight=req.per_pair_weight,
+    )
+    grid = synastry_grid(hits)
+    overlay = overlay_positions(req.posA, req.posB)
+    scores = synastry_score(hits)
+    return SynastryResponse(
+        hits=[SynastryHitOut(**h.__dict__) for h in hits],
+        grid=grid,
+        overlay=overlay,
+        scores=scores,
+        meta={"count": len(hits)},
+    )
+
+
+@router.post("/composite", response_model=CompositeResponse, summary="Composite (midpoint) positions")
+def api_composite(req: CompositeRequest):
+    pos = composite_positions(req.posA, req.posB, bodies=req.bodies)
+    return CompositeResponse(positions=pos, meta={"bodies": list(pos.keys())})
+
+
+@router.post("/davison", response_model=DavisonResponse, summary="Davison chart at time midpoint (MVP)")
+def api_davison(req: DavisonRequest):
+    provider = aspects_module._get_provider()
+    geo_a = Geo(lat_deg=req.locA.lat_deg, lon_deg_east=req.locA.lon_deg_east)
+    geo_b = Geo(lat_deg=req.locB.lat_deg, lon_deg_east=req.locB.lon_deg_east)
+    pos = davison_positions(provider, req.dtA, geo_a, req.dtB, geo_b, bodies=req.bodies)
+    mid_dt, mid_lat, mid_lon = davison_midpoints(req.dtA, geo_a, req.dtB, geo_b)
+    return DavisonResponse(
+        positions=pos,
+        midpoint_time_utc=mid_dt,
+        midpoint_geo=req.locA.__class__(lat_deg=mid_lat, lon_deg_east=mid_lon),
+        meta={"bodies": list(pos.keys())},
+    )

--- a/app/schemas/relationship.py
+++ b/app/schemas/relationship.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, Field
+
+from app.schemas.aspects import OrbPolicyInline
+
+
+# --------------------------- Synastry --------------------------------------
+class SynastryRequest(BaseModel):
+    posA: Dict[str, float] = Field(..., description="Chart A: body → longitude (deg)")
+    posB: Dict[str, float] = Field(..., description="Chart B: body → longitude (deg)")
+    aspects: List[str] = Field(
+        default_factory=lambda: [
+            "conjunction",
+            "opposition",
+            "square",
+            "trine",
+            "sextile",
+        ]
+    )
+    orb_policy_inline: Optional[OrbPolicyInline] = None
+    per_aspect_weight: Optional[Dict[str, float]] = None
+    per_pair_weight: Optional[Dict[Tuple[str, str], float]] = None
+
+
+class SynastryHitOut(BaseModel):
+    a: str
+    b: str
+    aspect: str
+    angle: float
+    delta: float
+    orb: float
+    limit: float
+    severity: float
+
+
+class SynastryResponse(BaseModel):
+    hits: List[SynastryHitOut]
+    grid: Dict[str, Dict[str, str]]
+    overlay: Dict[str, Dict[str, Any]]
+    scores: Dict[str, Any]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+# --------------------------- Composite -------------------------------------
+class CompositeRequest(BaseModel):
+    posA: Dict[str, float]
+    posB: Dict[str, float]
+    bodies: Optional[List[str]] = None
+
+
+class CompositeResponse(BaseModel):
+    positions: Dict[str, float]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+# --------------------------- Davison ---------------------------------------
+class GeoIn(BaseModel):
+    lat_deg: float
+    lon_deg_east: float
+
+
+class DavisonRequest(BaseModel):
+    dtA: datetime
+    dtB: datetime
+    locA: GeoIn
+    locB: GeoIn
+    bodies: Optional[List[str]] = None
+
+
+class DavisonResponse(BaseModel):
+    positions: Dict[str, float]
+    midpoint_time_utc: datetime
+    midpoint_geo: GeoIn
+    meta: Dict[str, Any] = Field(default_factory=dict)

--- a/core/relationship_plus/__init__.py
+++ b/core/relationship_plus/__init__.py
@@ -10,6 +10,13 @@ from .composite import (
     norm360,
     delta_short,
 )
+from .synastry import (
+    SynastryHit,
+    overlay_positions,
+    synastry_grid,
+    synastry_hits,
+    synastry_score,
+)
 
 __all__ = [
     "Geo",
@@ -20,4 +27,9 @@ __all__ = [
     "midpoint_angle",
     "norm360",
     "delta_short",
+    "SynastryHit",
+    "overlay_positions",
+    "synastry_grid",
+    "synastry_hits",
+    "synastry_score",
 ]

--- a/core/relationship_plus/synastry.py
+++ b/core/relationship_plus/synastry.py
@@ -1,0 +1,165 @@
+"""Synastry helpers for combining two position sets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Tuple
+
+from astroengine.core.aspects_plus.harmonics import BASE_ASPECTS
+from astroengine.core.aspects_plus.matcher import angular_sep_deg
+from astroengine.core.aspects_plus.orb_policy import orb_limit
+
+
+@dataclass
+class SynastryHit:
+    """Container for a single synastry hit."""
+
+    a: str
+    b: str
+    aspect: str
+    angle: float
+    delta: float
+    orb: float
+    limit: float
+    severity: float
+
+
+def _pair_weight(
+    weights: Optional[Mapping[Tuple[str, str], float]],
+    a: str,
+    b: str,
+) -> float:
+    if not weights:
+        return 1.0
+    if (a, b) in weights:
+        return float(weights[(a, b)])
+    if (b, a) in weights:
+        return float(weights[(b, a)])
+    return 1.0
+
+
+def _best_aspect(
+    a_name: str,
+    b_name: str,
+    delta: float,
+    aspects: Iterable[str],
+    policy: Mapping[str, Any],
+) -> Optional[Tuple[str, float, float]]:
+    best: Optional[Tuple[str, float, float]] = None
+    for asp in aspects:
+        key = asp.lower()
+        angle = BASE_ASPECTS.get(key)
+        if angle is None:
+            continue
+        limit = float(orb_limit(a_name, b_name, key, policy))
+        orb = abs(delta - float(angle))
+        if best is None or orb < best[1]:
+            best = (key, orb, limit)
+    return best
+
+
+def synastry_hits(
+    pos_a: Mapping[str, float],
+    pos_b: Mapping[str, float],
+    *,
+    aspects: Iterable[str],
+    policy: Mapping[str, Any],
+    per_aspect_weight: Optional[Mapping[str, float]] = None,
+    per_pair_weight: Optional[Mapping[Tuple[str, str], float]] = None,
+) -> List[SynastryHit]:
+    """Return matched aspects for all A×B pairs within the configured policy."""
+
+    hits: List[SynastryHit] = []
+    for name_a, lon_a in pos_a.items():
+        if lon_a is None:
+            continue
+        for name_b, lon_b in pos_b.items():
+            if lon_b is None:
+                continue
+            delta = angular_sep_deg(float(lon_a), float(lon_b))
+            best = _best_aspect(name_a, name_b, delta, aspects, policy)
+            if best is None:
+                continue
+            aspect, orb, limit = best
+            base = 0.0 if limit <= 0.0 else max(0.0, 1.0 - orb / limit)
+            w_aspect = 1.0 if per_aspect_weight is None else float(per_aspect_weight.get(aspect, 1.0))
+            w_pair = _pair_weight(per_pair_weight, name_a, name_b)
+            severity = base * w_aspect * w_pair
+            hits.append(
+                SynastryHit(
+                    a=name_a,
+                    b=name_b,
+                    aspect=aspect,
+                    angle=float(BASE_ASPECTS.get(aspect, 0.0)),
+                    delta=float(delta),
+                    orb=float(orb),
+                    limit=float(limit),
+                    severity=severity,
+                )
+            )
+    hits.sort(key=lambda h: (h.a, h.b, h.orb, h.aspect))
+    return hits
+
+
+def synastry_grid(hits: Iterable[SynastryHit]) -> Dict[str, Dict[str, str]]:
+    """Return a simple grid summarising the dominant aspect per pair."""
+
+    best: Dict[str, Dict[str, SynastryHit]] = {}
+    for hit in hits:
+        row = best.setdefault(hit.a, {})
+        current = row.get(hit.b)
+        if current is None or hit.orb < current.orb:
+            row[hit.b] = hit
+    return {
+        a_name: {b_name: entry.aspect for b_name, entry in cols.items()}
+        for a_name, cols in best.items()
+    }
+
+
+def overlay_positions(pos_a: Mapping[str, float], pos_b: Mapping[str, float]) -> Dict[str, Dict[str, float]]:
+    """Return overlay of chart positions keyed by body."""
+
+    overlay: Dict[str, Dict[str, float]] = {}
+    for name in sorted(set(pos_a.keys()) | set(pos_b.keys())):
+        entry: Dict[str, float] = {}
+        if name in pos_a and pos_a[name] is not None:
+            entry["A"] = float(pos_a[name])
+        if name in pos_b and pos_b[name] is not None:
+            entry["B"] = float(pos_b[name])
+        if "A" in entry and "B" in entry:
+            entry["delta"] = angular_sep_deg(entry["A"], entry["B"])
+        overlay[name] = entry
+    return overlay
+
+
+def synastry_score(hits: Iterable[SynastryHit]) -> Dict[str, Any]:
+    """Aggregate severity across the hit list."""
+
+    total = 0.0
+    per_aspect: Dict[str, float] = {}
+    per_pair: Dict[str, float] = {}
+    count = 0
+    for hit in hits:
+        severity = float(hit.severity)
+        total += severity
+        per_aspect[hit.aspect] = per_aspect.get(hit.aspect, 0.0) + severity
+        key = f"{hit.a}→{hit.b}"
+        per_pair[key] = per_pair.get(key, 0.0) + severity
+        count += 1
+    average = total / count if count else 0.0
+    return {
+        "total": total,
+        "average": average,
+        "per_aspect": per_aspect,
+        "per_pair": per_pair,
+        "count": count,
+    }
+
+
+__all__ = [
+    "SynastryHit",
+    "synastry_grid",
+    "synastry_hits",
+    "synastry_score",
+    "overlay_positions",
+]

--- a/tests/test_api_relationship.py
+++ b/tests/test_api_relationship.py
@@ -1,0 +1,91 @@
+from datetime import datetime, timedelta, timezone
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.relationship import router as relationship_router
+from app.routers import aspects as aspects_module
+
+
+class LinearEphemeris:
+    """Synthetic linear ephemeris used for deterministic Davison tests."""
+
+    def __init__(self, t0, base, rates):
+        self.t0 = t0
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts):
+        dt_days = (ts - self.t0).total_seconds() / 86400.0
+        return {
+            key: (self.base.get(key, 0.0) + self.rates.get(key, 0.0) * dt_days) % 360.0
+            for key in self.base
+        }
+
+
+def build_app(provider=None):
+    app = FastAPI()
+    if provider is not None:
+        aspects_module.position_provider = provider
+        if hasattr(aspects_module, "_cached"):
+            aspects_module._cached = None
+    app.include_router(relationship_router)
+    return app
+
+
+POS_A = {"Sun": 350.0, "Moon": 20.0, "Mars": 100.0}
+POS_B = {"Sun": 10.0, "Moon": 80.0, "Venus": 200.0}
+
+
+def test_synastry_endpoint():
+    app = build_app()
+    client = TestClient(app)
+    payload = {
+        "posA": POS_A,
+        "posB": POS_B,
+        "aspects": ["conjunction", "sextile", "trine", "square", "opposition"],
+        "orb_policy_inline": {
+            "per_aspect": {
+                "conjunction": 8.0,
+                "sextile": 3.0,
+                "trine": 6.0,
+                "square": 6.0,
+                "opposition": 7.0,
+            }
+        },
+    }
+    response = client.post("/relationship/synastry", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert {"hits", "grid", "overlay", "scores"} <= set(data.keys())
+    assert any(hit["a"] == "Sun" and hit["b"] == "Sun" for hit in data["hits"])
+
+
+def test_composite_endpoint():
+    app = build_app()
+    client = TestClient(app)
+    response = client.post("/relationship/composite", json={"posA": POS_A, "posB": POS_B})
+    assert response.status_code == 200
+    data = response.json()
+    assert abs(data["positions"]["Sun"] - 0.0) < 1e-9
+
+
+def test_davison_endpoint_mid_time_positions():
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(t0, base={"Sun": 10.0, "Venus": 40.0}, rates={"Sun": 1.0, "Venus": 1.2})
+    app = build_app(eph)
+    client = TestClient(app)
+
+    payload = {
+        "dtA": t0.isoformat(),
+        "dtB": (t0 + timedelta(days=10)).isoformat(),
+        "locA": {"lat_deg": 10.0, "lon_deg_east": 20.0},
+        "locB": {"lat_deg": -10.0, "lon_deg_east": 40.0},
+        "bodies": ["Sun", "Venus"],
+    }
+    response = client.post("/relationship/davison", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert abs(data["positions"]["Sun"] - 15.0) < 1e-9
+    assert abs(data["positions"]["Venus"] - 46.0) < 1e-9
+    assert data["midpoint_time_utc"].startswith((t0 + timedelta(days=5)).isoformat()[:16])


### PR DESCRIPTION
## Summary
- add a dedicated relationship router exposing synastry, composite, and Davison endpoints
- provide Pydantic request/response schemas and synastry utilities to back the new API
- register the router with the FastAPI app and cover the endpoints with deterministic tests

## Testing
- pytest -q tests/test_api_relationship.py

------
https://chatgpt.com/codex/tasks/task_e_68d833cda82083249b32eac412417678