### PR TITLE
Add relationship interpretation scaffolding

### DIFF
--- a/core/interpret_plus/__init__.py
+++ b/core/interpret_plus/__init__.py
@@ -1,0 +1,11 @@
+"""Relationship interpretation scaffolding utilities."""
+
+from .engine import ASPECT_SYMBOLS, ARCHETYPES, Finding, interpret, load_rules
+
+__all__ = [
+    "ASPECT_SYMBOLS",
+    "ARCHETYPES",
+    "Finding",
+    "interpret",
+    "load_rules",
+]

--- a/core/interpret_plus/engine.py
+++ b/core/interpret_plus/engine.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, Tuple
+import json
+
+try:  # pragma: no cover - optional dependency for richer rulepacks
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+
+# --------------------------- Data Models -----------------------------------
+@dataclass
+class Finding:
+    """Structured interpretation assembled from a rule match."""
+
+    id: str
+    scope: str  # synastry|composite|davison
+    title: str
+    text: str
+    score: float
+    tags: List[str]
+    meta: Dict[str, Any]
+
+
+Rule = Dict[str, Any]
+Request = Dict[str, Any]
+SynastryHit = Dict[str, Any]
+
+
+# --------------------------- Rule loading ----------------------------------
+def load_rules(path: str) -> List[Rule]:
+    """Load a rulepack from YAML or JSON."""
+
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = handle.read()
+    if path.endswith(".json") or yaml is None:
+        return json.loads(raw)
+    return yaml.safe_load(raw)
+
+
+# --------------------------- Helpers ---------------------------------------
+ASPECT_SYMBOLS: Dict[str, str] = {
+    "conjunction": "☌",
+    "opposition": "☍",
+    "trine": "△",
+    "square": "□",
+    "sextile": "✶",
+    "quincunx": "⚻",
+}
+
+ARCHETYPES: Dict[str, str] = {
+    "Sun": "Core Self",
+    "Moon": "Emotional Body",
+    "Mercury": "Mind & Speech",
+    "Venus": "Relating & Pleasure",
+    "Mars": "Drive & Desire",
+    "Jupiter": "Growth",
+    "Saturn": "Structure & Commitment",
+}
+
+
+def _fmt(template: str, ctx: Dict[str, Any]) -> str:
+    """Best-effort format that falls back to template on error."""
+
+    try:
+        return template.format(**ctx)
+    except Exception:
+        return template
+
+
+def _coerce_bodies(raw: Any) -> Sequence[str]:
+    if raw is None:
+        return ()
+    if isinstance(raw, str):
+        return (raw,)
+    return tuple(raw)
+
+
+# --------------------------- Matching Primitives ---------------------------
+def _match_synastry_rule(rule: Rule, hits: Sequence[SynastryHit]) -> List[Tuple[SynastryHit, float]]:
+    """Return (hit, strength) pairs that satisfy the synastry rule."""
+
+    cond = rule.get("when", {}) or {}
+    bodies = set(_coerce_bodies(cond.get("bodies")))
+    aspect_in = {str(name).lower() for name in cond.get("aspect_in", [])}
+    min_severity = float(cond.get("min_severity", 0.0))
+
+    matches: List[Tuple[SynastryHit, float]] = []
+    for hit in hits:
+        a = hit.get("a")
+        b = hit.get("b")
+        aspect = str(hit.get("aspect", "")).lower()
+        if aspect_in and aspect not in aspect_in:
+            continue
+
+        if bodies:
+            pair = {a, b}
+            if len(bodies) == 1:
+                if a not in bodies and b not in bodies:
+                    continue
+            elif pair != bodies:
+                continue
+
+        severity = float(hit.get("severity", 0.0))
+        if severity < min_severity:
+            continue
+        matches.append((hit, max(severity, min_severity)))
+    return matches
+
+
+def _match_body_longitude(rule: Rule, positions: Dict[str, float]) -> List[Tuple[str, float]]:
+    cond = rule.get("when", {}) or {}
+    bodies = _coerce_bodies(cond.get("bodies") or cond.get("body"))
+    if not bodies:
+        return []
+
+    ranges = cond.get("longitude_ranges") or []
+    normalised_ranges = [tuple(map(float, window)) for window in ranges]
+    matches: List[Tuple[str, float]] = []
+    for body in bodies:
+        if body not in positions:
+            continue
+        longitude = float(positions[body])
+        if normalised_ranges:
+            in_range = any(lo <= longitude < hi for lo, hi in normalised_ranges)
+            if not in_range:
+                continue
+        matches.append((body, longitude))
+    return matches
+
+
+# --------------------------- Engine ----------------------------------------
+def interpret(request: Request, rules: Sequence[Rule]) -> List[Finding]:
+    """Evaluate the supplied rules against the request payload."""
+
+    scope = request.get("scope")
+    findings: List[Finding] = []
+
+    for rule in rules:
+        if rule.get("scope") != scope:
+            continue
+
+        base_score = float(rule.get("score", 1.0))
+        title = rule.get("title") or rule.get("id", "")
+        template = rule.get("text", "")
+        tags = list(rule.get("tags", []) or [])
+
+        if scope == "synastry":
+            hits = request.get("hits", []) or []
+            for hit, strength in _match_synastry_rule(rule, hits):
+                a = hit.get("a")
+                b = hit.get("b")
+                aspect = str(hit.get("aspect", "")).lower()
+                ctx = {
+                    "a": a,
+                    "b": b,
+                    "aspect": aspect,
+                    "aspect_symbol": ASPECT_SYMBOLS.get(aspect, aspect),
+                    "severity": float(hit.get("severity", 0.0)),
+                    "a_arch": ARCHETYPES.get(a, a),
+                    "b_arch": ARCHETYPES.get(b, b),
+                }
+                findings.append(
+                    Finding(
+                        id=rule.get("id", "rule"),
+                        scope=scope,
+                        title=title,
+                        text=_fmt(template, ctx),
+                        score=base_score * strength,
+                        tags=tags,
+                        meta={"hit": hit},
+                    )
+                )
+        else:
+            positions = request.get("positions", {}) or {}
+            for body, longitude in _match_body_longitude(rule, positions):
+                ctx = {
+                    "body": body,
+                    "longitude": longitude,
+                    "arch": ARCHETYPES.get(body, body),
+                }
+                findings.append(
+                    Finding(
+                        id=rule.get("id", "rule"),
+                        scope=scope,
+                        title=title,
+                        text=_fmt(template, ctx),
+                        score=base_score,
+                        tags=tags,
+                        meta={"body": body, "longitude": longitude},
+                    )
+                )
+
+    findings.sort(key=lambda item: (-item.score, item.id))
+    return findings
+
+
+__all__ = [
+    "ARCHETYPES",
+    "ASPECT_SYMBOLS",
+    "Finding",
+    "interpret",
+    "load_rules",
+]

