### PR TITLE
Add Streamlit relationship report builder app

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,6 @@ recursive-include astroengine/registry *.yaml *.yml *.csv
 recursive-include astroengine/profiles *.yaml *.yml *.json
 recursive-include astroengine/datasets *.csv *.json
 # >>> AUTO-GEN END: astroengine manifest data v1.0
+
+recursive-include streamlit/report_builder/templates *.md.j2
+recursive-include streamlit/report_builder/samples *.json

--- a/streamlit/report_builder/__init__.py
+++ b/streamlit/report_builder/__init__.py
@@ -1,0 +1,3 @@
+"""Relationship report builder Streamlit helpers."""
+
+__all__: list[str] = []

--- a/streamlit/report_builder/app.py
+++ b/streamlit/report_builder/app.py
@@ -1,0 +1,428 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Mapping
+
+import pandas as pd
+import streamlit as st
+from streamlit import components
+
+from . import sections
+from .client import APIError, RelationshipClient
+from .state import (
+    DEFAULT_ASPECTS,
+    DEFAULT_TEMPLATE_ID,
+    ReportFilters,
+    ReportState,
+    get_state,
+    load_project,
+    reset_state,
+    store_project,
+    update_state,
+)
+from .templating import ReportContext, build_scores_table, render_markdown
+
+FALLBACK_RULEPACKS = [
+    {"id": "synastry-basic", "title": "Synastry Essentials", "version": "1.0"}
+]
+DEFAULT_REL_BASE = "http://localhost:8000"
+
+
+def _read_sample(path: str) -> str:
+    from importlib import resources
+
+    return resources.files("streamlit.report_builder.samples").joinpath(path).read_text("utf-8")
+
+
+def _collect_tags(payload: Mapping[str, Any] | None) -> List[str]:
+    tags: set[str] = set()
+    if isinstance(payload, Mapping):
+        findings = payload.get("findings")
+        if isinstance(findings, Iterable):
+            for item in findings:
+                if not isinstance(item, Mapping):
+                    continue
+                for tag in item.get("tags", []) or []:
+                    if isinstance(tag, str):
+                        tags.add(tag)
+    return sorted(tags)
+
+
+def _finding_snippet(item: Mapping[str, Any]) -> str:
+    snippet = item.get("snippet") if isinstance(item, Mapping) else None
+    if isinstance(snippet, str) and snippet.strip():
+        return snippet.strip()
+    rendered = item.get("rendered_markdown") if isinstance(item, Mapping) else None
+    if isinstance(rendered, str) and rendered.strip():
+        return rendered.strip().splitlines()[0]
+    return ""
+
+
+def _inputs_summary(hits: Iterable[Mapping[str, Any]] | None) -> pd.DataFrame:
+    records: List[Dict[str, Any]] = []
+    if hits:
+        for hit in hits:
+            if not isinstance(hit, Mapping):
+                continue
+            record = {
+                "aspect": hit.get("aspect"),
+                "score": hit.get("score"),
+                "orb": hit.get("orb"),
+            }
+            bodies = hit.get("bodies")
+            if isinstance(bodies, Mapping):
+                record["body_a"] = bodies.get("a")
+                record["body_b"] = bodies.get("b")
+            records.append(record)
+    return pd.DataFrame(records)
+
+
+def _theme_styles(theme: str) -> str:
+    theme = theme.lower()
+    if theme == "dark":
+        bg, fg, border = "#0f172a", "#e2e8f0", "#1f2937"
+    elif theme == "light":
+        bg, fg, border = "#f8fafc", "#0f172a", "#cbd5f5"
+    else:
+        bg, fg, border = "#f5f5f4", "#111827", "#d4d4d8"
+    return f"""
+    <style>
+    .report-preview {{
+        font-family: 'Fira Code', 'JetBrains Mono', 'SFMono-Regular', monospace;
+        background-color: {bg};
+        color: {fg};
+        border: 1px solid {border};
+        border-radius: 0.75rem;
+        padding: 1.5rem;
+        white-space: pre-wrap;
+        word-wrap: break-word;
+    }}
+    .report-preview textarea {{
+        font-family: inherit;
+    }}
+    </style>
+    """
+
+
+def _copy_to_clipboard_button(markdown: str) -> None:
+    payload = json.dumps(markdown)
+    components.v1.html(
+        f"""
+        <button id=\"copy-md\">Copy Markdown</button>
+        <script>
+        const btn = document.getElementById('copy-md');
+        if (btn) {{
+            btn.addEventListener('click', async () => {{
+                try {{
+                    await navigator.clipboard.writeText({payload});
+                    btn.innerText = 'Copied!';
+                    setTimeout(() => btn.innerText = 'Copy Markdown', 1500);
+                }} catch (err) {{
+                    console.error(err);
+                    btn.innerText = 'Copy failed';
+                }}
+            }});
+        }}
+        </script>
+        """,
+        height=60,
+    )
+
+
+def _project_download(state: ReportState) -> tuple[str, str] | None:
+    if not state.findings:
+        return None
+    payload = state.model_dump()
+    payload["generated_at"] = datetime.now(timezone.utc).isoformat()
+    return "report_project.json", json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _build_filters(state: ReportState) -> ReportFilters:
+    return ReportFilters.model_validate(state.filters.model_dump())
+
+
+def _ensure_rulepack_selection(state: ReportState, rulepacks: List[Mapping[str, Any]]) -> str:
+    current = state.rulepack_id or (rulepacks[0]["id"] if rulepacks else "")
+    return current
+
+
+def _render_markdown(state: ReportState, generated_at: datetime) -> str:
+    findings_payload = state.findings or {}
+    filters = _build_filters(state)
+    filters_payload = filters.model_dump()
+    filters_payload.pop("top_highlights", None)
+    context = ReportContext(
+        findings=list(findings_payload.get("findings", [])),
+        rulepack=findings_payload.get("rulepack") or {"id": state.rulepack_id},
+        filters={**findings_payload.get("filters", {}), **filters_payload},
+        pair=state.pair.model_dump(),
+        totals=findings_payload.get("totals") or {},
+        generated_at=generated_at,
+        top_highlights=state.filters.top_highlights,
+        template_id=state.template_id or DEFAULT_TEMPLATE_ID,
+    )
+    return render_markdown(context)
+
+
+def main() -> None:  # pragma: no cover - Streamlit entrypoint
+    st.set_page_config(page_title="Relationship Report Builder", layout="wide")
+    state = get_state(st.session_state)
+
+    with st.sidebar:
+        st.title("Report Builder")
+        rel_base = st.text_input("Relationship API base", value=st.session_state.get("relationship_base", DEFAULT_REL_BASE))
+        int_base = st.text_input("Interpret API base", value=st.session_state.get("interpret_base", rel_base))
+        st.session_state["relationship_base"] = rel_base
+        st.session_state["interpret_base"] = int_base
+        theme = st.selectbox("Preview theme", options=["System", "Light", "Dark"], index=0)
+        st.markdown(_theme_styles(theme), unsafe_allow_html=True)
+
+        if st.button("Reset session"):
+            state = reset_state(st.session_state)
+            st.experimental_rerun()
+
+        project_file = st.file_uploader("Import project", type=["json"], accept_multiple_files=False)
+        if project_file is not None:
+            try:
+                payload = json.loads(project_file.getvalue().decode("utf-8"))
+                state = load_project(st.session_state, payload)
+                if state.markdown:
+                    st.session_state["markdown_preview"] = state.markdown
+                st.success("Project loaded")
+            except Exception as exc:  # pragma: no cover - user input
+                st.error(f"Failed to load project: {exc}")
+
+        export = _project_download(state)
+        if export:
+            filename, data = export
+            st.download_button(
+                "Export project", data=data, file_name=filename, mime="application/json"
+            )
+
+    st.title("Relationship Report Builder")
+    st.caption("Convert synastry, composite, or davison findings into polished Markdown.")
+
+    tabs = st.tabs(["Compute Hits", "Use Existing Hits"])
+    with tabs[0]:
+        default_a = _read_sample("positions_A.json")
+        default_b = _read_sample("positions_B.json")
+        col_a, col_b = st.columns(2)
+        text_a = col_a.text_area("ChartPositions A (JSON)", value=st.session_state.get("positionsA_text", default_a), height=220)
+        text_b = col_b.text_area("ChartPositions B (JSON)", value=st.session_state.get("positionsB_text", default_b), height=220)
+        aspects = st.multiselect(
+            "Aspects",
+            DEFAULT_ASPECTS,
+            default=state.aspects or DEFAULT_ASPECTS,
+        )
+        if aspects != state.aspects:
+            state = update_state(st.session_state, aspects=aspects)
+        if st.button("Compute hits"):
+            try:
+                positions_a = json.loads(text_a)
+                positions_b = json.loads(text_b)
+            except json.JSONDecodeError as exc:
+                st.error(f"Invalid JSON payload: {exc}")
+            else:
+                payload = {
+                    "positionsA": {"__root__": positions_a},
+                    "positionsB": {"__root__": positions_b},
+                    "aspects": aspects or DEFAULT_ASPECTS,
+                }
+                client = RelationshipClient(rel_base, int_base)
+                try:
+                    response = client.synastry(payload)
+                except APIError as exc:
+                    st.error(str(exc))
+                else:
+                    hits = response.get("hits", [])
+                    state = update_state(
+                        st.session_state,
+                        hits=hits,
+                        inputs={"positionsA": positions_a, "positionsB": positions_b, "aspects": aspects},
+                        findings=None,
+                        markdown=None,
+                    )
+                    st.session_state["markdown_preview"] = ""
+                    st.session_state["positionsA_text"] = text_a
+                    st.session_state["positionsB_text"] = text_b
+                    st.success(f"Captured {len(hits)} hits from synastry computation.")
+
+    with tabs[1]:
+        default_hits = _read_sample("hits_sample.json")
+        hits_text = st.text_area("Paste hits JSON", value=st.session_state.get("hits_text", default_hits), height=280)
+        upload = st.file_uploader("…or upload hits.json", type=["json"])
+        if upload is not None:
+            hits_text = upload.getvalue().decode("utf-8")
+        if st.button("Use pasted hits"):
+            try:
+                hits_payload = json.loads(hits_text)
+            except json.JSONDecodeError as exc:
+                st.error(f"Invalid JSON payload: {exc}")
+            else:
+                hits = hits_payload.get("hits") if isinstance(hits_payload, Mapping) else None
+                if not isinstance(hits, list):
+                    st.error("Expected {\"hits\": [...]} in uploaded payload")
+                else:
+                    state = update_state(
+                        st.session_state,
+                        hits=hits,
+                        inputs={"hits": hits},
+                        findings=None,
+                        markdown=None,
+                    )
+                    st.session_state["markdown_preview"] = ""
+                    st.session_state["hits_text"] = hits_text
+                    st.success(f"Loaded {len(hits)} hits from provided data.")
+
+    hits_df = _inputs_summary(state.hits)
+    if not hits_df.empty:
+        with st.expander("Hits summary"):
+            st.dataframe(hits_df, use_container_width=True)
+
+    st.subheader("Interpretation settings")
+    try:
+        client = RelationshipClient(rel_base, int_base)
+        rulepacks = client.list_rulepacks()
+        if not rulepacks:
+            rulepacks = FALLBACK_RULEPACKS
+    except APIError as exc:
+        st.warning(f"Failed to fetch rulepacks: {exc}")
+        rulepacks = FALLBACK_RULEPACKS
+
+    rulepack_ids = [pack["id"] for pack in rulepacks]
+    current_rulepack = _ensure_rulepack_selection(state, rulepacks) if rulepacks else ""
+    default_index = rulepack_ids.index(current_rulepack) if current_rulepack in rulepack_ids else 0
+    selected_rulepack = st.selectbox(
+        "Rulepack",
+        options=rulepack_ids,
+        format_func=lambda value: next((f"{item['title']} ({item['version']})" for item in rulepacks if item["id"] == value), value),
+        index=default_index if rulepack_ids else 0,
+    )
+
+    pair_col1, pair_col2 = st.columns(2)
+    name_a = pair_col1.text_input("Name A", value=state.pair.nameA)
+    name_b = pair_col2.text_input("Name B", value=state.pair.nameB)
+
+    filters_dict = state.filters.model_dump()
+    profile_options = sorted({"balanced", "chemistry_plus", filters_dict.get("profile", "balanced")})
+    current_profile = filters_dict.get("profile", "balanced")
+    filters_dict["profile"] = st.selectbox(
+        "Profile",
+        options=profile_options,
+        index=profile_options.index(current_profile),
+    )
+    filters_dict["min_score"] = st.slider("Minimum score", 0.0, 1.0, float(filters_dict.get("min_score", 0.3)), 0.05)
+    filters_dict["top_k"] = st.number_input("Top-k findings", min_value=10, max_value=500, value=int(filters_dict.get("top_k", 50)), step=5)
+    filters_dict["top_highlights"] = st.slider("Highlights displayed", 1, 20, int(filters_dict.get("top_highlights", 7)))
+
+    available_tags = sorted(set(_collect_tags(state.findings)) | set(filters_dict.get("include_tags", [])) | set(filters_dict.get("exclude_tags", [])))
+    include_selection = st.multiselect("Include tags", options=available_tags, default=filters_dict.get("include_tags", []))
+    exclude_selection = st.multiselect("Exclude tags", options=available_tags, default=filters_dict.get("exclude_tags", []))
+    filters_dict["include_tags"] = include_selection
+    filters_dict["exclude_tags"] = exclude_selection
+
+    pending_updates: Dict[str, Any] = {}
+    if name_a != state.pair.nameA or name_b != state.pair.nameB:
+        pending_updates["pair"] = {"nameA": name_a, "nameB": name_b}
+    if selected_rulepack != state.rulepack_id:
+        pending_updates["rulepack_id"] = selected_rulepack
+    if filters_dict != state.filters.model_dump():
+        pending_updates["filters"] = filters_dict
+    if pending_updates:
+        state = update_state(st.session_state, **pending_updates)
+
+    st.markdown("---")
+    st.subheader("Generate report")
+    scope = st.selectbox("Interpretation scope", options=["synastry", "composite", "davison"], index=["synastry", "composite", "davison"].index(state.scope if state.scope in {"synastry", "composite", "davison"} else "synastry"))
+    if scope != state.scope:
+        state = update_state(st.session_state, scope=scope)
+
+    if st.button("Run interpretation", type="primary"):
+        if not state.hits and scope == "synastry":
+            st.error("Provide hits before running the interpretation.")
+        else:
+            payload = {
+                "rulepack_id": selected_rulepack,
+                "scope": scope,
+                "filters": {
+                    "profile": filters_dict["profile"],
+                    "min_score": float(filters_dict["min_score"]),
+                    "top_k": int(filters_dict["top_k"]),
+                    "include_tags": include_selection or None,
+                    "exclude_tags": exclude_selection or None,
+                },
+                "pair": {"nameA": name_a, "nameB": name_b},
+            }
+            if scope == "synastry":
+                payload["synastry"] = {"hits": state.hits or []}
+            elif scope == "composite":
+                payload["composite"] = state.inputs or {}
+            elif scope == "davison":
+                payload["davison"] = state.inputs or {}
+
+            client = RelationshipClient(rel_base, int_base)
+            try:
+                result = client.interpret(payload)
+            except APIError as exc:
+                st.error(str(exc))
+            else:
+                generated_at = datetime.now(timezone.utc)
+                state = update_state(st.session_state, findings=result, markdown=None)
+                markdown = _render_markdown(state, generated_at)
+                state = update_state(st.session_state, markdown=markdown)
+                st.session_state["markdown_preview"] = markdown
+                store_project(st.session_state, state.model_dump())
+                st.success("Interpretation complete. Preview available below.")
+
+    if state.findings:
+        st.subheader("Report preview")
+        markdown_value = state.markdown or _render_markdown(state, datetime.now(timezone.utc))
+        edited_markdown = st.text_area(
+            "Markdown", value=markdown_value, height=400, key="markdown_preview"
+        )
+        if edited_markdown != state.markdown:
+            state = update_state(st.session_state, markdown=edited_markdown)
+
+        _copy_to_clipboard_button(edited_markdown)
+
+        st.download_button(
+            "Download report.md",
+            data=edited_markdown,
+            file_name="relationship_report.md",
+            mime="text/markdown",
+        )
+
+        st.download_button(
+            "Download findings.json",
+            data=json.dumps(state.findings, indent=2, ensure_ascii=False),
+            file_name="relationship_findings.json",
+            mime="application/json",
+        )
+
+        totals = state.findings.get("totals", {}) if isinstance(state.findings, Mapping) else {}
+        score_table = build_scores_table(sections.summarise_scores(totals))
+        with st.expander("Score breakdown", expanded=True):
+            st.dataframe(score_table, use_container_width=True)
+
+        findings_list = state.findings.get("findings", []) if isinstance(state.findings, Mapping) else []
+        with st.expander("Grouped findings"):
+            groups = sections.group_by_primary_tag(findings_list)
+            for group in groups:
+                st.markdown(f"### {group.tag.title()}")
+                for item in group.items:
+                    snippet = _finding_snippet(item)
+                    score_val = item.get("score") if isinstance(item, Mapping) else None
+                    try:
+                        score_fmt = f"{float(score_val):.2f}"
+                    except (TypeError, ValueError):
+                        score_fmt = "n/a"
+                    title = item.get("title") if isinstance(item, Mapping) else "Finding"
+                    st.write(f"- **{title}** ({score_fmt}) {snippet}")
+
+        with st.expander("Raw payload"):
+            st.json(state.findings)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/streamlit/report_builder/client.py
+++ b/streamlit/report_builder/client.py
@@ -1,0 +1,127 @@
+"""HTTP client for relationship interpretation APIs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+import requests
+
+
+@dataclass(slots=True)
+class APIError(Exception):
+    """Lightweight exception for surfacing API failures."""
+
+    message: str
+    status: Optional[int] = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        if self.status is None:
+            return self.message
+        return f"{self.message} (HTTP {self.status})"
+
+
+def _normalise_base(url: str) -> str:
+    """Ensure the base URL does not end with a trailing slash."""
+
+    return url.rstrip("/") if url else ""
+
+
+def _extract_detail(response: Optional[requests.Response]) -> Optional[str]:
+    """Attempt to pull a human friendly error message from a response."""
+
+    if response is None:
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError:
+        text = (response.text or "").strip()
+        return text or None
+
+    if isinstance(payload, dict):
+        detail = payload.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+        if isinstance(detail, Iterable) and not isinstance(detail, (str, bytes)):
+            first = next((item for item in detail if isinstance(item, str) and item.strip()), None)
+            if first:
+                return first.strip()
+        for key in ("message", "error"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+class RelationshipClient:
+    """Thin wrapper around the relationship interpretation endpoints."""
+
+    def __init__(self, relationship_base: str, interpretation_base: str | None = None) -> None:
+        if not relationship_base:
+            raise ValueError("relationship_base must be provided")
+        self.relationship_base = _normalise_base(relationship_base)
+        self.interpretation_base = _normalise_base(interpretation_base or relationship_base)
+
+    # ------------------------------------------------------------------
+    # REST helpers
+    def _post(self, base: str, path: str, payload: Dict[str, Any], *, timeout: int) -> Dict[str, Any] | List[Any]:
+        url = f"{base}{path}" if path.startswith("/") else f"{base}/{path}"
+        try:
+            response = requests.post(url, json=payload, timeout=timeout)
+        except requests.RequestException as exc:  # pragma: no cover - network
+            raise APIError(str(exc)) from exc
+
+        if response.status_code >= 400:
+            message = _extract_detail(response) or response.text or "Unknown API error"
+            raise APIError(message, response.status_code)
+
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise APIError("API returned a non-JSON response") from exc
+
+    def _get(self, base: str, path: str, *, timeout: int) -> Dict[str, Any] | List[Any]:
+        url = f"{base}{path}" if path.startswith("/") else f"{base}/{path}"
+        try:
+            response = requests.get(url, timeout=timeout)
+        except requests.RequestException as exc:  # pragma: no cover - network
+            raise APIError(str(exc)) from exc
+
+        if response.status_code >= 400:
+            message = _extract_detail(response) or response.text or "Unknown API error"
+            raise APIError(message, response.status_code)
+
+        try:
+            return response.json()
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise APIError("API returned a non-JSON response") from exc
+
+    # ------------------------------------------------------------------
+    # Public endpoints
+    def synastry(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke the B-003 synastry endpoint and return the response body."""
+
+        data = self._post(self.relationship_base, "/v1/relationship/synastry", payload, timeout=90)
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise APIError("Unexpected response payload from synastry endpoint")
+        return data
+
+    def interpret(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Invoke the B-006 relationship interpretation endpoint."""
+
+        data = self._post(self.interpretation_base, "/v1/interpret/relationship", payload, timeout=90)
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise APIError("Unexpected response payload from interpret endpoint")
+        return data
+
+    def list_rulepacks(self) -> List[Dict[str, Any]]:
+        """Return available rulepacks for relationship interpretations."""
+
+        data = self._get(self.interpretation_base, "/v1/interpret/rulepacks", timeout=60)
+        if isinstance(data, dict):
+            items = data.get("items") if isinstance(data, dict) else None
+            if isinstance(items, list):
+                data = items
+        if not isinstance(data, list):  # pragma: no cover - defensive
+            raise APIError("Unexpected response payload from rulepack listing")
+        return data

--- a/streamlit/report_builder/samples/findings_sample.json
+++ b/streamlit/report_builder/samples/findings_sample.json
@@ -1,0 +1,30 @@
+{
+  "pair": {"nameA": "Ada", "nameB": "Charles"},
+  "rulepack": {"id": "synastry-basic", "title": "Synastry Essentials", "version": "1.0"},
+  "filters": {"profile": "balanced", "min_score": 0.3, "top_k": 50},
+  "totals": {"overall": 0.76, "by_tag": {"chemistry": 0.82, "growth": 0.64, "friction": 0.31}},
+  "findings": [
+    {
+      "id": "sun-moon-trine",
+      "title": "Sun Trine Moon",
+      "score": 0.91,
+      "tags": ["chemistry", "support"],
+      "snippet": "Natural warmth and support energise this pairing."
+    },
+    {
+      "id": "venus-mars-square",
+      "title": "Venus Square Mars",
+      "score": 0.62,
+      "tags": ["chemistry", "friction"],
+      "context": {"bodyA": "Venus", "bodyB": "Mars", "aspect": "square", "severity": 0.62},
+      "markdown_template": "{{ bodyA }} {{ aspect }} {{ bodyB }} stirs passion that needs a healthy outlet."
+    },
+    {
+      "id": "saturn-sun-conjunction",
+      "title": "Saturn Conjunct Sun",
+      "score": 0.58,
+      "tags": ["growth", "stability"],
+      "rendered_markdown": "Long-term planning comes into focus when Saturn aligns with the Sun."
+    }
+  ]
+}

--- a/streamlit/report_builder/samples/hits_sample.json
+++ b/streamlit/report_builder/samples/hits_sample.json
@@ -1,0 +1,22 @@
+{
+  "hits": [
+    {
+      "aspect": "trine",
+      "orb": 1.2,
+      "score": 0.91,
+      "bodies": {"a": "sun", "b": "moon"}
+    },
+    {
+      "aspect": "square",
+      "orb": 0.8,
+      "score": 0.62,
+      "bodies": {"a": "venus", "b": "mars"}
+    },
+    {
+      "aspect": "conjunction",
+      "orb": 0.5,
+      "score": 0.58,
+      "bodies": {"a": "saturn", "b": "sun"}
+    }
+  ]
+}

--- a/streamlit/report_builder/samples/positions_A.json
+++ b/streamlit/report_builder/samples/positions_A.json
@@ -1,0 +1,12 @@
+{
+  "name": "Ada Lovelace",
+  "datetime": "1815-12-10T12:00:00Z",
+  "location": {"lat": 51.5074, "lon": -0.1278},
+  "bodies": {
+    "sun": {"lon": 257.3},
+    "moon": {"lon": 132.1},
+    "mercury": {"lon": 245.6},
+    "venus": {"lon": 210.4},
+    "mars": {"lon": 190.2}
+  }
+}

--- a/streamlit/report_builder/samples/positions_B.json
+++ b/streamlit/report_builder/samples/positions_B.json
@@ -1,0 +1,12 @@
+{
+  "name": "Charles Babbage",
+  "datetime": "1791-12-26T08:30:00Z",
+  "location": {"lat": 51.7520, "lon": -1.2577},
+  "bodies": {
+    "sun": {"lon": 274.9},
+    "moon": {"lon": 15.4},
+    "mercury": {"lon": 250.8},
+    "venus": {"lon": 268.5},
+    "mars": {"lon": 118.9}
+  }
+}

--- a/streamlit/report_builder/sections.py
+++ b/streamlit/report_builder/sections.py
@@ -1,0 +1,88 @@
+"""Utilities for organising interpretation findings into report sections."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Sequence
+
+from jinja2 import Environment
+
+DEFAULT_GROUP = "uncategorized"
+
+
+@dataclass(slots=True)
+class FindingGroup:
+    tag: str
+    items: List[Dict[str, Any]]
+
+
+def _primary_tag(finding: Dict[str, Any]) -> str:
+    tags = finding.get("tags")
+    if isinstance(tags, Sequence) and tags:
+        first = tags[0]
+        if isinstance(first, str) and first.strip():
+            return first.strip()
+    return DEFAULT_GROUP
+
+
+def _score(finding: Dict[str, Any]) -> float:
+    value = finding.get("score")
+    try:
+        return float(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive
+        return 0.0
+
+
+def group_by_primary_tag(findings: Iterable[Dict[str, Any]]) -> List[FindingGroup]:
+    """Group findings by their primary tag with deterministic ordering."""
+
+    buckets: Dict[str, List[Dict[str, Any]]] = {}
+    for finding in findings:
+        tag = _primary_tag(finding)
+        buckets.setdefault(tag, []).append(finding)
+
+    groups: List[FindingGroup] = []
+    for tag in sorted(buckets.keys(), key=lambda item: item.lower()):
+        items = sorted(buckets[tag], key=_score, reverse=True)
+        groups.append(FindingGroup(tag=tag, items=items))
+    return groups
+
+
+def render_snippet(finding: Dict[str, Any], env: Environment) -> str | None:
+    """Derive a concise snippet for a finding if possible."""
+
+    snippet = finding.get("snippet")
+    if isinstance(snippet, str) and snippet.strip():
+        return snippet.strip()
+
+    rendered = finding.get("rendered_markdown")
+    if isinstance(rendered, str) and rendered.strip():
+        first_line = rendered.strip().splitlines()[0].strip()
+        return first_line or rendered.strip()
+
+    template_src = finding.get("markdown_template")
+    context = finding.get("context", {})
+    if not (isinstance(template_src, str) and template_src.strip() and isinstance(context, dict)):
+        return None
+
+    try:
+        template = env.from_string(template_src)
+        rendered = template.render(**context)
+    except Exception:  # pragma: no cover - defensive fallback
+        return None
+
+    first_line = rendered.strip().splitlines()[0].strip()
+    return first_line or rendered.strip() or None
+
+
+def summarise_scores(totals: Dict[str, Any]) -> Dict[str, float]:
+    """Return a flattened mapping of tag → score for table rendering."""
+
+    by_tag = totals.get("by_tag") if isinstance(totals, dict) else None
+    result: Dict[str, float] = {}
+    if isinstance(by_tag, dict):
+        for key, value in by_tag.items():
+            try:
+                result[str(key)] = float(value)
+            except (TypeError, ValueError):  # pragma: no cover - defensive
+                continue
+    return result

--- a/streamlit/report_builder/state.py
+++ b/streamlit/report_builder/state.py
@@ -1,0 +1,101 @@
+"""Session-state helpers for the report builder Streamlit app."""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional
+
+from pydantic import BaseModel, Field, ValidationError
+
+DEFAULT_ASPECTS = [0, 30, 45, 60, 72, 90, 120, 135, 144, 150, 180]
+DEFAULT_SCOPE = "synastry"
+DEFAULT_TEMPLATE_ID = "default"
+
+
+class ReportFilters(BaseModel):
+    profile: str = "balanced"
+    top_k: int = 50
+    min_score: float = 0.3
+    include_tags: List[str] = Field(default_factory=list)
+    exclude_tags: List[str] = Field(default_factory=list)
+    top_highlights: int = 7
+
+
+class PairIdentity(BaseModel):
+    nameA: str = "Person A"
+    nameB: str = "Person B"
+
+    class Config:
+        populate_by_name = True
+
+
+class ReportState(BaseModel):
+    pair: PairIdentity = Field(default_factory=PairIdentity)
+    aspects: List[int] = Field(default_factory=lambda: list(DEFAULT_ASPECTS))
+    filters: ReportFilters = Field(default_factory=ReportFilters)
+    rulepack_id: str = ""
+    scope: str = DEFAULT_SCOPE
+    hits: Optional[List[Dict[str, Any]]] = None
+    findings: Optional[Dict[str, Any]] = None
+    inputs: Optional[Dict[str, Any]] = None
+    markdown: Optional[str] = None
+    template_id: str = DEFAULT_TEMPLATE_ID
+    project_payload: Optional[Dict[str, Any]] = None
+
+
+def get_state(store: MutableMapping[str, Any]) -> ReportState:
+    raw = store.get("report_state")
+    if isinstance(raw, ReportState):  # pragma: no cover - defensive
+        return raw
+    if isinstance(raw, Mapping):
+        try:
+            return ReportState.model_validate(raw)
+        except ValidationError:
+            pass
+    state = ReportState()
+    store["report_state"] = state.model_dump()
+    return state
+
+
+def update_state(store: MutableMapping[str, Any], **updates: Any) -> ReportState:
+    state = get_state(store)
+    data = state.model_dump()
+    data.update(updates)
+    new_state = ReportState.model_validate(data)
+    store["report_state"] = new_state.model_dump()
+    return new_state
+
+
+def store_project(store: MutableMapping[str, Any], payload: Dict[str, Any]) -> None:
+    """Persist a project payload inside session state."""
+
+    state = get_state(store)
+    updated = state.model_copy(update={"project_payload": payload})
+    store["report_state"] = updated.model_dump()
+
+
+def reset_state(store: MutableMapping[str, Any]) -> ReportState:
+    state = ReportState()
+    store["report_state"] = state.model_dump()
+    return state
+
+
+def load_project(store: MutableMapping[str, Any], payload: Mapping[str, Any]) -> ReportState:
+    """Replace the current report builder state with a project payload."""
+
+    state = ReportState.model_validate(payload)
+    store["report_state"] = state.model_dump()
+    return state
+
+
+__all__ = [
+    "DEFAULT_ASPECTS",
+    "DEFAULT_SCOPE",
+    "DEFAULT_TEMPLATE_ID",
+    "PairIdentity",
+    "ReportFilters",
+    "ReportState",
+    "get_state",
+    "update_state",
+    "reset_state",
+    "store_project",
+    "load_project",
+]

--- a/streamlit/report_builder/templates/default.md.j2
+++ b/streamlit/report_builder/templates/default.md.j2
@@ -1,0 +1,42 @@
+---
+title: "Relationship Report — {{ pair.nameA }} × {{ pair.nameB }}"
+date: "{{ generated_at }}"
+rulepack: "{{ rulepack.title }} (v{{ rulepack.version }})"
+profile: "{{ filters.profile }}"
+---
+
+# Highlights
+{% if highlights %}
+{% for f in highlights %}- **{{ f.title }}** — score {{ '%.2f'|format(f.score) }} — _tags: {{ f.tags|join(', ') }}_
+{% endfor %}
+{% else %}
+_No highlight findings match the current filters._
+{% endif %}
+
+# Scores Overview
+- Overall: **{{ '%.2f'|format(scores.overall) }}**
+- By tag:
+{% if scores.by_tag %}
+{% for tag, val in scores.by_tag.items() %}  - {{ tag }}: {{ '%.2f'|format(val) }}
+{% endfor %}
+{% else %}  - n/a
+{% endif %}
+
+# Detailed Findings
+{% for group in grouped_findings %}
+## {{ group.tag | title }}
+{% for f in group.items %}- **{{ f.title }}** ({{ '%.2f'|format(f.score) }}){% if f.snippet %} — {{ f.snippet }}{% endif %}
+{% endfor %}
+{% else %}
+_No findings matched the selected filters._
+{% endfor %}
+
+# Appendix
+- Inputs: {{ appendix.inputs_link or 'embedded' }}
+- Findings included: {{ appendix.hits_count }} total
+- Generated: {{ generated_at }}
+- Filters: `{{ filters | tojson(indent=2) | safe }}`
+
+```json
+{{ appendix.payload | safe }}
+```

--- a/streamlit/report_builder/templating.py
+++ b/streamlit/report_builder/templating.py
@@ -1,0 +1,115 @@
+"""Report templating helpers for the Streamlit relationship report builder."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime
+from importlib import resources
+from typing import Any, Dict, Iterable, List, Mapping
+
+import pandas as pd
+from jinja2 import Environment, StrictUndefined, select_autoescape
+
+from . import sections
+
+TEMPLATE_PACKAGE = "streamlit.report_builder.templates"
+
+
+@dataclass(slots=True)
+class ReportContext:
+    findings: List[Dict[str, Any]]
+    rulepack: Mapping[str, Any]
+    filters: Mapping[str, Any]
+    pair: Mapping[str, Any]
+    totals: Mapping[str, Any]
+    generated_at: datetime
+    top_highlights: int
+    template_id: str
+
+
+def _load_template_source(template_id: str) -> str:
+    filename = f"{template_id}.md.j2"
+    try:
+        return resources.files(TEMPLATE_PACKAGE).joinpath(filename).read_text("utf-8")
+    except FileNotFoundError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown template: {template_id}") from exc
+
+
+def _build_environment() -> Environment:
+    env = Environment(autoescape=select_autoescape([]), undefined=StrictUndefined)
+    env.filters["deg"] = lambda value: f"{float(value):.2f}°"  # type: ignore[arg-type]
+    env.filters["round"] = lambda value, ndigits=2: round(float(value), ndigits)  # type: ignore[arg-type]
+    return env
+
+
+def _prepare_findings(ctx: ReportContext, env: Environment) -> List[Dict[str, Any]]:
+    prepared: List[Dict[str, Any]] = []
+    for finding in ctx.findings:
+        snippet = sections.render_snippet(finding, env)
+        enriched = dict(finding)
+        if snippet:
+            enriched["snippet"] = snippet
+        prepared.append(enriched)
+    prepared.sort(key=lambda item: float(item.get("score", 0.0)), reverse=True)
+    return prepared
+
+
+def render_markdown(context: ReportContext, *, template_override: str | None = None) -> str:
+    """Render a Markdown report from the provided interpretation context."""
+
+    env = _build_environment()
+    template_source = template_override or _load_template_source(context.template_id)
+    template = env.from_string(template_source)
+
+    findings = _prepare_findings(context, env)
+    groups = sections.group_by_primary_tag(findings)
+    highlight_count = max(0, int(context.top_highlights))
+    highlights = findings[:highlight_count] if highlight_count else []
+
+    appendix = {
+        "inputs_link": context.filters.get("inputs_link"),
+        "hits_count": len(findings),
+        "payload": json.dumps(
+            {
+                "pair": context.pair,
+                "rulepack": context.rulepack,
+                "filters": context.filters,
+                "totals": context.totals,
+            },
+            indent=2,
+            ensure_ascii=False,
+        ),
+    }
+
+    scores = {
+        "overall": float(context.totals.get("overall", 0.0)),
+        "by_tag": sections.summarise_scores(context.totals),
+    }
+
+    rendered = template.render(
+        pair=context.pair,
+        generated_at=context.generated_at.isoformat(timespec="seconds"),
+        rulepack=context.rulepack,
+        filters=context.filters,
+        findings=findings,
+        grouped_findings=groups,
+        highlights=highlights,
+        top_highlights=highlight_count,
+        appendix=appendix,
+        scores=scores,
+    )
+    return rendered.strip() + "\n"
+
+
+def build_scores_table(scores: Mapping[str, float]) -> pd.DataFrame:
+    """Create a pandas DataFrame of scores sorted descending."""
+
+    rows = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+    return pd.DataFrame(rows, columns=["Tag", "Score"])
+
+
+__all__ = [
+    "ReportContext",
+    "render_markdown",
+    "build_scores_table",
+]

--- a/tests/data/report_builder/default_report.md
+++ b/tests/data/report_builder/default_report.md
@@ -1,0 +1,72 @@
+---
+title: "Relationship Report — Ada × Charles"
+date: "2024-01-01T12:00:00+00:00"
+rulepack: "Synastry Essentials (v1.0)"
+profile: "balanced"
+---
+
+# Highlights
+
+- **Sun Trine Moon** — score 0.91 — _tags: chemistry, support_
+- **Venus Square Mars** — score 0.62 — _tags: chemistry, friction_
+
+
+
+# Scores Overview
+- Overall: **0.76**
+- By tag:
+
+  - chemistry: 0.82
+  - growth: 0.64
+  - friction: 0.31
+
+
+
+# Detailed Findings
+
+## Chemistry
+- **Sun Trine Moon** (0.91) — Natural warmth and support energise this pairing.
+- **Venus Square Mars** (0.62) — Venus square Mars stirs passion that needs a healthy outlet.
+
+
+## Growth
+- **Saturn Conjunct Sun** (0.58) — Long-term planning comes into focus when Saturn aligns with the Sun.
+
+
+
+# Appendix
+- Inputs: embedded
+- Findings included: 3 total
+- Generated: 2024-01-01T12:00:00+00:00
+- Filters: `{
+  "min_score": 0.3,
+  "profile": "balanced",
+  "top_k": 50
+}`
+
+```json
+{
+  "pair": {
+    "nameA": "Ada",
+    "nameB": "Charles"
+  },
+  "rulepack": {
+    "id": "synastry-basic",
+    "title": "Synastry Essentials",
+    "version": "1.0"
+  },
+  "filters": {
+    "profile": "balanced",
+    "min_score": 0.3,
+    "top_k": 50
+  },
+  "totals": {
+    "overall": 0.76,
+    "by_tag": {
+      "chemistry": 0.82,
+      "growth": 0.64,
+      "friction": 0.31
+    }
+  }
+}
+```

--- a/tests/streamlit/test_report_builder_templating.py
+++ b/tests/streamlit/test_report_builder_templating.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from streamlit.report_builder.templating import ReportContext, render_markdown
+
+
+def test_default_template_snapshot() -> None:
+    sample = json.loads(Path("streamlit/report_builder/samples/findings_sample.json").read_text())
+    context = ReportContext(
+        findings=sample["findings"],
+        rulepack=sample["rulepack"],
+        filters=sample["filters"],
+        pair=sample["pair"],
+        totals=sample["totals"],
+        generated_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        top_highlights=2,
+        template_id="default",
+    )
+    markdown = render_markdown(context)
+    expected = Path("tests/data/report_builder/default_report.md").read_text()
+    assert markdown == expected


### PR DESCRIPTION
## Summary
- add a dedicated `streamlit/report_builder` Streamlit UI that supports computing or importing hits, selecting rulepacks, filtering findings, rendering/editing Markdown, downloading reports, and exporting/importing project bundles for synastry/composite/davison work
- factor templating, grouping, and state helpers plus a default Markdown template with bundled sample inputs for deterministic preview rendering
- provide a thin RelationshipClient wrapper around the B-003/B-006 endpoints and a snapshot test to keep the Markdown output stable

## Testing
- pytest tests/streamlit/test_report_builder_templating.py
- pytest *(fails: legacy API modules are missing dependencies such as FastAPI APIRouter and SQLAlchemy Index definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68d849b16b1c83249bc09a072d8532ed