### PR TITLE
Add Streamlit relationship lab interface

### DIFF
--- a/apps/relationship_lab.py
+++ b/apps/relationship_lab.py
@@ -1,0 +1,29 @@
+"""Streamlit entrypoint for the Relationship Lab."""
+
+from __future__ import annotations
+
+import importlib
+import pathlib
+import sys
+
+
+def _resolve_run():
+    try:
+        from streamlit.relationship_lab import run as streamlit_run
+        return streamlit_run
+    except ModuleNotFoundError:
+        repo_root = pathlib.Path(__file__).resolve().parents[1]
+        package_root = repo_root / "streamlit"
+        for path in (str(repo_root), str(package_root)):
+            if path not in sys.path:
+                sys.path.insert(0, path)
+        module = importlib.import_module("relationship_lab.app")
+        sys.modules.setdefault("streamlit.relationship_lab", module)
+        return module.run
+
+
+run = _resolve_run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution guard
+    run()

--- a/core/relationship_plus/synastry.py
+++ b/core/relationship_plus/synastry.py
@@ -1,4 +1,3 @@
-tionship-api
 """Synastry helpers for combining two position sets."""
 
 from __future__ import annotations

--- a/streamlit/relationship_lab/__init__.py
+++ b/streamlit/relationship_lab/__init__.py
@@ -1,0 +1,5 @@
+"""Relationship Lab Streamlit module."""
+
+from .app import run
+
+__all__ = ["run"]