--- a/core/interpret_plus/registry.py
+++ b/core/interpret_plus/registry.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Dict
+
+ARCHETYPES: Dict[str, str] = {
+    "Sun": "Core Self",
+    "Moon": "Emotional Body",
+    "Mercury": "Mind & Speech",
+    "Venus": "Relating & Pleasure",
+    "Mars": "Drive & Desire",
+    "Jupiter": "Growth",
+    "Saturn": "Structure & Commitment",
+}
+
+__all__ = ["ARCHETYPES"]

--- a/core/interpret_plus/samples/relationship_basic.yaml
+++ b/core/interpret_plus/samples/relationship_basic.yaml
@@ -1,0 +1,52 @@
+- id: syn_sun_moon_harmony
+  scope: synastry
+  title: Sun–Moon harmony
+  when:
+    bodies: [Sun, Moon]
+    aspect_in: [trine, sextile]
+    min_severity: 0.3
+  score: 1.2
+  tags: [warmth, emotional_flow]
+  text: "{a} ({a_arch}) {aspect_symbol} {b} ({b_arch}) — easy emotional rapport and daily rhythm alignment."
+
+- id: syn_venus_mars_chemistry
+  scope: synastry
+  title: Venus–Mars chemistry
+  when:
+    bodies: [Venus, Mars]
+    aspect_in: [conjunction, trine, sextile]
+    min_severity: 0.25
+  score: 1.4
+  tags: [attraction, chemistry]
+  text: "{a}–{b} {aspect} highlights magnetism and desire; chemistry tends to feel mutual."
+
+- id: syn_saturn_binding_hard
+  scope: synastry
+  title: Saturn binding (hard aspect)
+  when:
+    bodies: [Saturn]
+    aspect_in: [conjunction, square, opposition]
+    min_severity: 0.2
+  score: 1.6
+  tags: [commitment, tests]
+  text: "Saturn contact adds weight and lessons; structures form through effort."
+
+- id: comp_venus_angular_aries_like
+  scope: composite
+  title: Venus in early fire
+  when:
+    bodies: [Venus]
+    longitude_ranges: [[0, 30]]
+  score: 0.8
+  tags: [spark]
+  text: "Composite {body} ({arch}) at early degrees favors spontaneity and simple pleasures."
+
+- id: dav_sun_early_degree
+  scope: davison
+  title: Davison Sun early degree
+  when:
+    bodies: [Sun]
+    longitude_ranges: [[0, 15]]
+  score: 0.7
+  tags: [fresh_start]
+  text: "Davison {body} at early degrees signals a fresh, initiating quality in the relationship’s timeline."

