### PR TITLE
Add relationship API v1 service

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,26 @@ The page offers real datasets for quick regression checks:
 Sample longitude presets bundled with the page correspond to historical charts
 captured from published ephemerides so the outputs remain fully data-backed.
 
+### Relationship API (v1)
+
+The new FastAPI-powered relationship service exposes deterministic REST
+endpoints at the `/v1` base path. Launch it via Uvicorn with
+
+```bash
+uvicorn app.relationship_api:create_app --factory --host 0.0.0.0 --port 8000
+```
+
+Key routes:
+
+- `POST /v1/relationship/synastry` → synastry hits, grids, overlays, scores
+- `POST /v1/relationship/composite` → midpoint composites for selected bodies
+- `POST /v1/relationship/davison` → Davison mid-time/space positions via Swiss/Skyfield
+- `GET /v1/healthz` → service health probe
+
+All requests accept strict JSON payloads using Pydantic v2 models and return
+`{code, message, details}` error envelopes on failure. ETags, request IDs, and
+rate limiting headers are emitted automatically for production observability.
+
 ### Next steps
 
 The documentation set now includes step-by-step recipes for three common

--- a/app/relationship_api/__init__.py
+++ b/app/relationship_api/__init__.py
@@ -1,0 +1,30 @@
+"""Relationship API service (B-003) exposing synastry, composite, Davison endpoints."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .config import ServiceSettings
+from .middleware import install_middleware
+from .routes import register_routes
+from .telemetry import configure_logging
+
+
+def create_app(settings: ServiceSettings | None = None) -> FastAPI:
+    """Create and configure a FastAPI application for the relationship API."""
+
+    settings = settings or ServiceSettings.from_env()
+    configure_logging()
+    app = FastAPI(
+        title="AstroEngine Relationship API",
+        version="1.0.0",
+        openapi_url="/v1/openapi.json",
+        docs_url="/docs",
+        redoc_url=None,
+    )
+    install_middleware(app, settings)
+    register_routes(app, settings)
+    return app
+
+
+__all__ = ["create_app", "ServiceSettings"]

--- a/app/relationship_api/composite.py
+++ b/app/relationship_api/composite.py
@@ -1,0 +1,53 @@
+"""Composite and Davison endpoint orchestration."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from core.relationship_plus.composite import Geo, composite_positions, davison_midpoints, davison_positions
+
+from .errors import ServiceError
+from .models import (
+    ChartPositions,
+    CompositeRequest,
+    CompositeResponse,
+    DavisonRequest,
+    DavisonResponse,
+    EclipticPos,
+)
+from .providers import make_position_provider
+from .synastry import chart_longitudes
+
+
+def _positions_to_chart(mapping: Dict[str, float]) -> ChartPositions:
+    payload = {name: EclipticPos(lon=float(lon)) for name, lon in mapping.items()}
+    return ChartPositions.model_validate(payload)
+
+
+def handle_composite(request: CompositeRequest) -> CompositeResponse:
+    pos_a = chart_longitudes(request.positionsA)
+    pos_b = chart_longitudes(request.positionsB)
+    bodies = request.bodies
+    result = composite_positions(pos_a, pos_b, bodies=bodies)
+    if not result:
+        raise ServiceError("MISSING_BODY", "No overlapping bodies for composite", details={"bodies": bodies})
+    return CompositeResponse(positions=_positions_to_chart(result))
+
+
+def handle_davison(request: DavisonRequest) -> DavisonResponse:
+    bodies = request.bodies
+    if not bodies:
+        raise ServiceError("BAD_INPUT", "At least one body must be specified", status_code=400)
+    provider = make_position_provider(request.eph, request.node_policy, bodies)
+    geo_a = Geo(lat_deg=request.birthA.lat, lon_deg_east=request.birthA.lon)
+    geo_b = Geo(lat_deg=request.birthB.lat, lon_deg_east=request.birthB.lon)
+    positions = davison_positions(provider, request.birthA.when, geo_a, request.birthB.when, geo_b, bodies=bodies)
+    missing = [body for body in bodies if body not in positions]
+    if missing:
+        raise ServiceError("MISSING_BODY", "Ephemeris missing requested bodies", details={"missing": missing})
+    mid_dt, mid_lat, mid_lon = davison_midpoints(request.birthA.when, geo_a, request.birthB.when, geo_b)
+    chart = _positions_to_chart(positions)
+    return DavisonResponse(mid_when=mid_dt, mid_lat=mid_lat, mid_lon=mid_lon, positions=chart)
+
+
+__all__ = ["handle_composite", "handle_davison"]

