### PR TITLE
Add relationship timeline engine and exports

### DIFF
--- a/astroengine/modules/predictive/__init__.py
+++ b/astroengine/modules/predictive/__init__.py
@@ -134,6 +134,12 @@ def register_predictive_module(registry: AstroRegistry) -> None:
             "description": "Transit scans referencing composite chart positions."
         },
     )
+    composite.register_subchannel(
+        "timeline",
+        metadata={
+            "description": "Timeline overlays combining returns and composite transits."
+        },
+    )
     synastry = relationships.register_channel(
         "synastry",
         metadata={"description": "Biwheel targeting between two natal charts."},

--- a/astroengine/relation_timeline/__init__.py
+++ b/astroengine/relation_timeline/__init__.py
@@ -1,0 +1,19 @@
+"""Relationship timeline engine and export helpers."""
+
+from .engine import (
+    Event,
+    TimelineRequest,
+    TimelineResult,
+    compute_relationship_timeline,
+)
+from .policy import DEFAULT_ASPECTS, DEFAULT_TARGETS, DEFAULT_TRANSITERS
+
+__all__ = [
+    "Event",
+    "TimelineRequest",
+    "TimelineResult",
+    "compute_relationship_timeline",
+    "DEFAULT_ASPECTS",
+    "DEFAULT_TARGETS",
+    "DEFAULT_TRANSITERS",
+]

--- a/astroengine/relation_timeline/csvout.py
+++ b/astroengine/relation_timeline/csvout.py
@@ -1,0 +1,56 @@
+"""CSV export helpers for relationship timeline events."""
+
+from __future__ import annotations
+
+import csv
+import io
+from typing import Iterable
+
+from .engine import Event
+
+__all__ = ["events_to_csv"]
+
+
+_CSV_COLUMNS: tuple[str, ...] = (
+    "type",
+    "chart",
+    "transiter",
+    "target",
+    "aspect",
+    "exact_utc",
+    "start_utc",
+    "end_utc",
+    "orb",
+    "max_severity",
+    "score",
+)
+
+
+def events_to_csv(
+    events: Iterable[Event],
+    *,
+    chart_type: str,
+) -> str:
+    """Return CSV rows encoding ``events``."""
+
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(_CSV_COLUMNS)
+    for event in events:
+        writer.writerow(
+            [
+                event.type,
+                chart_type,
+                event.transiter,
+                event.target or "",
+                event.aspect if event.aspect is not None else "",
+                event.exact_utc.replace(tzinfo=None).isoformat() + "Z",
+                event.start_utc.replace(tzinfo=None).isoformat() + "Z",
+                event.end_utc.replace(tzinfo=None).isoformat() + "Z",
+                f"{event.orb:.2f}",
+                f"{event.max_severity:.3f}",
+                f"{event.score:.3f}",
+            ]
+        )
+    return buffer.getvalue()
+

--- a/astroengine/relation_timeline/engine.py
+++ b/astroengine/relation_timeline/engine.py
@@ -1,0 +1,669 @@
+"""Core engine for Relationship Timeline (SPEC-B-012)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import math
+from dataclasses import dataclass, field
+from typing import Iterable, Mapping, Sequence
+
+from ..ephemeris.adapter import EphemerisAdapter, EphemerisSample
+from ..utils.angles import delta_angle, norm360
+from .policy import (
+    ASPECT_CAPS,
+    ASPECT_FAMILY,
+    ASPECT_WEIGHTS,
+    BASE_ORBS,
+    DEFAULT_ASPECTS,
+    DEFAULT_TARGETS,
+    DEFAULT_TRANSITERS,
+    SCORE_NORMALIZER,
+    SERIES_SAMPLE_HOURS,
+    TARGET_FAMILY,
+    TARGET_WEIGHTS,
+    TRANSITER_WEIGHTS,
+)
+
+__all__ = [
+    "Event",
+    "TimelineRequest",
+    "TimelineResult",
+    "TimelineSummary",
+    "compute_relationship_timeline",
+]
+
+
+_MAX_RANGE_DAYS = 366 * 3
+_DEDUPE_WINDOW = dt.timedelta(hours=12)
+_ROOT_TOL_SECONDS = 1.0
+_ORBITAL_ZERO_TOL = 1e-6
+
+try:  # pragma: no cover - import fallback mirrors other packages
+    import swisseph as swe
+except Exception:  # pragma: no cover - tests rely on dependency stub
+    swe = None
+
+
+_DEFAULT_BODY_IDS = {
+    "Venus": getattr(swe, "VENUS", 3),
+    "Mars": getattr(swe, "MARS", 4),
+    "Jupiter": getattr(swe, "JUPITER", 5),
+    "Saturn": getattr(swe, "SATURN", 6),
+}
+
+
+@dataclass(frozen=True)
+class TimelineRequest:
+    """Input payload describing the requested timeline scan."""
+
+    chart_type: str
+    positions: Mapping[str, float]
+    range_start: dt.datetime
+    range_end: dt.datetime
+    transiters: Sequence[str] | None = None
+    targets: Sequence[str] | None = None
+    aspects: Sequence[int] | None = None
+    min_severity: float = 0.0
+    top_k: int | None = None
+    include_series: bool = False
+
+
+@dataclass(frozen=True)
+class Event:
+    """Return or transit event detected by the timeline engine."""
+
+    type: str
+    transiter: str
+    target: str | None
+    aspect: int | None
+    exact_utc: dt.datetime
+    start_utc: dt.datetime
+    end_utc: dt.datetime
+    orb: float
+    max_severity: float
+    score: float
+    series: tuple[tuple[dt.datetime, float], ...] | None = None
+
+
+@dataclass(frozen=True)
+class TimelineSummary:
+    """Aggregate statistics describing the computed events."""
+
+    counts_by_transiter: Mapping[str, int]
+    counts_by_target: Mapping[str, int]
+    counts_by_aspect: Mapping[str, int]
+    total_score: float
+    calendar: Mapping[str, float]
+
+
+@dataclass(frozen=True)
+class TimelineResult:
+    """Full result bundle containing events and export payloads."""
+
+    events: tuple[Event, ...]
+    summary: TimelineSummary
+    csv: str
+    ics: str
+
+
+def compute_relationship_timeline(
+    request: TimelineRequest,
+    *,
+    adapter: EphemerisAdapter | None = None,
+    body_ids: Mapping[str, int] | None = None,
+) -> TimelineResult:
+    """Convenience wrapper creating an engine instance and executing it."""
+
+    engine = _TimelineEngine(adapter=adapter, body_ids=body_ids)
+    return engine.compute(request)
+
+
+class _TimelineEngine:
+    """Internal helper coordinating sampling, detection, and scoring."""
+
+    _STEP_HOURS: Mapping[str, int] = {
+        "Venus": 6,
+        "Mars": 6,
+        "Jupiter": 12,
+        "Saturn": 12,
+    }
+
+    def __init__(
+        self,
+        *,
+        adapter: EphemerisAdapter | None = None,
+        body_ids: Mapping[str, int] | None = None,
+    ) -> None:
+        self._adapter = adapter or EphemerisAdapter()
+        self._body_ids = dict(_DEFAULT_BODY_IDS)
+        if body_ids:
+            self._body_ids.update(body_ids)
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+    def compute(self, request: TimelineRequest) -> TimelineResult:
+        normalized = self._normalize_request(request)
+        samples = self._sample_transiters(normalized)
+        events = self._detect_events(normalized, samples)
+        filtered = self._apply_filters(events, normalized)
+        summary = self._summaries(filtered)
+        from .csvout import events_to_csv
+        from .ics import events_to_ics
+
+        csv_payload = events_to_csv(filtered, chart_type=normalized.chart_type)
+        ics_payload = events_to_ics(filtered, chart_type=normalized.chart_type)
+        return TimelineResult(
+            events=tuple(filtered),
+            summary=summary,
+            csv=csv_payload,
+            ics=ics_payload,
+        )
+
+    # ------------------------------------------------------------------
+    # Validation & normalisation helpers
+    # ------------------------------------------------------------------
+    def _normalize_request(self, request: TimelineRequest) -> TimelineRequest:
+        if request.chart_type not in {"Composite", "Davison"}:
+            raise ValueError("chart_type must be 'Composite' or 'Davison'")
+        start = _ensure_utc(request.range_start)
+        end = _ensure_utc(request.range_end)
+        if end <= start:
+            raise ValueError("range_end must be after range_start")
+        if (end - start).days > _MAX_RANGE_DAYS:
+            raise ValueError("range exceeds 3-year supported span")
+
+        raw_transiters = (
+            request.transiters if request.transiters is not None else DEFAULT_TRANSITERS
+        )
+        transiters = [name for name in raw_transiters if name in DEFAULT_TRANSITERS]
+        if not transiters:
+            raise ValueError("No supported transiters specified")
+
+        raw_aspects = request.aspects if request.aspects is not None else DEFAULT_ASPECTS
+        aspects = [int(angle) for angle in raw_aspects if int(angle) in ASPECT_CAPS]
+        if not aspects:
+            raise ValueError("No supported aspects specified")
+
+        raw_targets = request.targets if request.targets is not None else DEFAULT_TARGETS
+        targets = [str(name) for name in raw_targets]
+
+        positions = {key: norm360(float(val)) for key, val in request.positions.items()}
+
+        return TimelineRequest(
+            chart_type=request.chart_type,
+            positions=positions,
+            range_start=start,
+            range_end=end,
+            transiters=tuple(transiters),
+            targets=tuple(targets),
+            aspects=tuple(aspects),
+            min_severity=float(max(request.min_severity, 0.0)),
+            top_k=request.top_k,
+            include_series=request.include_series,
+        )
+
+    # ------------------------------------------------------------------
+    # Sampling
+    # ------------------------------------------------------------------
+    def _sample_transiters(
+        self, request: TimelineRequest
+    ) -> dict[str, list[tuple[dt.datetime, float]]]:
+        samples: dict[str, list[tuple[dt.datetime, float]]] = {}
+        for name in request.transiters:
+            code = self._resolve_body(name)
+            step_hours = self._STEP_HOURS.get(name, 12)
+            step = dt.timedelta(hours=step_hours)
+            current = request.range_start
+            entries: list[tuple[dt.datetime, float]] = []
+            while current <= request.range_end:
+                lon = self._longitude(code, current)
+                entries.append((current, lon))
+                current += step
+            if entries[-1][0] < request.range_end:
+                lon = self._longitude(code, request.range_end)
+                entries.append((request.range_end, lon))
+            samples[name] = entries
+        return samples
+
+    def _longitude(self, code: int, moment: dt.datetime) -> float:
+        sample: EphemerisSample = self._adapter.sample(code, moment)
+        return norm360(float(sample.longitude))
+
+    def _resolve_body(self, name: str) -> int:
+        try:
+            return int(self._body_ids[name])
+        except KeyError as exc:  # pragma: no cover - guard rail
+            raise ValueError(f"Unsupported transiter '{name}'") from exc
+
+    # ------------------------------------------------------------------
+    # Event detection
+    # ------------------------------------------------------------------
+    def _detect_events(
+        self,
+        request: TimelineRequest,
+        samples: Mapping[str, list[tuple[dt.datetime, float]]],
+    ) -> list[Event]:
+        events: list[Event] = []
+        for transiter in request.transiters:
+            entries = samples[transiter]
+            code = self._resolve_body(transiter)
+            base_long = request.positions.get(transiter)
+            if base_long is not None:
+                events.extend(
+                    self._detect_returns(
+                        request,
+                        transiter,
+                        code,
+                        float(base_long),
+                        entries,
+                    )
+                )
+            events.extend(
+                self._detect_transits(request, transiter, code, entries)
+            )
+        deduped = self._dedupe(events)
+        return deduped
+
+    def _detect_returns(
+        self,
+        request: TimelineRequest,
+        transiter: str,
+        code: int,
+        base_long: float,
+        entries: Sequence[tuple[dt.datetime, float]],
+    ) -> list[Event]:
+        events: list[Event] = []
+        orb = _effective_orb(transiter, 0)
+        if orb <= 0:
+            return events
+        for idx in range(1, len(entries)):
+            t0, lon0 = entries[idx - 1]
+            t1, lon1 = entries[idx]
+            d0 = delta_angle(lon0, base_long)
+            d1 = delta_angle(lon1, base_long)
+            if _is_bracket(d0, d1):
+                exact = self._refine_zero(
+                    lambda moment: delta_angle(
+                        self._longitude(code, moment), base_long
+                    ),
+                    t0,
+                    t1,
+                    d0,
+                    d1,
+                )
+                events.append(
+                    self._build_event(
+                        request,
+                        type_="return",
+                        transiter=transiter,
+                        target=None,
+                        aspect=None,
+                        orb=orb,
+                        exact=exact,
+                        delta=lambda moment: abs(
+                            delta_angle(self._longitude(code, moment), base_long)
+                        ),
+                    )
+                )
+        return events
+
+    def _detect_transits(
+        self,
+        request: TimelineRequest,
+        transiter: str,
+        code: int,
+        entries: Sequence[tuple[dt.datetime, float]],
+    ) -> list[Event]:
+        events: list[Event] = []
+        target_positions = {
+            target: request.positions[target]
+            for target in request.targets
+            if target in request.positions
+        }
+        for target, target_lon in target_positions.items():
+            axis_target = _is_node_axis(target)
+            for aspect in request.aspects:
+                orb = _effective_orb(transiter, aspect)
+                if orb <= 0:
+                    continue
+                for idx in range(1, len(entries)):
+                    t0, lon0 = entries[idx - 1]
+                    t1, lon1 = entries[idx]
+                    d0 = _aspect_delta(lon0, target_lon, aspect, axis_target)
+                    d1 = _aspect_delta(lon1, target_lon, aspect, axis_target)
+                    if _is_bracket(d0, d1):
+                        exact = self._refine_zero(
+                            lambda moment, targ=target_lon: _aspect_delta(
+                                self._longitude(code, moment), targ, aspect, axis_target
+                            ),
+                            t0,
+                            t1,
+                            d0,
+                            d1,
+                        )
+                        events.append(
+                            self._build_event(
+                                request,
+                                type_="transit",
+                                transiter=transiter,
+                                target=target,
+                                aspect=aspect,
+                                orb=orb,
+                                exact=exact,
+                                delta=lambda moment, targ=target_lon: abs(
+                                    _aspect_delta(
+                                        self._longitude(code, moment),
+                                        targ,
+                                        aspect,
+                                        axis_target,
+                                    )
+                                ),
+                            )
+                        )
+        return events
+
+    def _refine_zero(
+        self,
+        func,
+        t0: dt.datetime,
+        t1: dt.datetime,
+        v0: float,
+        v1: float,
+    ) -> dt.datetime:
+        if abs(v0) <= _ORBITAL_ZERO_TOL:
+            return t0
+        if abs(v1) <= _ORBITAL_ZERO_TOL:
+            return t1
+        if v0 * v1 > 0:
+            return t0 if abs(v0) < abs(v1) else t1
+        lower, upper = (t0, t1) if t0 < t1 else (t1, t0)
+        f_lower, f_upper = (v0, v1) if lower == t0 else (v1, v0)
+        for _ in range(64):
+            midpoint = lower + (upper - lower) / 2
+            value = float(func(midpoint))
+            if abs(value) <= _ORBITAL_ZERO_TOL or (
+                upper - lower
+            ).total_seconds() <= _ROOT_TOL_SECONDS:
+                return midpoint
+            if f_lower * value <= 0:
+                upper = midpoint
+                f_upper = value
+            else:
+                lower = midpoint
+                f_lower = value
+        return lower + (upper - lower) / 2
+
+    def _build_event(
+        self,
+        request: TimelineRequest,
+        *,
+        type_: str,
+        transiter: str,
+        target: str | None,
+        aspect: int | None,
+        orb: float,
+        exact: dt.datetime,
+        delta,
+    ) -> Event:
+        step_hours = self._STEP_HOURS.get(transiter, 12)
+        step = dt.timedelta(hours=step_hours)
+        start = self._expand_to_orb(
+            exact,
+            request.range_start,
+            -step,
+            orb,
+            delta,
+        )
+        end = self._expand_to_orb(
+            exact,
+            request.range_end,
+            step,
+            orb,
+            delta,
+        )
+        severity = lambda moment: _severity_from_delta(delta(moment), orb)
+        series = self._series_samples(start, end, severity) if request.include_series else None
+        score = self._score_event(transiter, target, aspect, start, end, severity)
+        max_sev = severity(exact)
+        return Event(
+            type=type_,
+            transiter=transiter,
+            target=target,
+            aspect=aspect,
+            exact_utc=exact,
+            start_utc=start,
+            end_utc=end,
+            orb=orb,
+            max_severity=max_sev,
+            score=score,
+            series=series,
+        )
+
+    def _expand_to_orb(
+        self,
+        exact: dt.datetime,
+        limit: dt.datetime,
+        step: dt.timedelta,
+        orb: float,
+        delta,
+    ) -> dt.datetime:
+        direction = -1 if step.total_seconds() < 0 else 1
+        current = exact
+        inside = exact
+        while True:
+            candidate = current + step
+            if direction < 0 and candidate <= limit:
+                boundary = limit
+                if delta(boundary) <= orb + _ORBITAL_ZERO_TOL:
+                    return boundary
+                break
+            if direction > 0 and candidate >= limit:
+                boundary = limit
+                if delta(boundary) <= orb + _ORBITAL_ZERO_TOL:
+                    return boundary
+                break
+            dist = delta(candidate)
+            if dist > orb + _ORBITAL_ZERO_TOL:
+                boundary = candidate
+                break
+            inside = candidate
+            current = candidate
+        lo = inside if inside < boundary else boundary
+        hi = boundary if boundary > inside else inside
+        f_lo = delta(lo) - orb
+        f_hi = delta(hi) - orb
+        if f_lo == 0:
+            return lo
+        if f_hi == 0:
+            return hi
+        if f_lo > 0 and f_hi > 0:
+            return lo
+        for _ in range(64):
+            mid = lo + (hi - lo) / 2
+            value = delta(mid) - orb
+            if abs(value) <= _ORBITAL_ZERO_TOL or (
+                hi - lo
+            ).total_seconds() <= _ROOT_TOL_SECONDS:
+                return mid
+            if f_lo * value <= 0:
+                hi = mid
+                f_hi = value
+            else:
+                lo = mid
+                f_lo = value
+        return lo + (hi - lo) / 2
+
+    def _series_samples(self, start, end, severity_fn):
+        step = dt.timedelta(hours=SERIES_SAMPLE_HOURS)
+        samples: list[tuple[dt.datetime, float]] = []
+        moment = start
+        while moment < end:
+            samples.append((moment, severity_fn(moment)))
+            moment += step
+        samples.append((end, severity_fn(end)))
+        return tuple(samples)
+
+    # ------------------------------------------------------------------
+    # Scoring & filters
+    # ------------------------------------------------------------------
+    def _score_event(
+        self,
+        transiter: str,
+        target: str | None,
+        aspect: int | None,
+        start: dt.datetime,
+        end: dt.datetime,
+        severity_fn,
+    ) -> float:
+        if end <= start:
+            return 0.0
+        step = dt.timedelta(hours=3)
+        samples: list[tuple[dt.datetime, float]] = []
+        moment = start
+        while moment < end:
+            samples.append((moment, severity_fn(moment)))
+            moment += step
+        samples.append((end, severity_fn(end)))
+        area = 0.0
+        for idx in range(1, len(samples)):
+            prev_time, prev_val = samples[idx - 1]
+            current_time, current_val = samples[idx]
+            hours = (current_time - prev_time).total_seconds() / 3600.0
+            area += 0.5 * (prev_val + current_val) * hours
+        aspect_weight = ASPECT_WEIGHTS.get(
+            ASPECT_FAMILY.get(aspect or 0, "neutral"), 1.0
+        )
+        transiter_weight = TRANSITER_WEIGHTS.get(transiter, 1.0)
+        target_weight = TARGET_WEIGHTS.get(
+            TARGET_FAMILY.get(target or "", "points"), 1.0
+        )
+        if aspect is None:
+            aspect_weight = ASPECT_WEIGHTS.get("neutral", 0.95)
+        if target is None:
+            target_weight = 1.0
+        raw_score = area * aspect_weight * transiter_weight * target_weight
+        return raw_score / SCORE_NORMALIZER
+
+    def _apply_filters(
+        self, events: Sequence[Event], request: TimelineRequest
+    ) -> list[Event]:
+        filtered = [
+            event for event in events if event.max_severity >= request.min_severity
+        ]
+        if request.top_k is not None and request.top_k >= 0:
+            filtered.sort(key=lambda event: event.score, reverse=True)
+            filtered = filtered[: request.top_k]
+        else:
+            filtered.sort(key=lambda event: event.exact_utc)
+        return filtered
+
+    def _summaries(self, events: Sequence[Event]) -> TimelineSummary:
+        by_transiter: dict[str, int] = {}
+        by_target: dict[str, int] = {}
+        by_aspect: dict[str, int] = {}
+        calendar: dict[str, float] = {}
+        total_score = 0.0
+        for event in events:
+            by_transiter[event.transiter] = by_transiter.get(event.transiter, 0) + 1
+            if event.target:
+                by_target[event.target] = by_target.get(event.target, 0) + 1
+            if event.aspect is not None:
+                key = str(event.aspect)
+                by_aspect[key] = by_aspect.get(key, 0) + 1
+            total_score += event.score
+            _update_calendar(calendar, event)
+        return TimelineSummary(
+            counts_by_transiter=dict(by_transiter),
+            counts_by_target=dict(by_target),
+            counts_by_aspect=dict(by_aspect),
+            total_score=total_score,
+            calendar=dict(calendar),
+        )
+
+    def _dedupe(self, events: Iterable[Event]) -> list[Event]:
+        ordered = sorted(events, key=lambda e: e.exact_utc)
+        merged: list[Event] = []
+        last_for_key: dict[tuple[str, str, str | None, int | None], int] = {}
+        for event in ordered:
+            key = (event.type, event.transiter, event.target, event.aspect)
+            index = last_for_key.get(key)
+            if index is not None:
+                existing = merged[index]
+                delta = abs((event.exact_utc - existing.exact_utc).total_seconds())
+                if delta <= _DEDUPE_WINDOW.total_seconds():
+                    if event.max_severity > existing.max_severity:
+                        merged[index] = event
+                    continue
+            merged.append(event)
+            last_for_key[key] = len(merged) - 1
+        return merged
+
+
+# ----------------------------------------------------------------------
+# Helper utilities
+# ----------------------------------------------------------------------
+
+
+def _ensure_utc(moment: dt.datetime) -> dt.datetime:
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=dt.timezone.utc)
+    return moment.astimezone(dt.timezone.utc)
+
+
+def _is_bracket(a: float, b: float) -> bool:
+    if abs(a) <= _ORBITAL_ZERO_TOL or abs(b) <= _ORBITAL_ZERO_TOL:
+        return True
+    return (a < 0 <= b) or (b < 0 <= a)
+
+
+def _aspect_delta(
+    moving: float, target: float, aspect: int, axis: bool
+) -> float:
+    target_angle = norm360(target + aspect)
+    diff = delta_angle(moving, target_angle)
+    if axis:
+        alt = norm360(target + 180.0 + aspect)
+        diff_alt = delta_angle(moving, alt)
+        if abs(diff_alt) < abs(diff):
+            diff = diff_alt
+    return diff
+
+
+def _is_node_axis(name: str) -> bool:
+    normalized = name.lower()
+    return normalized in {"node", "north node", "true node", "mean node"}
+
+
+def _effective_orb(transiter: str, aspect: int) -> float:
+    base = BASE_ORBS.get(transiter, 0.0)
+    cap = ASPECT_CAPS.get(aspect, base)
+    return float(min(base, cap))
+
+
+def _severity_from_delta(delta: float, orb: float) -> float:
+    if orb <= 0:
+        return 0.0
+    ratio = min(1.0, abs(delta) / orb)
+    return 0.5 * (1.0 + math.cos(math.pi * ratio))
+
+
+def _update_calendar(storage: dict[str, float], event: Event) -> None:
+    start = event.start_utc
+    end = event.end_utc
+    total_hours = max((end - start).total_seconds() / 3600.0, 1e-6)
+    cursor = start
+    while cursor < end:
+        next_day = dt.datetime.combine(
+            (cursor + dt.timedelta(days=1)).date(),
+            dt.time.min,
+            tzinfo=dt.timezone.utc,
+        )
+        segment_end = min(next_day, end)
+        hours = (segment_end - cursor).total_seconds() / 3600.0
+        date_key = cursor.date().isoformat()
+        storage[date_key] = storage.get(date_key, 0.0) + event.score * (
+            hours / total_hours
+        )
+        cursor = segment_end
+

--- a/astroengine/relation_timeline/ics.py
+++ b/astroengine/relation_timeline/ics.py
@@ -1,0 +1,124 @@
+"""ICS export helpers for relationship timeline events."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Iterable
+
+from .engine import Event
+
+__all__ = ["events_to_ics"]
+
+
+_ASPECT_SYMBOLS: dict[int, str] = {
+    0: "☌",
+    30: "⚺",
+    45: "∠",
+    60: "⚹",
+    72: "✶",
+    90: "□",
+    120: "△",
+    135: "⚼",
+    144: "✴",
+    150: "⚻",
+    180: "☍",
+}
+
+
+def _format_dt(moment: datetime) -> str:
+    if moment.tzinfo is None:
+        value = moment.replace(tzinfo=timezone.utc)
+    else:
+        value = moment.astimezone(timezone.utc)
+    return value.strftime("%Y%m%dT%H%M%SZ")
+
+
+def _aspect_symbol(aspect: int | None) -> str:
+    if aspect is None:
+        return ""
+    return _ASPECT_SYMBOLS.get(aspect, f"{int(aspect)}°")
+
+
+def _event_summary(event: Event, chart_type: str) -> str:
+    if event.type == "return":
+        return f"Return {event.transiter} ({chart_type})"
+    symbol = _aspect_symbol(event.aspect)
+    target = event.target or ""
+    if symbol:
+        return f"TR {event.transiter} {symbol} {chart_type} {target}".strip()
+    return f"TR {event.transiter} {chart_type} {target}".strip()
+
+
+def _event_description(event: Event) -> str:
+    exact = event.exact_utc.astimezone(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+    fields = [
+        f"Type: {event.type}",
+        f"Transiter: {event.transiter}",
+    ]
+    if event.target:
+        fields.append(f"Target: {event.target}")
+    if event.aspect is not None:
+        fields.append(f"Aspect: {event.aspect}°")
+    fields.extend(
+        [
+            f"Exact: {exact}",
+            f"Max severity: {event.max_severity:.3f}",
+            f"Orb: {event.orb:.2f}°",
+            f"Score: {event.score:.3f}",
+        ]
+    )
+    return "\\n".join(fields)
+
+
+def _event_uid(event: Event) -> str:
+    payload = "|".join(
+        [
+            event.type,
+            event.transiter,
+            event.target or "-",
+            str(event.aspect) if event.aspect is not None else "-",
+            _format_dt(event.exact_utc),
+        ]
+    )
+    digest = hashlib.sha1(payload.encode("utf-8")).hexdigest()
+    return f"{digest}@astroengine"
+
+
+def events_to_ics(
+    events: Iterable[Event],
+    *,
+    chart_type: str,
+    calendar_name: str = "Relationship Timeline",
+) -> str:
+    """Render ``events`` into an RFC5545 (iCalendar) payload."""
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "PRODID:-//Relationship Timelines//EN",
+        "VERSION:2.0",
+        f"X-WR-CALNAME:{calendar_name}",
+    ]
+    for event in events:
+        dt_start = _format_dt(event.start_utc)
+        dt_end = _format_dt(event.end_utc)
+        summary = _event_summary(event, chart_type)
+        description = _event_description(event)
+        uid = _event_uid(event)
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:{uid}",
+                f"DTSTART:{dt_start}",
+                f"DTEND:{dt_end}",
+                f"SUMMARY:{summary}",
+                "DESCRIPTION:" + description.replace("\n", "\\n"),
+                "END:VEVENT",
+            ]
+        )
+
+    lines.append("END:VCALENDAR")
+    return "\r\n".join(lines) + "\r\n"
+