--- a/tests/test_relationship_interpret.py
+++ b/tests/test_relationship_interpret.py
@@ -1,0 +1,85 @@
+from core.interpret_plus.engine import interpret
+
+
+HITS = [
+    {"a": "Sun", "b": "Moon", "aspect": "trine", "severity": 0.6},
+    {"a": "Venus", "b": "Mars", "aspect": "conjunction", "severity": 0.5},
+    {"a": "Saturn", "b": "Venus", "aspect": "square", "severity": 0.4},
+]
+
+
+RULES = [
+    {
+        "id": "syn_sun_moon_harmony",
+        "scope": "synastry",
+        "when": {
+            "bodies": ["Sun", "Moon"],
+            "aspect_in": ["trine", "sextile"],
+            "min_severity": 0.3,
+        },
+        "score": 1.2,
+        "text": "{a} {aspect} {b}",
+    },
+    {
+        "id": "syn_venus_mars_chem",
+        "scope": "synastry",
+        "when": {
+            "bodies": ["Venus", "Mars"],
+            "aspect_in": ["conjunction"],
+            "min_severity": 0.2,
+        },
+        "score": 1.4,
+        "text": "{a}-{b} {aspect} wow",
+    },
+    {
+        "id": "syn_saturn_hard",
+        "scope": "synastry",
+        "when": {
+            "bodies": ["Saturn"],
+            "aspect_in": ["conjunction", "square", "opposition"],
+            "min_severity": 0.2,
+        },
+        "score": 1.6,
+        "text": "Saturn binding",
+    },
+]
+
+
+def test_synastry_findings_sorted_and_formatted():
+    req = {"scope": "synastry", "hits": HITS}
+    out = interpret(req, RULES)
+    assert len(out) == 3
+    assert out[0].id in {"syn_venus_mars_chem", "syn_sun_moon_harmony", "syn_saturn_hard"}
+    assert any(token in out[1].text for token in {"trine", "wow", "Saturn"})
+
+
+def test_composite_longitude_rule():
+    rules = [
+        {
+            "id": "comp_venus_early",
+            "scope": "composite",
+            "when": {"bodies": ["Venus"], "longitude_ranges": [[0, 30]]},
+            "score": 0.8,
+            "text": "Composite {body} ok",
+        }
+    ]
+    req = {"scope": "composite", "positions": {"Venus": 5.0}}
+    out = interpret(req, rules)
+    assert len(out) == 1
+    assert out[0].text.startswith("Composite Venus")
+
+
+def test_davison_longitude_rule():
+    rules = [
+        {
+            "id": "dav_sun_early",
+            "scope": "davison",
+            "when": {"bodies": ["Sun"], "longitude_ranges": [[0, 15]]},
+            "score": 0.7,
+            "text": "Davison {body} early",
+        }
+    ]
+    req = {"scope": "davison", "positions": {"Sun": 10.0}}
+    out = interpret(req, rules)
+    assert len(out) == 1
+    assert out[0].id == "dav_sun_early"


### PR DESCRIPTION
## Summary
- add interpretation engine module to evaluate synastry and composite rules into structured findings
- provide archetype registry and sample relationship rulepack for core scenarios
- cover rule matching and templating behaviour with unit tests

## Testing
- pytest -q tests/test_relationship_interpret.py


------
https://chatgpt.com/codex/tasks/task_e_68d839ab70e48324937d2fd5f7e845f8