--- a/streamlit/relationship_lab/api.py
+++ b/streamlit/relationship_lab/api.py
@@ -1,0 +1,174 @@
+"""Client helpers for Relationship Lab data sources."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Protocol
+
+import requests
+
+try:  # FastAPI router utilities are optional at runtime
+    from app.routers import aspects as aspects_module  # type: ignore
+except Exception:  # pragma: no cover - optional dependency for local mode
+    aspects_module = None  # type: ignore[assignment]
+
+from core.relationship_plus.composite import (
+    Geo,
+    composite_positions,
+    davison_midpoints,
+    davison_positions,
+)
+from core.relationship_plus.synastry import (
+    SynastryHit,
+    overlay_positions,
+    synastry_grid,
+    synastry_hits,
+    synastry_score,
+)
+
+
+class RelationshipBackend(Protocol):
+    """Protocol describing the operations required by the UI layer."""
+
+    def synastry(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        ...
+
+    def composite(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        ...
+
+    def davison(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        ...
+
+
+@dataclass(frozen=True)
+class RelationshipAPI(RelationshipBackend):
+    """HTTP client against the relationship endpoints exposed by B-003."""
+
+    base_url: str
+    timeout_synastry: int = 60
+    timeout_composite: int = 30
+    timeout_davison: int = 60
+
+    def _post(self, path: str, payload: Mapping[str, Any], *, timeout: int) -> Dict[str, Any]:
+        root = self.base_url.rstrip("/")
+        url = f"{root}{path}" if path.startswith("/") else f"{root}/{path}"
+        response = requests.post(url, json=payload, timeout=timeout)
+        response.raise_for_status()
+        try:
+            data = response.json()
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise RuntimeError("API returned a non-JSON payload") from exc
+        if not isinstance(data, MutableMapping):  # pragma: no cover - defensive
+            raise RuntimeError("Unexpected response type from relationship API")
+        return dict(data)
+
+    def synastry(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        return self._post("/relationship/synastry", payload, timeout=self.timeout_synastry)
+
+    def composite(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        return self._post("/relationship/composite", payload, timeout=self.timeout_composite)
+
+    def davison(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        return self._post("/relationship/davison", payload, timeout=self.timeout_davison)
+
+
+@dataclass(frozen=True)
+class RelationshipInProcess(RelationshipBackend):
+    """In-process adapter that mirrors the behaviour of the HTTP API."""
+
+    def synastry(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        pos_a = _require_mapping(payload.get("posA"), "posA")
+        pos_b = _require_mapping(payload.get("posB"), "posB")
+        aspects = list(payload.get("aspects") or [])
+        policy = payload.get("orb_policy_inline") or {}
+        per_aspect_weight = payload.get("per_aspect_weight")
+        per_pair_weight = payload.get("per_pair_weight")
+
+        hits = synastry_hits(
+            pos_a,
+            pos_b,
+            aspects=aspects,
+            policy=policy,
+            per_aspect_weight=per_aspect_weight,
+            per_pair_weight=per_pair_weight,
+        )
+        grid = synastry_grid(hits)
+        overlay = overlay_positions(pos_a, pos_b)
+        scores = synastry_score(hits)
+        return {
+            "hits": [_hit_to_dict(hit) for hit in hits],
+            "grid": grid,
+            "overlay": overlay,
+            "scores": scores,
+            "meta": {"count": len(hits)},
+        }
+
+    def composite(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        pos_a = _require_mapping(payload.get("posA"), "posA")
+        pos_b = _require_mapping(payload.get("posB"), "posB")
+        bodies = payload.get("bodies")
+        positions = composite_positions(pos_a, pos_b, bodies=bodies)
+        return {"positions": positions, "meta": {"bodies": list(positions.keys())}}
+
+    def davison(self, payload: Mapping[str, Any]) -> Dict[str, Any]:
+        if aspects_module is None:
+            raise RuntimeError(
+                "Local Davison computation requires the API aspects module to resolve providers."
+            )
+        provider = aspects_module._get_provider()  # type: ignore[attr-defined]
+        dt_a = payload.get("dtA")
+        dt_b = payload.get("dtB")
+        if isinstance(dt_a, str):
+            dt_a = datetime.fromisoformat(dt_a)
+        if isinstance(dt_b, str):
+            dt_b = datetime.fromisoformat(dt_b)
+        if dt_a is None or dt_b is None:
+            raise RuntimeError("Davison payload requires 'dtA' and 'dtB' timestamps")
+        loc_a_raw = payload.get("locA")
+        loc_b_raw = payload.get("locB")
+        loc_a = _require_mapping(loc_a_raw, "locA")
+        loc_b = _require_mapping(loc_b_raw, "locB")
+        geo_a = Geo(lat_deg=float(loc_a["lat_deg"]), lon_deg_east=float(loc_a["lon_deg_east"]))
+        geo_b = Geo(lat_deg=float(loc_b["lat_deg"]), lon_deg_east=float(loc_b["lon_deg_east"]))
+        bodies = payload.get("bodies")
+        positions = davison_positions(provider, dt_a, geo_a, dt_b, geo_b, bodies=bodies)
+        mid_dt, mid_lat, mid_lon = davison_midpoints(dt_a, geo_a, dt_b, geo_b)
+        return {
+            "positions": positions,
+            "midpoint_time_utc": mid_dt.isoformat() if hasattr(mid_dt, "isoformat") else mid_dt,
+            "midpoint_geo": {"lat_deg": mid_lat, "lon_deg_east": mid_lon},
+            "meta": {"bodies": list(positions.keys())},
+        }
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise RuntimeError(f"Expected '{label}' to be a mapping of names to values")
+    return value
+
+
+def _hit_to_dict(hit: SynastryHit) -> Dict[str, Any]:
+    return {
+        "a": hit.a,
+        "b": hit.b,
+        "aspect": hit.aspect,
+        "angle": hit.angle,
+        "delta": hit.delta,
+        "orb": hit.orb,
+        "limit": hit.limit,
+        "severity": hit.severity,
+    }
+
+
+def build_backend(mode: str, *, base_url: Optional[str] = None) -> RelationshipBackend:
+    """Return a backend implementation based on ``mode``."""
+
+    if mode == "api":
+        if not base_url:
+            raise RuntimeError("API mode requires a base URL")
+        return RelationshipAPI(base_url)
+    if mode == "local":
+        return RelationshipInProcess()
+    raise ValueError(f"Unknown backend mode: {mode}")

--- a/streamlit/relationship_lab/app.py
+++ b/streamlit/relationship_lab/app.py
@@ -1,0 +1,339 @@
+"""Streamlit single-page app for the Relationship Lab."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+from datetime import UTC, datetime, timedelta, timezone
+from collections.abc import Iterable, Mapping
+from typing import Any, Dict
+
+try:  # pragma: no cover - Streamlit import guarded for tests
+    import streamlit as st
+except Exception:  # pragma: no cover - surfaced to CLI when dependencies missing
+    print("This app requires the UI extras. Install with: pip install -e .[ui]")
+    raise
+
+from .api import build_backend
+from .constants import ASPECTS, EXTENDED_ASPECTS, MAJOR_ASPECTS
+from .samples import DEFAULT_PAIR, get_sample, sample_labels
+from .state import get_state, update_state, export_state_payload
+from .views import (
+    build_summary_markdown,
+    filter_hits,
+    render_grid,
+    render_hits_table,
+    render_markdown_copy,
+    render_overlay_table,
+    render_scores,
+)
+from .wheels import render_wheel_svg
+
+
+def _parse_positions(text: str) -> Dict[str, float]:
+    if not text.strip():
+        return {}
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON payload: {exc}") from exc
+    if not isinstance(data, Mapping):
+        raise ValueError("Positions JSON must be an object mapping names to degrees")
+    result: Dict[str, float] = {}
+    for key, value in data.items():
+        try:
+            result[str(key)] = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Longitude for '{key}' must be numeric") from exc
+    return result
+
+
+def _ensure_text_key(st_module, key: str, default_text: str) -> None:
+    if key not in st_module.session_state:
+        st_module.session_state[key] = default_text
+
+
+def _positions_editor(column, label: str, state_attr: str, default_sample: str) -> str:
+    state = get_state(st)
+    text_key = f"{state_attr}_textarea"
+    current_default = getattr(state, state_attr) or json.dumps(get_sample(default_sample).positions, indent=2)
+    _ensure_text_key(st, text_key, current_default)
+
+    options = ["Custom"] + sample_labels()
+    default_index = options.index(default_sample) if default_sample in options else 0
+    choice = column.selectbox("Sample", options, index=default_index, key=f"{state_attr}_sample")
+    if choice != "Custom" and column.button("Load sample", key=f"{state_attr}_load"):
+        payload = json.dumps(get_sample(choice).positions, indent=2)
+        st.session_state[text_key] = payload
+        update_state(st, **{state_attr: payload})
+    upload = column.file_uploader("Upload ChartPositions JSON", type=["json"], key=f"{state_attr}_upload")
+    if upload is not None:
+        try:
+            payload = json.load(upload)
+        except json.JSONDecodeError as exc:
+            column.error(f"Failed to parse uploaded JSON: {exc}")
+        else:
+            if isinstance(payload, Mapping):
+                text_payload = json.dumps(payload, indent=2)
+                st.session_state[text_key] = text_payload
+                update_state(st, **{state_attr: text_payload})
+            else:
+                column.error("Uploaded JSON must be an object mapping names to longitudes.")
+    text = column.text_area(label, key=text_key, height=240)
+    update_state(st, **{state_attr: text})
+    return text
+
+
+def _weights_payload(profile: str, aspects: Iterable[str]) -> Dict[str, float] | None:
+    if profile == "flat":
+        return {aspect: 1.0 for aspect in aspects}
+    return None
+
+
+def _wheel_section(pos_a: Mapping[str, float], pos_b: Mapping[str, float]) -> None:
+    col_left, col_right = st.columns(2)
+    with col_left:
+        st.markdown("**Chart A**")
+        svg_a = render_wheel_svg(pos_a)
+        st.markdown(svg_a, unsafe_allow_html=True)
+    with col_right:
+        st.markdown("**Chart B**")
+        svg_b = render_wheel_svg(pos_b)
+        st.markdown(svg_b, unsafe_allow_html=True)
+
+
+def _composite_wheel(title: str, positions: Mapping[str, float]) -> None:
+    st.markdown(f"**{title}**")
+    svg = render_wheel_svg(positions, size=360)
+    st.markdown(svg, unsafe_allow_html=True)
+
+
+def run() -> None:
+    st.set_page_config(page_title="Relationship Lab", page_icon="💞", layout="wide")
+    state = get_state(st)
+
+    st.title("Relationship Lab")
+
+    with st.sidebar:
+        st.header("Configuration")
+        mode_labels = {"API (B-003)": "api", "Local (in-process)": "local"}
+        current_label = next((label for label, value in mode_labels.items() if value == state.mode), "API (B-003)")
+        selected_label = st.radio("Computation mode", list(mode_labels.keys()), index=list(mode_labels.keys()).index(current_label))
+        mode = mode_labels[selected_label]
+        update_state(st, mode=mode)
+        if mode == "api":
+            base = st.text_input("API base URL", value=state.api_base_url)
+            update_state(st, api_base_url=base)
+        else:
+            st.caption("Local mode uses the in-process relationship engine if available.")
+
+        min_sev = st.slider("Minimum severity", 0.0, 1.0, value=state.min_severity, step=0.05)
+        update_state(st, min_severity=min_sev)
+
+        aspect_modes = ["Majors only", "Majors + minors", "Custom"]
+        aspect_mode = st.radio("Aspect set", aspect_modes, index=aspect_modes.index("Majors + minors" if state.aspect_mode == "extended" else ("Majors only" if state.aspect_mode == "majors" else "Custom")))
+        if aspect_mode == "Majors only":
+            aspects = list(MAJOR_ASPECTS)
+            update_state(st, aspect_mode="majors", aspects=aspects)
+        elif aspect_mode == "Majors + minors":
+            aspects = list(EXTENDED_ASPECTS)
+            update_state(st, aspect_mode="extended", aspects=aspects)
+        else:
+            all_options = list(ASPECTS.keys())
+            selected = st.multiselect("Select aspects", all_options, default=state.aspects)
+            if selected:
+                update_state(st, aspect_mode="custom", aspects=selected)
+            aspects = state.aspects
+
+        weights_profile = st.selectbox("Weights profile", ["default", "flat"], format_func=lambda key: "Default policy" if key == "default" else "Flat (1.0)", index=["default", "flat"].index(state.weights_profile if state.weights_profile in ("default", "flat") else "default"))
+        update_state(st, weights_profile=weights_profile)
+
+        with st.expander("Session state", expanded=False):
+            exported = json.dumps(export_state_payload(state), indent=2)
+            st.download_button("Export session JSON", data=exported, file_name="relationship_lab_state.json", mime="application/json")
+            imported = st.file_uploader("Import session JSON", type=["json"], key="session_import")
+            if imported is not None:
+                try:
+                    payload = json.load(imported)
+                except json.JSONDecodeError as exc:
+                    st.error(f"Failed to decode session JSON: {exc}")
+                else:
+                    if isinstance(payload, Mapping):
+                        update_state(st, **payload)
+                        st.success("Session state imported. Reloading…")
+                        st.experimental_rerun()
+                    else:
+                        st.error("Session JSON must be an object.")
+
+    state = get_state(st)
+
+    col_a, col_b = st.columns(2)
+    text_a = _positions_editor(col_a, "Chart A — ChartPositions JSON", "positions_a_text", DEFAULT_PAIR[0])
+    text_b = _positions_editor(col_b, "Chart B — ChartPositions JSON", "positions_b_text", DEFAULT_PAIR[1])
+
+    tabs = st.tabs(["Synastry", "Composite", "Davison"])
+
+    backend_kwargs = {"base_url": state.api_base_url} if state.mode == "api" else {}
+    backend = build_backend(state.mode, **backend_kwargs)
+
+    with tabs[0]:
+        st.subheader("Synastry: aspects, grid, scores")
+        if st.button("Compute synastry", type="primary"):
+            try:
+                pos_a = _parse_positions(text_a)
+                pos_b = _parse_positions(text_b)
+            except ValueError as exc:
+                st.error(str(exc))
+            else:
+                payload = {
+                    "posA": pos_a,
+                    "posB": pos_b,
+                    "aspects": list(get_state(st).aspects),
+                }
+                weights = _weights_payload(get_state(st).weights_profile, payload["aspects"])
+                if weights:
+                    payload["per_aspect_weight"] = weights
+                try:
+                    result = backend.synastry(payload)
+                except Exception as exc:
+                    st.error(f"Failed to compute synastry: {exc}")
+                else:
+                    update_state(st, last_synastry=result)
+        result = get_state(st).last_synastry
+        if result:
+            try:
+                pos_a = _parse_positions(text_a)
+                pos_b = _parse_positions(text_b)
+            except ValueError:
+                pos_a = {}
+                pos_b = {}
+            _wheel_section(pos_a, pos_b)
+            hits = result.get("hits", [])
+            filtered_hits = filter_hits(hits, get_state(st).min_severity)
+            hits_df = render_hits_table(hits, min_severity=get_state(st).min_severity)
+            grid_df = render_grid(result.get("grid", {}))
+            scores_summary = render_scores(filtered_hits)
+            overlay_df = render_overlay_table(result.get("overlay", {}))
+            summary_text = build_summary_markdown("Synastry summary", filtered_hits, scores_summary)
+            with st.expander("Copy summary", expanded=False):
+                render_markdown_copy(summary_text)
+            if hits_df is not None:
+                st.download_button(
+                    "Download hits CSV",
+                    data=hits_df.to_csv(index=False).encode("utf-8"),
+                    file_name="synastry_hits.csv",
+                    mime="text/csv",
+                )
+            st.download_button(
+                "Download synastry JSON",
+                data=json.dumps(result, indent=2),
+                file_name="synastry_result.json",
+                mime="application/json",
+            )
+            with st.expander("Import saved synastry result", expanded=False):
+                uploaded = st.file_uploader("Load synastry JSON", type=["json"], key="synastry_import")
+                if uploaded is not None:
+                    try:
+                        payload = json.load(uploaded)
+                    except json.JSONDecodeError as exc:
+                        st.error(f"Failed to decode synastry JSON: {exc}")
+                    else:
+                        if isinstance(payload, Mapping):
+                            update_state(st, last_synastry=payload)
+                            st.experimental_rerun()
+                        else:
+                            st.error("Synastry JSON must be an object.")
+
+    with tabs[1]:
+        st.subheader("Composite — midpoint positions")
+        if st.button("Compute composite"):
+            try:
+                pos_a = _parse_positions(text_a)
+                pos_b = _parse_positions(text_b)
+            except ValueError as exc:
+                st.error(str(exc))
+            else:
+                bodies = sorted(set(pos_a) & set(pos_b)) or None
+                payload = {"posA": pos_a, "posB": pos_b}
+                if bodies:
+                    payload["bodies"] = bodies
+                try:
+                    result = backend.composite(payload)
+                except Exception as exc:
+                    st.error(f"Failed to compute composite positions: {exc}")
+                else:
+                    update_state(st, last_composite=result)
+        result = get_state(st).last_composite
+        if result:
+            positions = result.get("positions", {})
+            if positions:
+                df = pd.DataFrame({"Body": list(positions.keys()), "Longitude": [positions[k] for k in positions]})
+                st.dataframe(df, use_container_width=True, hide_index=True)
+                _composite_wheel("Composite wheel", positions)
+                st.download_button(
+                    "Download composite JSON",
+                    data=json.dumps(result, indent=2),
+                    file_name="composite_positions.json",
+                    mime="application/json",
+                )
+            else:
+                st.info("Composite result does not contain positions.")
+
+    with tabs[2]:
+        st.subheader("Davison — midpoint chart")
+        now = datetime.now(timezone.utc)
+        col_dt_a, col_dt_b = st.columns(2)
+        dt_a = col_dt_a.datetime_input("Chart A datetime (UTC)", value=now - timedelta(days=7))
+        dt_b = col_dt_b.datetime_input("Chart B datetime (UTC)", value=now)
+        col_geo_a, col_geo_b = st.columns(2)
+        lat_a = col_geo_a.number_input("Chart A latitude (°)", -90.0, 90.0, value=0.0, step=0.1)
+        lon_a = col_geo_a.number_input("Chart A longitude east (°)", -180.0, 180.0, value=0.0, step=0.1)
+        lat_b = col_geo_b.number_input("Chart B latitude (°)", -90.0, 90.0, value=0.0, step=0.1)
+        lon_b = col_geo_b.number_input("Chart B longitude east (°)", -180.0, 180.0, value=0.0, step=0.1)
+        bodies_text = st.text_input("Bodies (comma separated, optional)", value=", ".join(get_state(st).aspects[:5]))
+        if st.button("Compute Davison"):
+            def _ensure_utc(dt: datetime) -> datetime:
+                if dt.tzinfo is None:
+                    return dt.replace(tzinfo=UTC)
+                return dt.astimezone(UTC)
+
+            dt_a_utc = _ensure_utc(dt_a)
+            dt_b_utc = _ensure_utc(dt_b)
+            bodies = [part.strip() for part in bodies_text.split(",") if part.strip()]
+            payload = {
+                "dtA": dt_a_utc.isoformat(),
+                "dtB": dt_b_utc.isoformat(),
+                "locA": {"lat_deg": float(lat_a), "lon_deg_east": float(lon_a)},
+                "locB": {"lat_deg": float(lat_b), "lon_deg_east": float(lon_b)},
+            }
+            if bodies:
+                payload["bodies"] = bodies
+            try:
+                result = backend.davison(payload)
+            except Exception as exc:
+                st.error(f"Failed to compute Davison positions: {exc}")
+            else:
+                update_state(st, last_davison=result)
+        result = get_state(st).last_davison
+        if result:
+            midpoint = result.get("midpoint_time_utc")
+            if midpoint:
+                st.caption(f"Midpoint UTC: {midpoint}")
+            positions = result.get("positions", {})
+            if positions:
+                df = pd.DataFrame({"Body": list(positions.keys()), "Longitude": [positions[k] for k in positions]})
+                st.dataframe(df, use_container_width=True, hide_index=True)
+                _composite_wheel("Davison wheel", positions)
+                st.download_button(
+                    "Download Davison JSON",
+                    data=json.dumps(result, indent=2),
+                    file_name="davison_positions.json",
+                    mime="application/json",
+                )
+            else:
+                st.info("Davison result did not include positions.")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution guard
+    run()

