### PR TITLE
Add rulepack interpretation engine

### DIFF
--- a/astroengine/interpret/__init__.py
+++ b/astroengine/interpret/__init__.py
@@ -1,0 +1,14 @@
+"""Relationship interpretation engine (B-005)."""
+
+from .engine import EvaluationResult, evaluate
+from .loader import load_rulepack, load_rulepack_from_data
+from .models import Rule, Rulepack
+
+__all__ = [
+    "EvaluationResult",
+    "Rule",
+    "Rulepack",
+    "evaluate",
+    "load_rulepack",
+    "load_rulepack_from_data",
+]

--- a/astroengine/interpret/engine.py
+++ b/astroengine/interpret/engine.py
@@ -1,0 +1,165 @@
+"""Core evaluation engine for interpretation findings."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import cos, pi
+from typing import Any, Iterable
+
+from .loader import iter_rulepack_rules
+from .models import Rule, Rulepack
+
+
+@dataclass(slots=True)
+class Hit:
+    """Normalized relationship aspect hit."""
+
+    bodyA: str
+    bodyB: str
+    aspect: int
+    severity: float
+    offset: float | None = None
+
+
+@dataclass(slots=True)
+class Finding:
+    """Single interpretation finding."""
+
+    id: str
+    title: str
+    tags: list[str]
+    score: float
+    context: dict[str, Any]
+    markdown: str | None = None
+
+
+@dataclass(slots=True)
+class EvaluationResult:
+    """Aggregate output from the engine."""
+
+    findings: list[Finding]
+    totals: dict[str, Any]
+
+
+def _severity_modifier(name: str, severity: float) -> float:
+    if severity <= 0:
+        return 0.0
+    if name.startswith("cosine"):
+        power = 1.0
+        if "^" in name:
+            try:
+                power = float(name.split("^", 1)[1])
+            except ValueError:
+                power = 1.0
+        value = 0.5 * (1 + cos(pi * (1 - severity)))
+        return max(0.0, min(1.0, value**power))
+    if name == "linear":
+        return max(0.0, min(1.0, severity))
+    return max(0.0, min(1.0, severity))
+
+
+def _match(rule: Rule, hit: Hit) -> bool:
+    if rule.scope != "synastry":
+        return False
+    when = rule.when
+    if when.bodiesA != "*" and hit.bodyA not in when.bodiesA:
+        return False
+    if when.bodiesB != "*" and hit.bodyB not in when.bodiesB:
+        return False
+    if when.aspects != "*" and hit.aspect not in when.aspects:
+        return False
+    if hit.severity < when.min_severity:
+        return False
+    return True
+
+
+def _context_from_hit(hit: Hit) -> dict[str, Any]:
+    context = {
+        "bodyA": hit.bodyA,
+        "bodyB": hit.bodyB,
+        "aspect": hit.aspect,
+        "severity": hit.severity,
+    }
+    if hit.offset is not None:
+        context["offset"] = hit.offset
+    return context
+
+
+def evaluate(
+    rulepack: Rulepack,
+    *,
+    scope: str,
+    hits: Iterable[dict[str, Any]] | None = None,
+    positionsA: Any | None = None,
+    positionsB: Any | None = None,
+    profile: str = "balanced",
+    renderer=None,
+) -> EvaluationResult:
+    """Evaluate *rulepack* against chart data and return scored findings."""
+
+    del positionsA, positionsB  # composite/davison support is planned but not yet implemented.
+
+    tag_weights = rulepack.profile_weights(profile)
+    raw_findings: list[Finding] = []
+
+    if scope == "synastry" and hits:
+        for hit_data in hits:
+            hit = Hit(
+                bodyA=hit_data["bodyA"],
+                bodyB=hit_data["bodyB"],
+                aspect=int(hit_data["aspect"]),
+                severity=float(hit_data["severity"]),
+                offset=float(hit_data.get("offset")) if hit_data.get("offset") is not None else None,
+            )
+            for rule in iter_rulepack_rules(rulepack):
+                if not _match(rule, hit):
+                    continue
+                modifier = _severity_modifier(rule.then.score_fn, hit.severity)
+                if modifier <= 0:
+                    continue
+                weights = [tag_weights.get(tag, 1.0) for tag in rule.then.tags]
+                weight = sum(weights) / max(1, len(weights))
+                score = min(1.0, rule.then.base_score * modifier * weight)
+                markdown = None
+                if renderer and rule.then.markdown_template:
+                    markdown = renderer.render(rule.then.markdown_template, _context_from_hit(hit))
+                raw_findings.append(
+                    Finding(
+                        id=rule.id,
+                        title=rule.then.title,
+                        tags=list(rule.then.tags),
+                        score=score,
+                        context=_context_from_hit(hit),
+                        markdown=markdown,
+                    )
+                )
+
+    deduped: dict[tuple[Any, ...], Finding] = {}
+    for finding in raw_findings:
+        key = (
+            finding.id,
+            finding.context.get("bodyA"),
+            finding.context.get("bodyB"),
+            finding.context.get("aspect"),
+            tuple(sorted(finding.tags)),
+        )
+        existing = deduped.get(key)
+        if existing is None or finding.score > existing.score:
+            deduped[key] = finding
+
+    findings = sorted(deduped.values(), key=lambda f: f.score, reverse=True)
+
+    by_tag: dict[str, float] = {}
+    for finding in findings:
+        for tag in finding.tags:
+            by_tag[tag] = by_tag.get(tag, 0.0) + finding.score
+
+    totals = {
+        "by_tag": by_tag,
+        "overall": sum(f.score for f in findings),
+    }
+
+    return EvaluationResult(findings=findings, totals=totals)
+
+
+__all__ = ["EvaluationResult", "evaluate"]

--- a/astroengine/interpret/examples/basic.yaml
+++ b/astroengine/interpret/examples/basic.yaml
@@ -1,0 +1,64 @@
+rulepack: "relationship-basic"
+version: 1
+meta:
+  title: "Basic Relationship Interpretations"
+  author: "Core Team"
+  description: "Majors+minors, luminary emphasis, Saturn dynamics"
+profiles:
+  balanced:
+    tags:
+      chemistry: 1.0
+      stability: 1.0
+      growth: 1.0
+      friction: 1.0
+  chemistry_plus:
+    tags:
+      chemistry: 1.3
+      stability: 1.0
+      growth: 1.0
+      friction: 0.9
+archetypes:
+  saturn_binding:
+    - "Saturn↔Sun"
+    - "Saturn↔Moon"
+    - "Saturn↔Venus"
+rules:
+  - id: r.sun_moon_trine
+    scope: synastry
+    when:
+      bodiesA: [Sun]
+      bodiesB: [Moon]
+      aspects: [120]
+      min_severity: 0.6
+    then:
+      title: "Sun–Moon Trine (A→B)"
+      tags: [chemistry, stability]
+      base_score: 0.8
+      score_fn: "cosine^1"
+      markdown_template: |
+        **Sun (A)** trines **Moon (B)** (offset {{ offset | round(2) }}°).
+        Warmth and ease support day-to-day flow.
+  - id: r.saturn_conj_venus
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Venus]
+      aspects: [0]
+      min_severity: 0.5
+    then:
+      title: "Saturn–Venus Conjunction"
+      tags: [stability, friction]
+      base_score: 0.7
+      score_fn: "cosine^1.2"
+  - id: r.mars_square_mars
+    scope: synastry
+    when:
+      bodiesA: [Mars]
+      bodiesB: [Mars]
+      aspects: [90]
+      min_severity: 0.5
+    then:
+      title: "Mars–Mars Square"
+      tags: [friction, growth]
+      base_score: 0.65
+      score_fn: "cosine^1.0"

--- a/astroengine/interpret/loader.py
+++ b/astroengine/interpret/loader.py
@@ -1,0 +1,71 @@
+"""Utilities for loading interpretation rulepacks."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import jsonschema
+import yaml
+
+from .models import Rulepack
+from .schema import RULEPACK_SCHEMA
+
+
+class RulepackValidationError(ValueError):
+    """Raised when a rulepack fails schema or model validation."""
+
+
+class RulepackNotFoundError(FileNotFoundError):
+    """Raised when a rulepack path does not exist."""
+
+
+def _load_file(path: Path) -> Any:
+    if not path.exists():
+        raise RulepackNotFoundError(f"Rulepack not found: {path}")
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        return yaml.safe_load(text) or {}
+    if path.suffix.lower() == ".json":
+        import json
+
+        return json.loads(text)
+    raise RulepackNotFoundError(f"Unsupported rulepack format: {path.suffix}")
+
+
+def load_rulepack(path: str | Path) -> Rulepack:
+    """Load and validate a rulepack from *path*."""
+
+    data = _load_file(Path(path))
+    return load_rulepack_from_data(data)
+
+
+def load_rulepack_from_data(data: Any) -> Rulepack:
+    """Validate *data* against the schema and return a :class:`Rulepack`."""
+
+    try:
+        jsonschema.validate(instance=data, schema=RULEPACK_SCHEMA)
+    except jsonschema.ValidationError as exc:  # pragma: no cover - error path message
+        raise RulepackValidationError(str(exc)) from exc
+
+    try:
+        return Rulepack.model_validate(data)
+    except Exception as exc:  # pragma: no cover - Pydantic detail
+        raise RulepackValidationError(str(exc)) from exc
+
+
+def iter_rulepack_rules(rulepack: Rulepack):
+    """Yield rules from *rulepack* preserving author order."""
+
+    yield from rulepack.rules
+
+
+__all__ = [
+    "Rulepack",
+    "RulepackNotFoundError",
+    "RulepackValidationError",
+    "iter_rulepack_rules",
+    "load_rulepack",
+    "load_rulepack_from_data",
+]