--- a/app/relationship_api/config.py
+++ b/app/relationship_api/config.py
@@ -1,0 +1,49 @@
+"""Runtime configuration helpers for the relationship API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import os
+from typing import Iterable
+
+
+@dataclass(slots=True)
+class ServiceSettings:
+    """Container for environment-derived settings."""
+
+    cors_allow_origins: tuple[str, ...] = field(default_factory=tuple)
+    rate_limit_per_minute: int = 60
+    redis_url: str | None = None
+    gzip_minimum_size: int = 512
+    request_max_bytes: int = 1_000_000
+    enable_etag: bool = True
+
+    @classmethod
+    def from_env(cls) -> "ServiceSettings":
+        def _parse_origins(value: str | None) -> tuple[str, ...]:
+            if not value:
+                return tuple()
+            parts = [item.strip() for item in value.split(",")]
+            return tuple(sorted({p for p in parts if p}))
+
+        redis_url = os.getenv("RELATIONSHIP_REDIS_URL") or os.getenv("REDIS_URL")
+        rate_limit = int(os.getenv("RELATIONSHIP_RATE_LIMIT", "60"))
+        gzip_min_size = int(os.getenv("RELATIONSHIP_GZIP_MIN", "512"))
+        request_max = int(os.getenv("RELATIONSHIP_REQUEST_MAX", "1000000"))
+        enable_etag = os.getenv("RELATIONSHIP_DISABLE_ETAG") not in {"1", "true", "TRUE"}
+        return cls(
+            cors_allow_origins=_parse_origins(os.getenv("CORS_ALLOW_ORIGINS")),
+            rate_limit_per_minute=max(1, rate_limit),
+            redis_url=redis_url,
+            gzip_minimum_size=max(128, gzip_min_size),
+            request_max_bytes=max(32_768, request_max),
+            enable_etag=enable_etag,
+        )
+
+    def cors_origin_list(self) -> Iterable[str]:
+        if self.cors_allow_origins:
+            return self.cors_allow_origins
+        return ("*",)
+
+
+__all__ = ["ServiceSettings"]

--- a/app/relationship_api/errors.py
+++ b/app/relationship_api/errors.py
@@ -1,0 +1,21 @@
+"""Service error types for the relationship API."""
+
+from __future__ import annotations
+
+
+class ServiceError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        status_code: int = 400,
+        details: dict | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status_code = status_code
+        self.details = details or {}
+
+
+__all__ = ["ServiceError"]

--- a/app/relationship_api/middleware.py
+++ b/app/relationship_api/middleware.py
@@ -1,0 +1,116 @@
+"""API middleware stack (request context, body limits, rate limiting)."""
+
+from __future__ import annotations
+
+from logging import LoggerAdapter
+from time import perf_counter
+from typing import Callable
+from uuid import uuid4
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.middleware.gzip import GZipMiddleware
+
+from .config import ServiceSettings
+from .models import ApiError
+from .rate_limit import RateLimiter
+from .telemetry import get_logger
+
+
+class RequestLogger(LoggerAdapter):
+    def process(self, msg, kwargs):  # type: ignore[override]
+        kwargs.setdefault("extra", {})
+        kwargs["extra"].setdefault("request_id", self.extra.get("request_id", "-"))
+        return msg, kwargs
+
+
+class BodyLimitMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, max_bytes: int) -> None:
+        super().__init__(app)
+        self.max_bytes = max_bytes
+
+    async def dispatch(self, request: Request, call_next: Callable):  # type: ignore[override]
+        header_len = request.headers.get("content-length")
+        if header_len and int(header_len) > self.max_bytes:
+            payload = ApiError(code="REQUEST_TOO_LARGE", message="Payload exceeds limit").model_dump()
+            return JSONResponse(status_code=413, content=payload)
+        body = await request.body()
+        if len(body) > self.max_bytes:
+            payload = ApiError(code="REQUEST_TOO_LARGE", message="Payload exceeds limit").model_dump()
+            return JSONResponse(status_code=413, content=payload)
+        request._body = body  # type: ignore[attr-defined]
+        return await call_next(request)
+
+
+class RequestContextMiddleware(BaseHTTPMiddleware):
+    def __init__(self, app: FastAPI, rate_limiter: RateLimiter | None) -> None:
+        super().__init__(app)
+        self.rate_limiter = rate_limiter
+
+    async def dispatch(self, request: Request, call_next: Callable):  # type: ignore[override]
+        request_id = request.headers.get("x-request-id") or uuid4().hex
+        adapter = RequestLogger(get_logger(), {"request_id": request_id})
+        request.state.logger = adapter
+        request.state.request_id = request_id
+        start = perf_counter()
+        adapter.info(
+            "request.start",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "length": request.headers.get("content-length", "0"),
+            },
+        )
+        rate_headers: dict[str, str] | None = None
+        if self.rate_limiter is not None:
+            identity = request.headers.get("x-forwarded-for") or (
+                request.client.host if request.client else "anonymous"
+            )
+            result = await self.rate_limiter.check(identity)
+            rate_headers = {
+                "X-RateLimit-Limit": str(self.rate_limiter.limit),
+                "X-RateLimit-Remaining": str(max(0, result.remaining)),
+                "X-RateLimit-Reset": str(result.reset_seconds),
+            }
+            if not result.allowed:
+                adapter.warning("rate.limit.exceeded", extra={"path": request.url.path})
+                payload = ApiError(code="RATE_LIMIT", message="Rate limit exceeded").model_dump()
+                headers = {"Retry-After": str(result.reset_seconds)}
+                headers.update(rate_headers)
+                headers["X-Request-ID"] = request_id
+                return JSONResponse(status_code=429, content=payload, headers=headers)
+        try:
+            response = await call_next(request)
+        except Exception as exc:
+            adapter.exception("request.error", extra={"error": str(exc)})
+            raise
+        finally:
+            duration_ms = (perf_counter() - start) * 1000.0
+            adapter.info(
+                "request.end",
+                extra={"path": request.url.path, "duration_ms": f"{duration_ms:.2f}"},
+            )
+        response.headers.setdefault("X-Request-ID", request_id)
+        if rate_headers:
+            for key, value in rate_headers.items():
+                response.headers.setdefault(key, value)
+        return response
+
+
+def install_middleware(app: FastAPI, settings: ServiceSettings) -> None:
+    app.add_middleware(GZipMiddleware, minimum_size=settings.gzip_minimum_size)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=list(settings.cors_origin_list()),
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+    rate_limiter = RateLimiter(settings.rate_limit_per_minute, settings.redis_url)
+    app.add_middleware(BodyLimitMiddleware, max_bytes=settings.request_max_bytes)
+    app.add_middleware(RequestContextMiddleware, rate_limiter=rate_limiter)
+
+
+__all__ = ["install_middleware", "RequestLogger"]

--- a/app/relationship_api/models.py
+++ b/app/relationship_api/models.py
@@ -1,0 +1,209 @@
+"""Pydantic models for the relationship API."""
+
+from __future__ import annotations
+
+from typing import Dict, Literal, Tuple
+
+from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, RootModel
+
+Body = Literal[
+    "Sun",
+    "Moon",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+    "Chiron",
+    "Node",
+]
+
+Aspect = Literal[0, 30, 45, 60, 72, 90, 120, 135, 144, 150, 180]
+
+
+class EclipticPos(BaseModel):
+    lon: float = Field(ge=0.0, lt=360.0, description="Ecliptic longitude in degrees")
+    lat: float | None = Field(default=None, description="Ecliptic latitude in degrees")
+    dist: float | None = Field(default=None, description="Optional distance in AU")
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ChartPositions(RootModel[Dict[Body, EclipticPos]]):
+    pass
+
+
+class BirthEvent(BaseModel):
+    when: AwareDatetime
+    lat: float = Field(ge=-90.0, le=90.0)
+    lon: float = Field(ge=-180.0, le=180.0)
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "when": "1985-01-17T12:15:00Z",
+            "lat": 40.7128,
+            "lon": -74.0060,
+        }
+    })
+
+
+class OrbPolicy(BaseModel):
+    base_orb_by_body: Dict[str, float] = Field(default_factory=dict)
+    cap_by_aspect: Dict[int, float] = Field(default_factory=dict)
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Weights(BaseModel):
+    aspect_family: Dict[str, float] = Field(default_factory=dict)
+    body_family: Dict[str, float] = Field(default_factory=dict)
+    conjunction_sign: float = 1.0
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SynastryRequest(BaseModel):
+    positionsA: ChartPositions
+    positionsB: ChartPositions
+    aspects: Tuple[Aspect, ...] | None = None
+    orb_policy: OrbPolicy | None = None
+    weights: Weights | None = None
+    gamma: float = Field(default=1.0, ge=0.1, le=4.0)
+    min_severity: float = Field(default=0.0, ge=0.0)
+    top_k: int | None = Field(default=None, ge=1)
+    offset: int = Field(default=0, ge=0)
+    limit: int | None = Field(default=None, ge=1)
+
+    model_config = ConfigDict(json_schema_extra={
+        "example": {
+            "positionsA": {
+                "Sun": {"lon": 10.0, "lat": 0.0},
+                "Moon": {"lon": 120.5},
+            },
+            "positionsB": {
+                "Sun": {"lon": 190.0},
+                "Moon": {"lon": 300.0},
+            },
+            "min_severity": 0.25,
+            "top_k": 5,
+        }
+    })
+
+
+class Hit(BaseModel):
+    bodyA: Body
+    bodyB: Body
+    aspect: Aspect
+    delta: float
+    orb: float
+    severity: float
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class GridCell(BaseModel):
+    best: Hit | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Overlay(BaseModel):
+    wheelA: list[tuple[Body, float]]
+    wheelB: list[tuple[Body, float]]
+    lines: list[dict]
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class Scores(BaseModel):
+    by_aspect_family: Dict[str, float]
+    by_body_family: Dict[str, float]
+    overall: float
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class SynastryResponse(BaseModel):
+    hits: list[Hit]
+    grid: Dict[str, Dict[str, GridCell]]
+    overlay: Overlay
+    scores: Scores
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class CompositeRequest(BaseModel):
+    positionsA: ChartPositions
+    positionsB: ChartPositions
+    bodies: list[Body] | None = None
+
+    model_config = ConfigDict(extra="forbid", json_schema_extra={
+        "example": {
+            "positionsA": {"Sun": {"lon": 10.0}},
+            "positionsB": {"Sun": {"lon": 20.0}},
+        }
+    })
+
+
+class CompositeResponse(BaseModel):
+    positions: ChartPositions
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class DavisonRequest(BaseModel):
+    birthA: BirthEvent
+    birthB: BirthEvent
+    bodies: list[Body]
+    node_policy: Literal["true", "mean"] = "true"
+    eph: Literal["swiss", "skyfield"] = "swiss"
+
+    model_config = ConfigDict(extra="forbid", json_schema_extra={
+        "example": {
+            "birthA": {"when": "1985-01-17T12:15:00Z", "lat": 40.7128, "lon": -74.0060},
+            "birthB": {"when": "1990-11-30T09:30:00Z", "lat": 51.5072, "lon": -0.1276},
+            "bodies": ["Sun", "Moon", "Venus"],
+        }
+    })
+
+
+class DavisonResponse(BaseModel):
+    mid_when: AwareDatetime
+    mid_lat: float
+    mid_lon: float
+    positions: ChartPositions
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ApiError(BaseModel):
+    code: str
+    message: str
+    details: Dict[str, object] | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+__all__ = [
+    "ApiError",
+    "Aspect",
+    "BirthEvent",
+    "Body",
+    "ChartPositions",
+    "CompositeRequest",
+    "CompositeResponse",
+    "DavisonRequest",
+    "DavisonResponse",
+    "EclipticPos",
+    "GridCell",
+    "Hit",
+    "Overlay",
+    "OrbPolicy",
+    "Scores",
+    "SynastryRequest",
+    "SynastryResponse",
+    "Weights",
+]

--- a/app/relationship_api/providers.py
+++ b/app/relationship_api/providers.py
@@ -1,0 +1,64 @@
+"""Ephemeris provider resolution for Davison composites."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Callable, Iterable
+
+from .telemetry import get_logger
+
+PositionProvider = Callable[[datetime], dict[str, float]]
+
+
+@lru_cache(maxsize=8)
+def _provider_instance(name: str, node_policy: str):
+    name = name.lower()
+    if name == "swiss":
+        try:
+            from astroengine.providers.swiss_provider import SwissProvider
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("Swiss ephemeris unavailable") from exc
+        provider = SwissProvider()
+        if hasattr(provider, "configure"):
+            try:
+                provider.configure(nodes_variant=node_policy)
+            except Exception as exc:  # pragma: no cover - configuration failure
+                get_logger().warning(
+                    "swiss.configure.failed",
+                    extra={"error": str(exc), "request_id": "-"},
+                )
+        return provider
+    if name == "skyfield":
+        try:
+            from astroengine.providers.skyfield_provider import SkyfieldProvider
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise RuntimeError("Skyfield ephemeris unavailable") from exc
+        return SkyfieldProvider()
+    raise ValueError(f"Unsupported ephemeris '{name}'")
+
+
+def make_position_provider(name: str, node_policy: str, bodies: Iterable[str]) -> PositionProvider:
+    bodies_tuple = tuple(sorted(set(bodies)))
+    provider = _provider_instance(name, node_policy)
+
+    def _inner(ts: datetime) -> dict[str, float]:
+        iso = ts.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        data = provider.positions_ecliptic(iso, bodies_tuple)
+        if not isinstance(data, dict):
+            raise TypeError("Ephemeris provider returned unexpected payload")
+        out: dict[str, float] = {}
+        for body in bodies_tuple:
+            entry = data.get(body)
+            if entry is None:
+                continue
+            lon = entry.get("lon")
+            if lon is None:
+                continue
+            out[body] = float(lon) % 360.0
+        return out
+
+    return _inner
+
+
+__all__ = ["make_position_provider", "PositionProvider"]