--- a/streamlit/relationship_lab/constants.py
+++ b/streamlit/relationship_lab/constants.py
@@ -1,0 +1,55 @@
+"""Shared constants for the Relationship Lab UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List
+
+
+@dataclass(frozen=True)
+class AspectInfo:
+    key: str
+    label: str
+    degrees: float
+    symbol: str
+    family: str
+
+
+ASPECTS: Dict[str, AspectInfo] = {
+    "conjunction": AspectInfo("conjunction", "Conjunction (0°)", 0.0, "☌", "neutral"),
+    "sextile": AspectInfo("sextile", "Sextile (60°)", 60.0, "⚹", "harmonious"),
+    "square": AspectInfo("square", "Square (90°)", 90.0, "□", "challenging"),
+    "trine": AspectInfo("trine", "Trine (120°)", 120.0, "△", "harmonious"),
+    "opposition": AspectInfo("opposition", "Opposition (180°)", 180.0, "☍", "challenging"),
+    "quincunx": AspectInfo("quincunx", "Quincunx (150°)", 150.0, "⚻", "challenging"),
+    "semisquare": AspectInfo("semisquare", "Semi-square (45°)", 45.0, "∠", "challenging"),
+    "sesquisquare": AspectInfo("sesquisquare", "Sesqui-square (135°)", 135.0, "⚼", "challenging"),
+    "quintile": AspectInfo("quintile", "Quintile (72°)", 72.0, "⚝", "harmonious"),
+    "biquintile": AspectInfo("biquintile", "Bi-quintile (144°)", 144.0, "✶", "harmonious"),
+}
+
+MAJOR_ASPECTS: List[str] = [
+    "conjunction",
+    "sextile",
+    "square",
+    "trine",
+    "opposition",
+]
+
+EXTENDED_ASPECTS: List[str] = MAJOR_ASPECTS + [
+    "quincunx",
+    "semisquare",
+    "sesquisquare",
+    "quintile",
+    "biquintile",
+]
+
+FAMILY_LABELS = {
+    "harmonious": "Harmonious",
+    "challenging": "Challenging",
+    "neutral": "Neutral",
+}
+
+
+def aspect_choices(keys: Iterable[str]) -> List[str]:
+    return [ASPECTS[key].label for key in keys if key in ASPECTS]

--- a/streamlit/relationship_lab/samples/__init__.py
+++ b/streamlit/relationship_lab/samples/__init__.py
@@ -1,0 +1,76 @@
+"""Sample ChartPositions payloads for quick testing in the Relationship Lab."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Mapping
+
+
+@dataclass(frozen=True)
+class ChartSample:
+    """Container describing a reusable ChartPositions dataset."""
+
+    label: str
+    positions: Mapping[str, float]
+
+
+SAMPLES: Dict[str, ChartSample] = {
+    "NYC 1990-02-16": ChartSample(
+        label="New York City — 1990-02-16 14:30 (regression dataset)",
+        positions={
+            "Sun": 327.824967,
+            "Moon": 226.812266,
+            "Mercury": 306.587384,
+            "Venus": 292.269912,
+            "Mars": 283.177018,
+            "Jupiter": 90.915699,
+            "Saturn": 290.924799,
+            "Uranus": 278.287469,
+            "Neptune": 283.6611,
+            "Pluto": 227.785695,
+        },
+    ),
+    "London 1985-07-13": ChartSample(
+        label="London — 1985-07-13 09:00 (regression dataset)",
+        positions={
+            "Sun": 111.215606,
+            "Moon": 61.184662,
+            "Mercury": 137.755721,
+            "Venus": 67.975138,
+            "Mars": 112.558487,
+            "Jupiter": 314.704774,
+            "Saturn": 231.586352,
+            "Uranus": 254.609143,
+            "Neptune": 271.716086,
+            "Pluto": 211.924831,
+        },
+    ),
+    "Tokyo 2000-12-25": ChartSample(
+        label="Tokyo — 2000-12-25 05:45 (regression dataset)",
+        positions={
+            "Sun": 273.465699,
+            "Moon": 265.156077,
+            "Mercury": 272.986165,
+            "Venus": 319.107477,
+            "Mars": 210.803963,
+            "Jupiter": 62.824828,
+            "Saturn": 54.933695,
+            "Uranus": 318.320888,
+            "Neptune": 305.085719,
+            "Pluto": 253.51329,
+        },
+    ),
+}
+
+DEFAULT_PAIR = ("NYC 1990-02-16", "London 1985-07-13")
+
+
+def sample_labels() -> list[str]:
+    return list(SAMPLES.keys())
+
+
+def get_sample(name: str) -> ChartSample:
+    try:
+        return SAMPLES[name]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise KeyError(f"Unknown sample '{name}'") from exc

