### PR TITLE
Add interpretation API endpoints

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -9,6 +9,7 @@ from app.routers import (
     aspects_router,
     electional_router,
     events_router,
+    interpret_router,
     lots_router,
     policies_router,
     relationship_router,
@@ -27,6 +28,7 @@ app.include_router(transits_router)
 app.include_router(policies_router)
 app.include_router(lots_router)
 app.include_router(relationship_router)
+app.include_router(interpret_router)
 
 
 __all__ = ["app", "configure_position_provider", "clear_position_provider"]

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -13,6 +13,7 @@ __all__ = [
     "policies_router",
     "lots_router",
     "relationship_router",
+    "interpret_router",
     "configure_position_provider",
     "clear_position_provider",
 ]
@@ -42,6 +43,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .events import router as events_router
 
         return events_router
+    if name == "interpret_router":
+        from .interpret import router as interpret_router
+
+        return interpret_router
     if name == "lots_router":
         from .lots import router as lots_router
 

--- a/app/routers/interpret.py
+++ b/app/routers/interpret.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import os
+from dataclasses import asdict
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, HTTPException
+
+from app.schemas.interpret import (
+    RulepacksResponse,
+    RulepackInfo,
+    FindingsRequest,
+    FindingsResponse,
+    FindingOut,
+)
+from core.interpret_plus.engine import interpret, load_rules
+
+router = APIRouter(prefix="/interpret", tags=["Interpretations"])
+
+# Directory containing rulepacks (YAML/JSON). Defaults to built-in samples.
+RULEPACK_DIR = os.getenv(
+    "RULEPACK_DIR",
+    os.path.abspath(
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "..",
+            "core",
+            "interpret_plus",
+            "samples",
+        )
+    ),
+)
+
+
+def _discover_rulepacks() -> List[RulepackInfo]:
+    items: List[RulepackInfo] = []
+    if not os.path.isdir(RULEPACK_DIR):
+        return items
+    for fn in os.listdir(RULEPACK_DIR):
+        if not (fn.endswith(".yaml") or fn.endswith(".yml") or fn.endswith(".json")):
+            continue
+        rid = os.path.splitext(fn)[0]
+        path = os.path.join(RULEPACK_DIR, fn)
+        items.append(RulepackInfo(id=rid, path=path, description=None))
+    items.sort(key=lambda x: x.id)
+    return items
+
+
+@router.get("/rulepacks", response_model=RulepacksResponse, summary="List available rulepacks")
+def list_rulepacks():
+    items = _discover_rulepacks()
+    return RulepacksResponse(items=items, meta={"count": len(items), "dir": RULEPACK_DIR})
+
+
+@router.post("/relationship", response_model=FindingsResponse, summary="Run relationship interpretations")
+def relationship_findings(req: FindingsRequest):
+    # Validate scope payload
+    if req.scope == "synastry" and not req.hits:
+        raise HTTPException(status_code=400, detail="synastry requires hits[]")
+    if req.scope in ("composite", "davison") and not req.positions:
+        raise HTTPException(status_code=400, detail="composite/davison require positions{}")
+
+    # Load rules
+    if req.rules_inline is not None:
+        rules: List[Dict[str, Any]] = req.rules_inline
+    else:
+        rp = req.rulepack_id or "relationship_basic"  # default built-in
+        match = next((r for r in _discover_rulepacks() if r.id == rp), None)
+        if not match:
+            raise HTTPException(status_code=404, detail=f"rulepack not found: {rp}")
+        rules = load_rules(match.path)
+
+    # Build request for engine
+    ireq: Dict[str, Any] = {"scope": req.scope}
+    if req.scope == "synastry":
+        ireq["hits"] = req.hits
+    else:
+        ireq["positions"] = req.positions
+
+    findings = interpret(ireq, rules)
+
+    # Filters
+    if req.min_score is not None:
+        findings = [f for f in findings if f.score >= req.min_score]
+    if req.top_k is not None and req.top_k > 0:
+        findings = findings[: req.top_k]
+
+    return FindingsResponse(
+        findings=[FindingOut(**asdict(f)) for f in findings],
+        meta={"count": len(findings)},
+    )
+
+
+__all__ = ["router", "list_rulepacks", "relationship_findings"]

--- a/app/schemas/interpret.py
+++ b/app/schemas/interpret.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+Scope = Literal["synastry", "composite", "davison"]
+
+
+class RulepackInfo(BaseModel):
+    id: str
+    path: str
+    description: Optional[str] = None
+
+
+class FindingsRequest(BaseModel):
+    scope: Scope
+    # One of these, depending on scope
+    hits: Optional[List[Dict[str, Any]]] = None
+    positions: Optional[Dict[str, float]] = None
+
+    # Rules source
+    rulepack_id: Optional[str] = None
+    rules_inline: Optional[List[Dict[str, Any]]] = None
+
+    # Filters
+    top_k: Optional[int] = Field(default=None, ge=1)
+    min_score: Optional[float] = Field(default=None, ge=0.0)
+
+
+class FindingOut(BaseModel):
+    id: str
+    scope: Scope
+    title: str
+    text: str
+    score: float
+    tags: List[str] = Field(default_factory=list)
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class FindingsResponse(BaseModel):
+    findings: List[FindingOut]
+    meta: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RulepacksResponse(BaseModel):
+    items: List[RulepackInfo]
+    meta: Dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_api_interpret.py
+++ b/tests/test_api_interpret.py
@@ -1,0 +1,63 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.routers.interpret import router as interpret_router
+
+APP = FastAPI()
+APP.include_router(interpret_router)
+CLIENT = TestClient(APP)
+
+SYN_HITS = [
+    {"a": "Sun", "b": "Moon", "aspect": "trine", "severity": 0.6},
+    {"a": "Venus", "b": "Mars", "aspect": "conjunction", "severity": 0.5},
+    {"a": "Saturn", "b": "Venus", "aspect": "square", "severity": 0.4},
+]
+
+
+def test_rulepacks_list():
+    response = CLIENT.get("/interpret/rulepacks")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["meta"]["count"] >= 1
+
+
+def test_relationship_findings_with_default_rulepack():
+    payload = {"scope": "synastry", "hits": SYN_HITS, "top_k": 2}
+    response = CLIENT.post("/interpret/relationship", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["findings"]) <= 2
+
+
+def test_inline_rules_override():
+    rules_inline = [
+        {
+            "id": "only_venus_mars",
+            "scope": "synastry",
+            "when": {
+                "bodies": ["Venus", "Mars"],
+                "aspect_in": ["conjunction"],
+                "min_severity": 0.2,
+            },
+            "score": 2.0,
+            "text": "chemistry",
+        }
+    ]
+    payload = {"scope": "synastry", "hits": SYN_HITS, "rules_inline": rules_inline}
+    response = CLIENT.post("/interpret/relationship", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["findings"]) == 1
+    assert data["findings"][0]["text"] == "chemistry"
+
+
+def test_composite_positions_rulepack():
+    payload = {
+        "scope": "composite",
+        "positions": {"Venus": 5.0},
+        "rulepack_id": "relationship_basic",
+    }
+    response = CLIENT.post("/interpret/relationship", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["findings"], list)


### PR DESCRIPTION
## Summary
- add relationship interpretation schemas and router for listing rulepacks and evaluating findings
- register the interpretation router with the FastAPI app and router exports
- cover the new endpoints with API tests

## Testing
- pytest -q tests/test_api_interpret.py

------
https://chatgpt.com/codex/tasks/task_e_68d83cd3d8c483249bd9817e27432e44