--- a/astroengine/interpret/models.py
+++ b/astroengine/interpret/models.py
@@ -1,0 +1,88 @@
+"""Typed models for interpretation rulepacks."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+Body = Literal[
+    "Sun",
+    "Moon",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+    "Chiron",
+    "Node",
+]
+
+Aspect = Literal[0, 30, 45, 60, 72, 90, 120, 135, 150, 180]
+
+
+class RuleWhen(BaseModel):
+    """Conditions required for a rule to match an aspect hit."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    bodiesA: list[Body] | Literal["*"]
+    bodiesB: list[Body] | Literal["*"]
+    aspects: list[int] | Literal["*"]
+    min_severity: float = Field(default=0.0, ge=0.0, le=1.0)
+
+
+class RuleThen(BaseModel):
+    """Payload emitted when a rule matches."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str
+    tags: list[str]
+    base_score: float = Field(default=0.5, ge=0.0, le=1.0)
+    score_fn: str = Field(default="cosine^1.0")
+    markdown_template: str | None = None
+
+
+class Rule(BaseModel):
+    """Single interpretation rule."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str
+    scope: Literal["synastry", "composite", "davison"] = "synastry"
+    when: RuleWhen
+    then: RuleThen
+
+
+class Profile(BaseModel):
+    """Tag weight profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tags: dict[str, float]
+
+
+class Rulepack(BaseModel):
+    """Container for an interpretation rulepack."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    rulepack: str
+    version: int = Field(default=1, ge=1)
+    meta: dict[str, Any] = Field(default_factory=dict)
+    profiles: dict[str, Profile]
+    archetypes: dict[str, list[str]] | None = None
+    rules: list[Rule]
+
+    def profile_weights(self, profile: str) -> dict[str, float]:
+        """Return tag weights for *profile* or fall back to equal weighting."""
+
+        if profile in self.profiles:
+            return self.profiles[profile].tags
+        # Fall back to average weights of the default profile when unavailable.
+        default_profile = next(iter(self.profiles.values()), None)
+        return default_profile.tags if default_profile else {}