--- a/streamlit/relationship_lab/state.py
+++ b/streamlit/relationship_lab/state.py
@@ -1,0 +1,59 @@
+"""Session state utilities for the Relationship Lab Streamlit app."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Dict, Optional
+
+from .constants import EXTENDED_ASPECTS
+
+SESSION_KEY = "relationship_lab_state"
+
+
+@dataclass
+class RelationshipState:
+    mode: str = "api"
+    api_base_url: str = "http://localhost:8000"
+    aspect_mode: str = "extended"
+    aspects: list[str] = field(default_factory=lambda: list(EXTENDED_ASPECTS))
+    min_severity: float = 0.0
+    weights_profile: str = "default"
+    positions_a_text: str = ""
+    positions_b_text: str = ""
+    last_synastry: Optional[Dict[str, Any]] = None
+    last_composite: Optional[Dict[str, Any]] = None
+    last_davison: Optional[Dict[str, Any]] = None
+
+
+def _coerce_state(value: Any) -> RelationshipState:
+    if isinstance(value, RelationshipState):
+        return value
+    if isinstance(value, dict):
+        data = dict(value)
+        data.setdefault("aspects", list(EXTENDED_ASPECTS))
+        return RelationshipState(**data)
+    return RelationshipState()
+
+
+def get_state(st) -> RelationshipState:
+    if SESSION_KEY not in st.session_state:
+        st.session_state[SESSION_KEY] = RelationshipState()
+    else:
+        st.session_state[SESSION_KEY] = _coerce_state(st.session_state[SESSION_KEY])
+    return st.session_state[SESSION_KEY]
+
+
+def update_state(st, **changes: Any) -> None:
+    state = get_state(st)
+    for key, value in changes.items():
+        setattr(state, key, value)
+    st.session_state[SESSION_KEY] = state
+
+
+def export_state_payload(state: RelationshipState) -> Dict[str, Any]:
+    payload = asdict(state)
+    # Remove bulky entries not needed for export/import toggles.
+    payload.pop("last_synastry", None)
+    payload.pop("last_composite", None)
+    payload.pop("last_davison", None)
+    return payload

--- a/streamlit/relationship_lab/views.py
+++ b/streamlit/relationship_lab/views.py
@@ -1,0 +1,156 @@
+"""Streamlit view helpers for the Relationship Lab."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping
+
+import pandas as pd
+import streamlit as st
+
+from .constants import ASPECTS, FAMILY_LABELS
+
+
+def filter_hits(hits: Iterable[Mapping[str, Any]], min_severity: float) -> list[Mapping[str, Any]]:
+    return [hit for hit in hits if float(hit.get("severity", 0.0)) >= min_severity]
+
+
+def _aspect_symbol(aspect: str) -> str:
+    info = ASPECTS.get(aspect)
+    return info.symbol if info else aspect[:2].upper()
+
+
+def render_hits_table(hits: Iterable[Mapping[str, Any]], *, min_severity: float) -> pd.DataFrame | None:
+    filtered = filter_hits(hits, min_severity)
+    if not filtered:
+        st.info("No aspect hits under the current filters.")
+        return None
+    frame = pd.DataFrame(filtered)
+    frame = frame.rename(columns={"a": "Chart A", "b": "Chart B"})
+    frame["symbol"] = frame["aspect"].map(lambda key: _aspect_symbol(str(key)))
+    frame = frame[["Chart A", "Chart B", "aspect", "symbol", "delta", "orb", "severity"]]
+    frame = frame.sort_values(by="severity", ascending=False)
+    st.dataframe(frame, use_container_width=True, hide_index=True)
+    return frame
+
+
+def render_grid(grid: Mapping[str, Mapping[str, str]]) -> pd.DataFrame | None:
+    if not grid:
+        st.info("Aspect grid unavailable for the current result set.")
+        return None
+    data: Dict[str, Dict[str, str]] = {}
+    for a_body, row in grid.items():
+        data[a_body] = {}
+        for b_body, aspect in row.items():
+            symbol = _aspect_symbol(str(aspect))
+            data[a_body][b_body] = symbol
+    frame = pd.DataFrame(data).fillna("").sort_index(axis=0).sort_index(axis=1)
+    st.dataframe(frame, use_container_width=True)
+    return frame
+
+
+def _summarise_families(hits: Iterable[Mapping[str, Any]]) -> Dict[str, float]:
+    totals: Dict[str, float] = {key: 0.0 for key in FAMILY_LABELS}
+    for hit in hits:
+        aspect = str(hit.get("aspect"))
+        severity = float(hit.get("severity", 0.0))
+        family = ASPECTS.get(aspect).family if aspect in ASPECTS else "neutral"
+        totals[family] = totals.get(family, 0.0) + severity
+    return totals
+
+
+def _summarise_bodies(hits: Iterable[Mapping[str, Any]]) -> Dict[str, Dict[str, float]]:
+    per_side = {"Chart A": {}, "Chart B": {}}
+    for hit in hits:
+        severity = float(hit.get("severity", 0.0))
+        body_a = str(hit.get("a"))
+        body_b = str(hit.get("b"))
+        per_side["Chart A"][body_a] = per_side["Chart A"].get(body_a, 0.0) + severity
+        per_side["Chart B"][body_b] = per_side["Chart B"].get(body_b, 0.0) + severity
+    return per_side
+
+
+def render_scores(hits: Iterable[Mapping[str, Any]], *, overall: float | None = None) -> Dict[str, Any]:
+    hit_list = list(hits)
+    total = overall if overall is not None else sum(float(hit.get("severity", 0.0)) for hit in hit_list)
+    families = _summarise_families(hit_list)
+    bodies = _summarise_bodies(hit_list)
+
+    st.metric("Overall score", f"{total:.2f}")
+
+    fam_df = pd.DataFrame(
+        {FAMILY_LABELS.get(key, key.title()): [value] for key, value in families.items() if value > 0.0}
+    ).T
+    if not fam_df.empty:
+        st.bar_chart(fam_df.rename(columns={0: "Severity"}))
+
+    body_tabs = st.tabs(list(bodies.keys()))
+    for tab, (label, values) in zip(body_tabs, bodies.items()):
+        with tab:
+            if values:
+                df = pd.DataFrame(sorted(values.items(), key=lambda kv: kv[1], reverse=True), columns=[label, "Severity"])
+                st.bar_chart(df.set_index(label))
+            else:
+                st.info("No bodies met the severity threshold.")
+
+    return {"total": total, "families": families, "bodies": bodies}
+
+
+
+def render_overlay_table(overlay: Mapping[str, Mapping[str, Any]]) -> pd.DataFrame | None:
+    if not overlay:
+        st.info("Overlay data unavailable for the current result set.")
+        return None
+    rows: List[Dict[str, Any]] = []
+    for body, data in overlay.items():
+        row = {"Body": body}
+        if "A" in data:
+            row["Chart A"] = data["A"]
+        if "B" in data:
+            row["Chart B"] = data["B"]
+        if "delta" in data:
+            row["Delta"] = data["delta"]
+        rows.append(row)
+    frame = pd.DataFrame(rows)
+    frame = frame.sort_values(by="Body")
+    st.dataframe(frame, use_container_width=True, hide_index=True)
+    return frame
+
+
+def build_summary_markdown(
+    title: str,
+    hits: Iterable[Mapping[str, Any]],
+    score_summary: Mapping[str, Any],
+    *,
+    top_n: int = 5,
+) -> str:
+    hit_list = sorted(hits, key=lambda item: float(item.get("severity", 0.0)), reverse=True)
+    lines = [f"## {title}", "", f"**Overall score:** {score_summary.get('total', 0.0):.2f}"]
+    families = score_summary.get("families", {})
+    if families:
+        lines.append("\n### Aspect families")
+        for key, label in FAMILY_LABELS.items():
+            value = float(families.get(key, 0.0))
+            if value > 0.0:
+                lines.append(f"- {label}: {value:.2f}")
+    if hit_list:
+        lines.append("\n### Top hits")
+        for hit in hit_list[:top_n]:
+            aspect = str(hit.get("aspect"))
+            symbol = _aspect_symbol(aspect)
+            a = hit.get("a")
+            b = hit.get("b")
+            sev = float(hit.get("severity", 0.0))
+            orb = float(hit.get("orb", 0.0))
+            lines.append(f"- {a} {symbol} {b} — severity {sev:.2f}, orb {orb:.2f}°")
+    return "\n".join(lines)
+
+
+def render_markdown_copy(markdown: str) -> None:
+    text = markdown
+    html = f"""
+    <div style='position: relative;'>
+        <textarea id='rel-copy' style='width:100%; min-height: 220px;'>{text}</textarea>
+        <button style='position:absolute; top:6px; right:6px;' onclick="navigator.clipboard.writeText(document.getElementById('rel-copy').value);">Copy</button>
+    </div>
+    """
+    st.markdown(html, unsafe_allow_html=True)