--- a/app/relationship_api/rate_limit.py
+++ b/app/relationship_api/rate_limit.py
@@ -1,0 +1,74 @@
+"""Rate limiting utilities backed by Redis with in-memory fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import time
+from typing import Dict
+
+from .telemetry import get_logger
+
+try:  # pragma: no cover - optional dependency
+    from redis.asyncio import Redis
+except Exception:  # pragma: no cover - redis optional
+    Redis = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class RateLimitResult:
+    allowed: bool
+    remaining: int
+    reset_seconds: int
+
+
+class RateLimiter:
+    """Minute-based sliding window rate limiter."""
+
+    def __init__(self, limit_per_minute: int, redis_url: str | None) -> None:
+        self.limit = max(1, int(limit_per_minute))
+        self._redis_url = redis_url
+        self._redis: Redis | None = None
+        self._memory: Dict[str, tuple[int, int]] = {}
+        if redis_url and Redis is not None:
+            try:
+                self._redis = Redis.from_url(redis_url, encoding="utf-8", decode_responses=True)
+            except Exception as exc:  # pragma: no cover - connection errors handled at runtime
+                get_logger().warning("rate limiter redis setup failed", extra={"error": str(exc), "request_id": "-"})
+                self._redis = None
+
+    async def check(self, identity: str) -> RateLimitResult:
+        now = int(time.time())
+        window_reset = 60 - (now % 60)
+        if self._redis is not None:
+            key = f"rl:{identity}:{now // 60}"
+            try:
+                pipe = self._redis.pipeline()
+                pipe.incr(key)
+                pipe.expire(key, 120)
+                count, _ = await pipe.execute()
+            except Exception as exc:  # pragma: no cover - redis runtime failure
+                get_logger().warning("rate limiter redis failed", extra={"error": str(exc), "request_id": "-"})
+            else:
+                count_int = int(count)
+                remaining = max(0, self.limit - count_int)
+                return RateLimitResult(
+                    allowed=count_int <= self.limit,
+                    remaining=remaining,
+                    reset_seconds=window_reset,
+                )
+        # Fallback memory limiter
+        count, expiry = self._memory.get(identity, (0, now + 60))
+        if expiry <= now:
+            count = 0
+            expiry = now + 60
+        count += 1
+        self._memory[identity] = (count, expiry)
+        remaining = max(0, self.limit - count)
+        return RateLimitResult(
+            allowed=count <= self.limit,
+            remaining=remaining,
+            reset_seconds=max(1, expiry - now),
+        )
+
+
+__all__ = ["RateLimiter", "RateLimitResult"]

--- a/app/relationship_api/routes.py
+++ b/app/relationship_api/routes.py
@@ -1,0 +1,116 @@
+"""Route registration for the relationship API."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+from fastapi import APIRouter, FastAPI, Request, Response, status
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+
+from .composite import handle_composite, handle_davison
+from .config import ServiceSettings
+from .errors import ServiceError
+from .models import (
+    ApiError,
+    CompositeRequest,
+    CompositeResponse,
+    DavisonRequest,
+    DavisonResponse,
+    SynastryRequest,
+    SynastryResponse,
+)
+from .synastry import compute_synastry
+from .telemetry import get_logger
+
+
+def _etag(path: str, payload: Any) -> str:
+    if hasattr(payload, "model_dump"):
+        data = payload.model_dump(mode="json")  # type: ignore[call-arg]
+    else:
+        data = payload
+    raw = json.dumps({"path": path, "payload": data}, sort_keys=True, separators=(",", ":"), default=str)
+    digest = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+    return f'"{digest}"'
+
+
+def register_routes(app: FastAPI, settings: ServiceSettings) -> None:
+    router = APIRouter(prefix="/v1", tags=["Relationship"])
+
+    @app.exception_handler(ServiceError)
+    async def _service_error_handler(request: Request, exc: ServiceError):  # type: ignore[override]
+        logger = getattr(request.state, "logger", get_logger())
+        logger.warning(
+            "service.error",
+            extra={"code": exc.code, "message": str(exc)},
+        )
+        payload = ApiError(code=exc.code, message=str(exc), details=exc.details)
+        return JSONResponse(status_code=exc.status_code, content=payload.model_dump())
+
+    @app.exception_handler(RequestValidationError)
+    async def _validation_handler(request: Request, exc: RequestValidationError):  # type: ignore[override]
+        logger = getattr(request.state, "logger", get_logger())
+        logger.warning("validation.error", extra={"errors": exc.errors()})
+        payload = ApiError(code="BAD_INPUT", message="Invalid request payload", details={"errors": exc.errors()})
+        return JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=payload.model_dump())
+
+    @router.get("/healthz", summary="Service health", tags=["Health"])
+    async def healthz() -> dict[str, Any]:
+        return {"status": "ok"}
+
+    @router.post(
+        "/relationship/synastry",
+        response_model=SynastryResponse,
+        summary="Synastry hits, grid, overlay, and scores",
+    )
+    async def synastry_endpoint(request: Request, response: Response, payload: SynastryRequest) -> SynastryResponse:
+        logger = getattr(request.state, "logger", get_logger())
+        logger.info("synastry.request", extra={"path": request.url.path})
+        if settings.enable_etag:
+            etag_value = _etag("synastry", payload)
+            if request.headers.get("if-none-match") == etag_value:
+                headers = {"ETag": etag_value}
+                headers.setdefault("X-Request-ID", getattr(request.state, "request_id", "-"))
+                return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)  # type: ignore[return-value]
+            response.headers["ETag"] = etag_value
+        result = compute_synastry(payload)
+        return result
+
+    @router.post(
+        "/relationship/composite",
+        response_model=CompositeResponse,
+        summary="Composite midpoint positions",
+    )
+    async def composite_endpoint(request: Request, response: Response, payload: CompositeRequest) -> CompositeResponse:
+        logger = getattr(request.state, "logger", get_logger())
+        logger.info("composite.request", extra={"path": request.url.path})
+        if settings.enable_etag:
+            etag_value = _etag("composite", payload)
+            if request.headers.get("if-none-match") == etag_value:
+                headers = {"ETag": etag_value}
+                headers.setdefault("X-Request-ID", getattr(request.state, "request_id", "-"))
+                return Response(status_code=status.HTTP_304_NOT_MODIFIED, headers=headers)  # type: ignore[return-value]
+            response.headers["ETag"] = etag_value
+        return handle_composite(payload)
+
+    @router.post(
+        "/relationship/davison",
+        response_model=DavisonResponse,
+        summary="Davison midpoints and positions",
+    )
+    async def davison_endpoint(request: Request, payload: DavisonRequest) -> DavisonResponse:
+        logger = getattr(request.state, "logger", get_logger())
+        logger.info("davison.request", extra={"path": request.url.path, "eph": payload.eph})
+        try:
+            return handle_davison(payload)
+        except ServiceError:
+            raise
+        except Exception as exc:
+            raise ServiceError("EPHEMERIS_ERROR", "Davison computation failed", status_code=500, details={"error": str(exc)}) from exc
+
+    app.include_router(router)
+
+
+__all__ = ["register_routes"]