--- a/astroengine/interpret/profiles.py
+++ b/astroengine/interpret/profiles.py
@@ -1,0 +1,9 @@
+"""Built-in interpretation profiles."""
+
+from __future__ import annotations
+
+DEFAULT_PROFILES = {
+    "balanced": {"tags": {"chemistry": 1.0, "stability": 1.0, "growth": 1.0, "friction": 1.0}},
+}
+
+__all__ = ["DEFAULT_PROFILES"]

--- a/astroengine/interpret/schema.py
+++ b/astroengine/interpret/schema.py
@@ -1,0 +1,118 @@
+"""JSON Schema definition for interpretation rulepacks."""
+
+from __future__ import annotations
+
+RULEPACK_SCHEMA: dict = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "required": ["rulepack", "version", "profiles", "rules"],
+    "properties": {
+        "rulepack": {"type": "string"},
+        "version": {"type": "integer", "minimum": 1},
+        "meta": {"type": "object"},
+        "profiles": {
+            "type": "object",
+            "minProperties": 1,
+            "additionalProperties": {
+                "type": "object",
+                "required": ["tags"],
+                "properties": {
+                    "tags": {
+                        "type": "object",
+                        "additionalProperties": {"type": "number"},
+                    }
+                },
+            },
+        },
+        "archetypes": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+        "rules": {
+            "type": "array",
+            "minItems": 1,
+            "items": {"$ref": "#/definitions/rule"},
+        },
+    },
+    "definitions": {
+        "rule": {
+            "type": "object",
+            "required": ["id", "scope", "when", "then"],
+            "properties": {
+                "id": {"type": "string"},
+                "scope": {
+                    "enum": ["synastry", "composite", "davison"],
+                    "default": "synastry",
+                },
+                "when": {"$ref": "#/definitions/when"},
+                "then": {"$ref": "#/definitions/then"},
+            },
+            "additionalProperties": False,
+        },
+        "when": {
+            "type": "object",
+            "required": ["bodiesA", "bodiesB", "aspects"],
+            "properties": {
+                "bodiesA": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                        },
+                        {"const": "*"},
+                    ]
+                },
+                "bodiesB": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "minItems": 1,
+                        },
+                        {"const": "*"},
+                    ]
+                },
+                "aspects": {
+                    "oneOf": [
+                        {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "minItems": 1,
+                        },
+                        {"const": "*"},
+                    ]
+                },
+                "min_severity": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            },
+            "additionalProperties": False,
+        },
+        "then": {
+            "type": "object",
+            "required": ["title", "tags"],
+            "properties": {
+                "title": {"type": "string"},
+                "tags": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 1,
+                },
+                "base_score": {
+                    "type": "number",
+                    "minimum": 0.0,
+                    "maximum": 1.0,
+                    "default": 0.5,
+                },
+                "score_fn": {"type": "string", "default": "cosine^1.0"},
+                "markdown_template": {"type": "string"},
+            },
+            "additionalProperties": False,
+        },
+    },
+    "additionalProperties": False,
+}
+
+__all__ = ["RULEPACK_SCHEMA"]