--- a/astroengine/relation_timeline/policy.py
+++ b/astroengine/relation_timeline/policy.py
@@ -1,0 +1,152 @@
+"""Policy constants and helpers for relationship timeline scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+__all__ = [
+    "DEFAULT_TRANSITERS",
+    "DEFAULT_TARGETS",
+    "DEFAULT_ASPECTS",
+    "BASE_ORBS",
+    "ASPECT_CAPS",
+    "ASPECT_FAMILY",
+    "ASPECT_WEIGHTS",
+    "TRANSITER_WEIGHTS",
+    "TARGET_FAMILY",
+    "TARGET_WEIGHTS",
+    "SCORE_NORMALIZER",
+    "SERIES_SAMPLE_HOURS",
+]
+
+
+DEFAULT_TRANSITERS: tuple[str, ...] = ("Venus", "Mars", "Jupiter", "Saturn")
+"""Transit-capable bodies supported in the MVP implementation."""
+
+
+DEFAULT_TARGETS: tuple[str, ...] = (
+    "Sun",
+    "Moon",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+    "Chiron",
+    "Node",
+)
+"""Default Composite/Davison targets receiving aspects from transiters."""
+
+
+DEFAULT_ASPECTS: tuple[int, ...] = (0, 60, 90, 120, 180)
+"""Major aspects scanned by default for performance reasons."""
+
+
+BASE_ORBS: Mapping[str, float] = {
+    "Venus": 3.0,
+    "Mars": 2.5,
+    "Jupiter": 2.0,
+    "Saturn": 2.0,
+}
+"""Base orb allowances keyed by transiting body."""
+
+
+ASPECT_CAPS: Mapping[int, float] = {
+    0: 8.0,
+    30: 2.0,
+    45: 2.0,
+    60: 4.0,
+    72: 1.5,
+    90: 6.0,
+    120: 6.0,
+    135: 2.0,
+    144: 1.5,
+    150: 2.0,
+    180: 8.0,
+}
+"""Aspect-specific orb caps in degrees."""
+
+
+ASPECT_FAMILY: Mapping[int, str] = {
+    0: "neutral",
+    30: "harmonious",
+    45: "challenging",
+    60: "harmonious",
+    72: "harmonious",
+    90: "challenging",
+    120: "harmonious",
+    135: "challenging",
+    144: "harmonious",
+    150: "challenging",
+    180: "challenging",
+}
+"""Family classification guiding aspect weighting."""
+
+
+ASPECT_WEIGHTS: Mapping[str, float] = {
+    "harmonious": 1.0,
+    "challenging": 1.1,
+    "neutral": 0.95,
+}
+"""Per-family multipliers applied to timeline scores."""
+
+
+TRANSITER_WEIGHTS: Mapping[str, float] = {
+    "Venus": 1.0,
+    "Mars": 1.1,
+    "Jupiter": 1.0,
+    "Saturn": 1.2,
+}
+"""Relative influence multipliers per transiting body."""
+
+
+TARGET_FAMILY: Mapping[str, str] = {
+    "Sun": "luminary",
+    "Moon": "luminary",
+    "Mercury": "personal",
+    "Venus": "personal",
+    "Mars": "personal",
+    "Jupiter": "social",
+    "Saturn": "social",
+    "Uranus": "outer",
+    "Neptune": "outer",
+    "Pluto": "outer",
+    "Chiron": "points",
+    "Node": "points",
+}
+"""Map of composite bodies into scoring families."""
+
+
+TARGET_WEIGHTS: Mapping[str, float] = {
+    "luminary": 1.3,
+    "personal": 1.1,
+    "social": 1.0,
+    "outer": 0.85,
+    "points": 0.8,
+}
+"""Weight multipliers keyed by target family."""
+
+
+SCORE_NORMALIZER: float = 60.0
+"""Calibration factor keeping event scores in a human-scaled range."""
+
+
+SERIES_SAMPLE_HOURS: int = 6
+"""Step in hours when optional severity series sampling is requested."""
+
+
+@dataclass(frozen=True)
+class OrbPolicy:
+    """Computed orb policy for a transiter / aspect combination."""
+
+    base: float
+    cap: float
+
+    @property
+    def effective(self) -> float:
+        return min(self.base, self.cap)
+

--- a/tests/relation_timeline/conftest.py
+++ b/tests/relation_timeline/conftest.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Mapping
+
+import pytest
+
+from astroengine.ephemeris.adapter import EphemerisSample
+
+
+@dataclass
+class LinearEphemeris:
+    epoch: dt.datetime
+    base_longitudes: Mapping[int, float]
+    rates_deg_per_day: Mapping[int, float]
+
+    def sample(self, body: int, moment: dt.datetime) -> EphemerisSample:
+        delta_days = (moment - self.epoch).total_seconds() / 86400.0
+        base = self.base_longitudes.get(body, 0.0)
+        rate = self.rates_deg_per_day.get(body, 0.0)
+        longitude = (base + rate * delta_days) % 360.0
+        return EphemerisSample(
+            jd_tt=0.0,
+            jd_utc=0.0,
+            longitude=longitude,
+            latitude=0.0,
+            distance=1.0,
+            speed_longitude=rate,
+            speed_latitude=0.0,
+            speed_distance=0.0,
+            right_ascension=0.0,
+            declination=0.0,
+            speed_right_ascension=0.0,
+            speed_declination=0.0,
+            delta_t_seconds=0.0,
+        )
+
+
+@pytest.fixture
+def timeline_epoch() -> dt.datetime:
+    return dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+
+@pytest.fixture
+def body_ids() -> dict[str, int]:
+    return {"Venus": 1, "Mars": 2, "Jupiter": 3, "Saturn": 4}
+
+
+@pytest.fixture
+def linear_ephemeris(timeline_epoch: dt.datetime) -> LinearEphemeris:
+    base = {1: 0.0, 2: 10.0, 3: 20.0, 4: 40.0}
+    rates = {1: 1.0, 2: 0.8, 3: 0.5, 4: 0.2}
+    return LinearEphemeris(epoch=timeline_epoch, base_longitudes=base, rates_deg_per_day=rates)
+

--- a/tests/relation_timeline/test_relation_timeline_exports.py
+++ b/tests/relation_timeline/test_relation_timeline_exports.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from astroengine.relation_timeline import (
+    TimelineRequest,
+    compute_relationship_timeline,
+)
+
+
+def test_exports_include_all_fields(linear_ephemeris, body_ids, timeline_epoch) -> None:
+    request = TimelineRequest(
+        chart_type="Composite",
+        positions={"Venus": 10.0},
+        range_start=timeline_epoch,
+        range_end=timeline_epoch + dt.timedelta(days=40),
+        transiters=("Venus",),
+        targets=(),
+        aspects=(0,),
+    )
+
+    result = compute_relationship_timeline(
+        request, adapter=linear_ephemeris, body_ids=body_ids
+    )
+
+    assert result.csv.startswith("type,chart,transiter")
+    assert "return,Composite,Venus" in result.csv
+
+    assert "BEGIN:VCALENDAR" in result.ics
+    assert "Return Venus (Composite)" in result.ics
+    assert "END:VCALENDAR" in result.ics

--- a/tests/relation_timeline/test_relation_timeline_returns.py
+++ b/tests/relation_timeline/test_relation_timeline_returns.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+from astroengine.relation_timeline import (
+    TimelineRequest,
+    compute_relationship_timeline,
+)
+
+
+def test_return_detection_has_precise_window(
+    linear_ephemeris, body_ids, timeline_epoch
+) -> None:
+    request = TimelineRequest(
+        chart_type="Composite",
+        positions={"Venus": 10.0},
+        range_start=timeline_epoch,
+        range_end=timeline_epoch + dt.timedelta(days=30),
+        transiters=("Venus",),
+        targets=(),
+        aspects=(0,),
+    )
+
+    result = compute_relationship_timeline(
+        request, adapter=linear_ephemeris, body_ids=body_ids
+    )
+
+    returns = [event for event in result.events if event.type == "return"]
+    assert len(returns) == 1
+
+    event = returns[0]
+    expected_exact = timeline_epoch + dt.timedelta(days=10)
+    assert abs((event.exact_utc - expected_exact).total_seconds()) < 120
+
+    # Base orb for Venus is 3°, motion 1°/day, so window spans ~6 days.
+    expected_start = timeline_epoch + dt.timedelta(days=7)
+    expected_end = timeline_epoch + dt.timedelta(days=13)
+    assert abs((event.start_utc - expected_start).total_seconds()) < 7200
+    assert abs((event.end_utc - expected_end).total_seconds()) < 7200
+
+    assert math.isclose(event.orb, 3.0, rel_tol=1e-6)
+    assert event.max_severity > 0.99
+    assert result.summary.counts_by_transiter["Venus"] == 1

--- a/tests/relation_timeline/test_relation_timeline_transits.py
+++ b/tests/relation_timeline/test_relation_timeline_transits.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from astroengine.relation_timeline import (
+    TimelineRequest,
+    compute_relationship_timeline,
+)
+
+
+def test_transit_square_detection(linear_ephemeris, body_ids, timeline_epoch) -> None:
+    request = TimelineRequest(
+        chart_type="Composite",
+        positions={"Sun": 50.0},
+        range_start=timeline_epoch,
+        range_end=timeline_epoch + dt.timedelta(days=220),
+        transiters=("Mars",),
+        targets=("Sun",),
+        aspects=(90,),
+    )
+
+    result = compute_relationship_timeline(
+        request, adapter=linear_ephemeris, body_ids=body_ids
+    )
+
+    events = [event for event in result.events if event.type == "transit"]
+    assert len(events) == 1
+    event = events[0]
+
+    expected_exact = timeline_epoch + dt.timedelta(days=162, hours=12)
+    assert abs((event.exact_utc - expected_exact).total_seconds()) < 3600
+    assert event.target == "Sun"
+    assert event.aspect == 90
+    assert event.max_severity > 0.99
+    assert result.summary.counts_by_aspect["90"] == 1

--- a/tests/relation_timeline/test_relation_timeline_windows_scores.py
+++ b/tests/relation_timeline/test_relation_timeline_windows_scores.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import datetime as dt
+
+from astroengine.relation_timeline import (
+    TimelineRequest,
+    compute_relationship_timeline,
+)
+
+
+def test_scoring_and_series(linear_ephemeris, body_ids, timeline_epoch) -> None:
+    request = TimelineRequest(
+        chart_type="Davison",
+        positions={"Node": 80.0},
+        range_start=timeline_epoch,
+        range_end=timeline_epoch + dt.timedelta(days=260),
+        transiters=("Jupiter",),
+        targets=("Node",),
+        aspects=(0,),
+        include_series=True,
+    )
+
+    result = compute_relationship_timeline(
+        request, adapter=linear_ephemeris, body_ids=body_ids
+    )
+
+    event = result.events[0]
+    assert event.type == "transit"
+    assert event.series is not None
+    assert event.series[0][0] == event.start_utc
+    assert event.series[-1][0] == event.end_utc
+    assert event.score > 0.0
+    assert event.max_severity <= 1.0
+
+    assert result.summary.total_score == event.score
+    assert event.start_utc.date().isoformat() in result.summary.calendar


### PR DESCRIPTION
## Summary
- implement a relationship timeline engine for composite and Davison charts including window refinement, scoring, and CSV/ICS exports
- register the relationship timeline channel within the predictive relationships module
- add deterministic tests covering returns, transits, scoring, and export payloads for the new engine

## Testing
- pytest tests/relation_timeline -q
- pytest -q *(fails: existing suite relies on optional FastAPI/SQLAlchemy modules and legacy packages that are unavailable in the CI image)*

------
https://chatgpt.com/codex/tasks/task_e_68d84c714be883249662edc4486ece8a