--- a/streamlit/relationship_lab/wheels.py
+++ b/streamlit/relationship_lab/wheels.py
@@ -1,0 +1,106 @@
+"""SVG helpers for rendering single-ring chart wheels."""
+
+from __future__ import annotations
+
+import math
+from typing import List, Mapping, Sequence, Tuple
+
+SIGN_GLYPHS = [
+    "♈",
+    "♉",
+    "♊",
+    "♋",
+    "♌",
+    "♍",
+    "♎",
+    "♏",
+    "♐",
+    "♑",
+    "♒",
+    "♓",
+]
+
+PLANET_GLYPHS = {
+    "Sun": "☉",
+    "Moon": "☽",
+    "Mercury": "☿",
+    "Venus": "♀",
+    "Mars": "♂",
+    "Jupiter": "♃",
+    "Saturn": "♄",
+    "Uranus": "♅",
+    "Neptune": "♆",
+    "Pluto": "♇",
+    "Chiron": "⚷",
+    "Node": "☊",
+}
+
+
+def _normalize_lon(lon: float) -> float:
+    return float(lon) % 360.0
+
+
+def _resolve_label(body: str) -> str:
+    return PLANET_GLYPHS.get(body, body[:2].upper())
+
+
+def render_wheel_svg(
+    positions: Mapping[str, float] | Sequence[Tuple[str, float]],
+    *,
+    size: int = 420,
+    font_family: str = "'Segoe UI Symbol', 'Noto Sans Symbols', sans-serif",
+) -> str:
+    """Render a minimalist zodiac wheel for ``positions`` as inline SVG."""
+
+    if isinstance(positions, Mapping):
+        items = list(positions.items())
+    else:
+        items = list(positions)
+
+    cx = cy = size / 2
+    outer_r = size * 0.45
+    glyph_r = outer_r - 38
+    tick_r = outer_r - 10
+    sign_r = outer_r - 24
+
+    parts: List[str] = [
+        f'<svg width="{size}" height="{size}" viewBox="0 0 {size} {size}" '
+        "xmlns='http://www.w3.org/2000/svg'>",
+        f'<rect width="100%" height="100%" fill="white"/>',
+        f'<circle cx="{cx}" cy="{cy}" r="{outer_r}" fill="none" stroke="#333" stroke-width="1"/>',
+    ]
+
+    for idx in range(12):
+        ang = math.radians(idx * 30.0)
+        x1 = cx + outer_r * math.cos(ang)
+        y1 = cy + outer_r * math.sin(ang)
+        x2 = cx + tick_r * math.cos(ang)
+        y2 = cy + tick_r * math.sin(ang)
+        parts.append(
+            f'<line x1="{x1:.3f}" y1="{y1:.3f}" x2="{x2:.3f}" y2="{y2:.3f}" stroke="#444" stroke-width="1"/>'
+        )
+        mid_ang = ang + math.radians(15.0)
+        sx = cx + sign_r * math.cos(mid_ang)
+        sy = cy + sign_r * math.sin(mid_ang)
+        glyph = SIGN_GLYPHS[idx]
+        parts.append(
+            f'<text x="{sx:.3f}" y="{sy:.3f}" text-anchor="middle" dominant-baseline="middle" '
+            f"font-size='16' font-family={font_family}>{glyph}</text>"
+        )
+
+    used_lons: List[float] = []
+    for body, lon in items:
+        lon = _normalize_lon(lon)
+        while any(abs(((lon - other + 180.0) % 360.0) - 180.0) < 6.0 for other in used_lons):
+            lon = (lon + 6.0) % 360.0
+        used_lons.append(lon)
+        theta = math.radians(lon)
+        px = cx + glyph_r * math.cos(theta)
+        py = cy + glyph_r * math.sin(theta)
+        parts.append(
+            f'<text x="{px:.3f}" y="{py:.3f}" text-anchor="middle" dominant-baseline="middle" '
+            f"font-size='18' font-family={font_family}>{_resolve_label(str(body))}</text>"
+        )
+
+    parts.append("</svg>")
+    return "".join(parts)


### PR DESCRIPTION
## Summary
- add a dedicated `streamlit.relationship_lab` package with API client, wheel renderer, state helpers, and Streamlit UI for synastry, composite, and Davison charts
- create an `apps/relationship_lab.py` entrypoint so the new Streamlit page can be launched directly
- clean a stray prefix from `core/relationship_plus/synastry.py`

## Testing
- pytest tests/test_api_relationship.py

------
https://chatgpt.com/codex/tasks/task_e_68d8480343e88324b55e99e323c3cb0f