--- a/astroengine/interpret/templates.py
+++ b/astroengine/interpret/templates.py
@@ -1,0 +1,48 @@
+"""Jinja2 utilities for rendering markdown snippets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+try:  # pragma: no cover - optional dependency path
+    from jinja2 import Environment, StrictUndefined
+except ImportError:  # pragma: no cover - fallback when jinja2 unavailable
+    Environment = None  # type: ignore[assignment]
+    StrictUndefined = None  # type: ignore[assignment]
+
+
+@dataclass(slots=True)
+class TemplateRenderer:
+    """Lightweight renderer that only activates when Jinja2 is installed."""
+
+    environment_factory: Callable[[], Environment | None]
+
+    def render(self, template: str, context: dict[str, Any]) -> str:
+        env = self.environment_factory()
+        if env is None:
+            raise RuntimeError("Jinja2 is required to render rulepack templates.")
+        return env.from_string(template).render(**context)
+
+
+def _create_environment() -> Environment | None:
+    if Environment is None:
+        return None
+
+    env = Environment(undefined=StrictUndefined, autoescape=False, trim_blocks=True, lstrip_blocks=True)
+    env.filters.update(
+        {
+            "round": lambda value, digits=0: round(float(value), int(digits)),
+            "deg": lambda value: f"{float(value):.2f}°",
+        }
+    )
+    return env
+
+
+def get_renderer() -> TemplateRenderer:
+    """Return a singleton renderer for markdown templates."""
+
+    return TemplateRenderer(environment_factory=_create_environment)
+
+
+__all__ = ["TemplateRenderer", "get_renderer"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
   "pandas>=2.0",
   "python-dateutil>=2.8",
   "pydantic>=2.11",
+  "jsonschema>=4.20",
   "PyYAML>=6.0",
   "requests>=2.31",
   "SQLAlchemy>=2.0",

--- a/tests/interpret/fixtures/hits_simple.json
+++ b/tests/interpret/fixtures/hits_simple.json
@@ -1,0 +1,5 @@
+[
+  {"bodyA": "Sun", "bodyB": "Moon", "aspect": 120, "severity": 0.78, "offset": 1.2},
+  {"bodyA": "Saturn", "bodyB": "Venus", "aspect": 0, "severity": 0.68, "offset": 0.3},
+  {"bodyA": "Mars", "bodyB": "Mars", "aspect": 90, "severity": 0.55, "offset": 3.5}
+]

--- a/tests/interpret/test_engine_profiles.py
+++ b/tests/interpret/test_engine_profiles.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from astroengine.interpret.engine import evaluate
+from astroengine.interpret.loader import load_rulepack
+
+
+def load_hits() -> list[dict[str, float | int | str]]:
+    hits_path = Path("tests/interpret/fixtures/hits_simple.json")
+    return json.loads(hits_path.read_text(encoding="utf-8"))
+
+
+def test_profile_weights_shift_scores() -> None:
+    rulepack = load_rulepack("astroengine/interpret/examples/basic.yaml")
+    hits = load_hits()
+
+    balanced = evaluate(rulepack, scope="synastry", hits=hits, profile="balanced")
+    chemistry = evaluate(rulepack, scope="synastry", hits=hits, profile="chemistry_plus")
+
+    balanced_scores = {finding.id: finding.score for finding in balanced.findings}
+    chemistry_scores = {finding.id: finding.score for finding in chemistry.findings}
+
+    assert chemistry_scores["r.sun_moon_trine"] > balanced_scores["r.sun_moon_trine"]
+    assert chemistry_scores["r.saturn_conj_venus"] <= balanced_scores["r.saturn_conj_venus"]

--- a/tests/interpret/test_engine_rules.py
+++ b/tests/interpret/test_engine_rules.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from astroengine.interpret.engine import evaluate
+from astroengine.interpret.loader import load_rulepack
+from astroengine.interpret.templates import get_renderer
+
+
+def load_hits() -> list[dict[str, float | int | str]]:
+    hits_path = Path("tests/interpret/fixtures/hits_simple.json")
+    return json.loads(hits_path.read_text(encoding="utf-8"))
+
+
+def test_engine_matches_and_scores() -> None:
+    rulepack = load_rulepack("astroengine/interpret/examples/basic.yaml")
+    hits = load_hits()
+
+    result = evaluate(rulepack, scope="synastry", hits=hits, profile="balanced")
+    assert result.findings, "Expected at least one finding"
+
+    sun_moon = next(f for f in result.findings if f.id == "r.sun_moon_trine")
+    assert sun_moon.score > 0.5
+    assert "chemistry" in sun_moon.tags
+
+    totals = result.totals
+    assert totals["overall"] >= sun_moon.score
+    assert totals["by_tag"]["chemistry"] >= sun_moon.score
+
+
+def test_engine_template_rendering() -> None:
+    rulepack = load_rulepack("astroengine/interpret/examples/basic.yaml")
+    hits = load_hits()[:1]
+    renderer = get_renderer()
+
+    result = evaluate(rulepack, scope="synastry", hits=hits, renderer=renderer)
+    assert result.findings[0].markdown is not None
+    assert "Sun (A)" in result.findings[0].markdown

--- a/tests/interpret/test_loader_schema.py
+++ b/tests/interpret/test_loader_schema.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from astroengine.interpret.loader import (
+    RulepackValidationError,
+    load_rulepack,
+    load_rulepack_from_data,
+)
+
+
+def test_load_rulepack_roundtrip(tmp_path: Path) -> None:
+    rulepack_path = Path("astroengine/interpret/examples/basic.yaml")
+    loaded = load_rulepack(rulepack_path)
+    assert loaded.rulepack == "relationship-basic"
+    assert "balanced" in loaded.profiles
+    assert loaded.rules[0].id == "r.sun_moon_trine"
+
+    # Ensure JSON loading path works too.
+    data = yaml.safe_load(rulepack_path.read_text(encoding="utf-8"))
+    json_path = tmp_path / "basic.json"
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+    json_loaded = load_rulepack(json_path)
+    assert json_loaded.rulepack == loaded.rulepack
+
+
+def test_load_rulepack_validation_error() -> None:
+    with pytest.raises(RulepackValidationError):
+        load_rulepack_from_data({"rulepack": "oops"})


### PR DESCRIPTION
## Summary
- add a new `astroengine.interpret` package with rulepack models, loader, schema, and evaluation engine
- provide an example rulepack plus optional Jinja2 rendering helpers and default profiles
- cover the new functionality with fixtures and focused tests for loading, scoring, and profile weighting

## Testing
- pytest tests/interpret -q

------
https://chatgpt.com/codex/tasks/task_e_68d848b63aec83249d92b8c2f70e8531