--- a/app/relationship_api/synastry.py
+++ b/app/relationship_api/synastry.py
@@ -1,0 +1,314 @@
+"""Synastry helpers for the relationship API."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Iterable, Sequence
+
+import numpy as np
+
+from .models import (
+    Aspect,
+    ChartPositions,
+    GridCell,
+    Hit,
+    Overlay,
+    OrbPolicy,
+    Scores,
+    SynastryRequest,
+    SynastryResponse,
+    Weights,
+)
+
+BODY_FAMILY = {
+    "Sun": "luminary",
+    "Moon": "luminary",
+    "Mercury": "personal",
+    "Venus": "personal",
+    "Mars": "personal",
+    "Jupiter": "social",
+    "Saturn": "social",
+    "Uranus": "outer",
+    "Neptune": "outer",
+    "Pluto": "outer",
+    "Chiron": "points",
+    "Node": "points",
+}
+
+ASPECT_FAMILY = {
+    0: "neutral",
+    30: "neutral",
+    45: "challenging",
+    60: "harmonious",
+    72: "harmonious",
+    90: "challenging",
+    120: "harmonious",
+    135: "challenging",
+    144: "harmonious",
+    150: "challenging",
+    180: "challenging",
+}
+
+DEFAULT_ORB_POLICY = OrbPolicy(
+    base_orb_by_body={
+        "Sun": 8.0,
+        "Moon": 8.0,
+        "Mercury": 6.0,
+        "Venus": 6.0,
+        "Mars": 6.0,
+        "Jupiter": 5.0,
+        "Saturn": 5.0,
+        "Uranus": 5.0,
+        "Neptune": 5.0,
+        "Pluto": 5.0,
+        "Chiron": 5.0,
+        "Node": 5.0,
+        "luminary": 8.0,
+        "personal": 6.0,
+        "social": 5.0,
+        "outer": 5.0,
+        "points": 5.0,
+    },
+    cap_by_aspect={
+        0: 8.0,
+        30: 2.0,
+        45: 2.0,
+        60: 4.0,
+        72: 1.5,
+        90: 6.0,
+        120: 6.0,
+        135: 2.0,
+        144: 1.5,
+        150: 2.0,
+        180: 8.0,
+    },
+)
+
+DEFAULT_WEIGHTS = Weights(
+    aspect_family={"harmonious": 1.0, "challenging": 1.0, "neutral": 0.8},
+    body_family={
+        "luminary": 1.2,
+        "personal": 1.0,
+        "social": 0.8,
+        "outer": 0.8,
+        "points": 0.9,
+    },
+    conjunction_sign=1.0,
+)
+
+DEFAULT_ASPECTS: tuple[Aspect, ...] = (0, 30, 45, 60, 72, 90, 120, 135, 144, 150, 180)
+
+
+def chart_longitudes(chart: ChartPositions) -> dict[str, float]:
+    return {key: float(pos.lon) for key, pos in chart.root.items()}
+
+
+def _resolve_base_orb(body: str, policy: OrbPolicy) -> float:
+    mapping = policy.base_orb_by_body or {}
+    if body in mapping:
+        return float(mapping[body])
+    family = BODY_FAMILY.get(body)
+    if family and family in mapping:
+        return float(mapping[family])
+    return float(DEFAULT_ORB_POLICY.base_orb_by_body.get(body, 5.0))
+
+
+def _aspect_cap(angle: int, policy: OrbPolicy) -> float:
+    caps = policy.cap_by_aspect or {}
+    if angle in caps:
+        return float(caps[angle])
+    return float(DEFAULT_ORB_POLICY.cap_by_aspect.get(angle, 3.0))
+
+
+def _pair_base_orb(body_a: str, body_b: str, policy: OrbPolicy) -> float:
+    a = _resolve_base_orb(body_a, policy)
+    b = _resolve_base_orb(body_b, policy)
+    return max(0.1, (a + b) / 2.0)
+
+
+def _pair_body_weight(body_a: str, body_b: str, weights: Weights) -> float:
+    mapping = weights.body_family or {}
+    default = DEFAULT_WEIGHTS.body_family
+    fam_a = BODY_FAMILY.get(body_a)
+    fam_b = BODY_FAMILY.get(body_b)
+    w_a = float(mapping.get(fam_a, default.get(fam_a, 1.0))) if fam_a else 1.0
+    w_b = float(mapping.get(fam_b, default.get(fam_b, 1.0))) if fam_b else 1.0
+    return max(0.1, (w_a + w_b) / 2.0)
+
+
+def _aspect_weight(angle: int, weights: Weights) -> float:
+    family = ASPECT_FAMILY.get(angle, "neutral")
+    mapping = weights.aspect_family or {}
+    default = DEFAULT_WEIGHTS.aspect_family
+    return float(mapping.get(family, default.get(family, 1.0)))
+
+
+def _same_sign(lon_a: float, lon_b: float) -> bool:
+    return int(lon_a // 30.0) == int(lon_b // 30.0)
+
+
+def _angular_sep(lon_a: float, lon_b: float) -> float:
+    return abs(((lon_a - lon_b + 180.0) % 360.0) - 180.0)
+
+
+def _compute_hits(
+    pos_a: dict[str, float],
+    pos_b: dict[str, float],
+    *,
+    aspects: Sequence[Aspect],
+    policy: OrbPolicy,
+    weights: Weights,
+    gamma: float,
+) -> list[Hit]:
+    bodies_a = sorted(pos_a.keys())
+    bodies_b = sorted(pos_b.keys())
+    if not bodies_a or not bodies_b:
+        return []
+    arr_a = np.array([pos_a[name] for name in bodies_a], dtype=float)
+    arr_b = np.array([pos_b[name] for name in bodies_b], dtype=float)
+    sep = np.abs(((arr_a[:, None] - arr_b[None, :]) + 180.0) % 360.0 - 180.0)
+    base_matrix = np.array(
+        [[_pair_base_orb(a, b, policy) for b in bodies_b] for a in bodies_a],
+        dtype=float,
+    )
+    body_weight_matrix = np.array(
+        [[_pair_body_weight(a, b, weights) for b in bodies_b] for a in bodies_a],
+        dtype=float,
+    )
+    same_sign_matrix = np.equal(np.floor(arr_a[:, None] / 30.0), np.floor(arr_b[None, :] / 30.0))
+
+    hits: list[Hit] = []
+    for aspect in aspects:
+        cap = _aspect_cap(int(aspect), policy)
+        limit_matrix = np.minimum(base_matrix, cap)
+        orb_matrix = np.abs(sep - float(aspect))
+        mask = orb_matrix <= limit_matrix
+        indices = np.argwhere(mask)
+        if indices.size == 0:
+            continue
+        aspect_weight = _aspect_weight(int(aspect), weights)
+        for idx in indices:
+            i, j = int(idx[0]), int(idx[1])
+            limit = float(limit_matrix[i, j])
+            if limit <= 0:
+                continue
+            orb = float(orb_matrix[i, j])
+            base_severity = max(0.0, 1.0 - orb / limit)
+            severity = base_severity * aspect_weight * float(body_weight_matrix[i, j])
+            if aspect == 0 and same_sign_matrix[i, j]:
+                severity *= float(weights.conjunction_sign)
+            severity = min(1.0, max(0.0, severity))
+            if gamma != 1.0:
+                severity = pow(severity, gamma)
+            hits.append(
+                Hit(
+                    bodyA=bodies_a[i],
+                    bodyB=bodies_b[j],
+                    aspect=int(aspect),
+                    delta=float(sep[i, j]),
+                    orb=orb,
+                    severity=severity,
+                )
+            )
+    hits.sort(key=lambda h: (-h.severity, h.orb, h.bodyA, h.bodyB, h.aspect))
+    return hits
+
+
+def _grid_from_hits(hits: Iterable[Hit]) -> dict[str, dict[str, GridCell]]:
+    grid: dict[str, dict[str, GridCell]] = {}
+    for hit in hits:
+        rows = grid.setdefault(hit.bodyA, {})
+        cell = rows.get(hit.bodyB)
+        if cell is None or (cell.best and hit.severity > cell.best.severity):
+            rows[hit.bodyB] = GridCell(best=hit)
+    return grid
+
+
+def _overlay(pos_a: dict[str, float], pos_b: dict[str, float], hits: Iterable[Hit]) -> Overlay:
+    wheel_a = sorted(((name, float(lon)) for name, lon in pos_a.items()), key=lambda item: item[0])
+    wheel_b = sorted(((name, float(lon)) for name, lon in pos_b.items()), key=lambda item: item[0])
+    index_a = {name: lon for name, lon in wheel_a}
+    index_b = {name: lon for name, lon in wheel_b}
+    lines = []
+    for hit in hits:
+        lon_a = index_a.get(hit.bodyA)
+        lon_b = index_b.get(hit.bodyB)
+        if lon_a is None or lon_b is None:
+            continue
+        lines.append(
+            {
+                "from": {"body": hit.bodyA, "lon": lon_a},
+                "to": {"body": hit.bodyB, "lon": lon_b},
+                "aspect": hit.aspect,
+                "severity": hit.severity,
+            }
+        )
+    return Overlay(wheelA=list(wheel_a), wheelB=list(wheel_b), lines=lines)
+
+
+def _scores(hits: Iterable[Hit]) -> Scores:
+    per_aspect: dict[str, float] = defaultdict(float)
+    per_body: dict[str, float] = defaultdict(float)
+    total = 0.0
+    for hit in hits:
+        total += hit.severity
+        family = ASPECT_FAMILY.get(hit.aspect, "neutral")
+        per_aspect[family] += hit.severity
+        fam_a = BODY_FAMILY.get(hit.bodyA)
+        fam_b = BODY_FAMILY.get(hit.bodyB)
+        if fam_a:
+            per_body[fam_a] += hit.severity / 2.0
+        if fam_b:
+            per_body[fam_b] += hit.severity / 2.0
+    return Scores(
+        by_aspect_family=dict(sorted(per_aspect.items())),
+        by_body_family=dict(sorted(per_body.items())),
+        overall=total,
+    )
+
+
+def resolve_aspects(request: SynastryRequest) -> tuple[Aspect, ...]:
+    return request.aspects or DEFAULT_ASPECTS
+
+
+def resolve_policy(request: SynastryRequest) -> OrbPolicy:
+    if request.orb_policy is not None:
+        return request.orb_policy
+    return DEFAULT_ORB_POLICY
+
+
+def resolve_weights(request: SynastryRequest) -> Weights:
+    if request.weights is not None:
+        return request.weights
+    return DEFAULT_WEIGHTS
+
+
+def compute_synastry(request: SynastryRequest) -> SynastryResponse:
+    aspects = resolve_aspects(request)
+    policy = resolve_policy(request)
+    weights = resolve_weights(request)
+    pos_a = chart_longitudes(request.positionsA)
+    pos_b = chart_longitudes(request.positionsB)
+    hits = _compute_hits(pos_a, pos_b, aspects=aspects, policy=policy, weights=weights, gamma=float(request.gamma))
+    if request.min_severity > 0:
+        hits = [hit for hit in hits if hit.severity >= request.min_severity]
+    if request.top_k is not None:
+        hits = hits[: request.top_k]
+    if request.limit is not None:
+        start = request.offset
+        end = start + request.limit
+        hits_page = hits[start:end]
+    else:
+        hits_page = hits[request.offset :]
+    grid = _grid_from_hits(hits_page)
+    overlay = _overlay(pos_a, pos_b, hits_page)
+    scores = _scores(hits_page)
+    return SynastryResponse(hits=hits_page, grid=grid, overlay=overlay, scores=scores)
+
+
+__all__ = [
+    "compute_synastry",
+    "chart_longitudes",
+    "DEFAULT_ORB_POLICY",
+    "DEFAULT_WEIGHTS",
+]

--- a/app/relationship_api/telemetry.py
+++ b/app/relationship_api/telemetry.py
@@ -1,0 +1,37 @@
+"""Logging utilities for the relationship API."""
+
+from __future__ import annotations
+
+import logging
+import os
+
+
+_LOGGER_NAME = "relationship_api"
+
+
+def configure_logging() -> None:
+    """Configure structured-ish logging once per process."""
+
+    if getattr(configure_logging, "_configured", False):  # type: ignore[attr-defined]
+        return
+    level_name = os.getenv("RELATIONSHIP_LOG_LEVEL", "INFO").upper()
+    level = getattr(logging, level_name, logging.INFO)
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter(
+        "%(asctime)s %(levelname)s %(name)s [%(request_id)s] %(message)s"
+    )
+    handler.setFormatter(formatter)
+    root = logging.getLogger(_LOGGER_NAME)
+    root.setLevel(level)
+    root.propagate = False
+    if not root.handlers:
+        root.addHandler(handler)
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)
+    configure_logging._configured = True  # type: ignore[attr-defined]
+
+
+def get_logger() -> logging.Logger:
+    return logging.getLogger(_LOGGER_NAME)
+
+
+__all__ = ["configure_logging", "get_logger"]

--- a/core/relationship_plus/synastry.py
+++ b/core/relationship_plus/synastry.py
@@ -1,4 +1,3 @@
-tionship-api
 """Synastry helpers for combining two position sets."""
 
 from __future__ import annotations

--- a/tests/test_relationship_api.py
+++ b/tests/test_relationship_api.py
@@ -1,0 +1,105 @@
+"""Tests for the B-003 relationship API service."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from app.relationship_api import ServiceSettings, create_app
+
+
+class LinearEphemeris:
+    def __init__(self, origin: datetime, base: dict[str, float], rates: dict[str, float]) -> None:
+        self.origin = origin
+        self.base = base
+        self.rates = rates
+
+    def __call__(self, ts: datetime) -> dict[str, float]:
+        delta_days = (ts - self.origin).total_seconds() / 86400.0
+        return {
+            name: (self.base.get(name, 0.0) + self.rates.get(name, 0.0) * delta_days) % 360.0
+            for name in self.base
+        }
+
+
+def build_client() -> TestClient:
+    settings = ServiceSettings(rate_limit_per_minute=1000, enable_etag=True)
+    app = create_app(settings)
+    return TestClient(app)
+
+
+def test_synastry_endpoint_returns_hits_and_etag():
+    client = build_client()
+    payload = {
+        "positionsA": {
+            "Sun": {"lon": 10.0},
+            "Moon": {"lon": 200.0},
+            "Venus": {"lon": 40.0},
+        },
+        "positionsB": {
+            "Sun": {"lon": 190.0},
+            "Moon": {"lon": 20.0},
+            "Mars": {"lon": 45.0},
+        },
+        "min_severity": 0.1,
+    }
+    response = client.post("/v1/relationship/synastry", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["hits"], "Expected synastry hits"
+    assert data["scores"]["overall"] > 0
+    etag = response.headers.get("ETag")
+    assert etag, "ETag header missing"
+    cached = client.post(
+        "/v1/relationship/synastry",
+        json=payload,
+        headers={"If-None-Match": etag},
+    )
+    assert cached.status_code == 304
+
+
+def test_composite_endpoint_midpoint():
+    client = build_client()
+    payload = {
+        "positionsA": {"Sun": {"lon": 350.0}, "Moon": {"lon": 20.0}},
+        "positionsB": {"Sun": {"lon": 10.0}, "Moon": {"lon": 80.0}},
+    }
+    response = client.post("/v1/relationship/composite", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert abs(data["positions"]["Sun"]["lon"] - 0.0) < 1e-6
+    assert abs(data["positions"]["Moon"]["lon"] - 50.0) < 1e-6
+
+
+def test_davison_endpoint_with_stub(monkeypatch):
+    client = build_client()
+    origin = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    stub = LinearEphemeris(
+        origin,
+        base={"Sun": 10.0, "Venus": 20.0},
+        rates={"Sun": 1.0, "Venus": 1.2},
+    )
+
+    def fake_provider(_name: str, _node_policy: str, bodies: list[str]):
+        def _inner(ts: datetime) -> dict[str, float]:
+            return stub(ts)
+
+        return _inner
+
+    monkeypatch.setattr("app.relationship_api.composite.make_position_provider", fake_provider)
+
+    payload = {
+        "birthA": {"when": origin.isoformat(), "lat": 10.0, "lon": 20.0},
+        "birthB": {"when": (origin + timedelta(days=10)).isoformat(), "lat": -10.0, "lon": 40.0},
+        "bodies": ["Sun", "Venus"],
+        "eph": "swiss",
+    }
+    response = client.post("/v1/relationship/davison", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert "positions" in data and set(data["positions"]) == {"Sun", "Venus"}
+    assert abs(data["positions"]["Sun"]["lon"] - 15.0) < 1e-6
+    assert abs(data["positions"]["Venus"]["lon"] - 26.0) < 1e-6
+    mid = datetime.fromisoformat(data["mid_when"].replace("Z", "+00:00"))
+    assert mid == origin + timedelta(days=5)


### PR DESCRIPTION
## Summary
- introduce a dedicated FastAPI relationship service with request ID logging, gzip, optional Redis rate limiting, and health checks
- define strict Pydantic v2 schemas plus vectorised synastry, composite, and Davison helpers with ephemeris adapters and defaults
- document the new `/v1` endpoints and add regression tests for synastry ETags, composite midpoints, and Davison responses

## Testing
- pytest tests/test_relationship_api.py
- pytest *(fails: existing api/router modules lack optional FastAPI & SQLAlchemy symbols in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d8475aa0308324b0a700181114bb1e