### PR TITLE
Add interpretation rulepacks and DSL extensions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@
 recursive-include astroengine/registry *.yaml *.yml *.csv
 recursive-include astroengine/profiles *.yaml *.yml *.json
 recursive-include astroengine/datasets *.csv *.json
+recursive-include interpret-packs *.yaml *.yml *.json *.md
 # >>> AUTO-GEN END: astroengine manifest data v1.0

--- a/app/routers/interpret.py
+++ b/app/routers/interpret.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import asdict
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException
 
@@ -17,32 +17,40 @@ from core.interpret_plus.engine import interpret, load_rules
 
 router = APIRouter(prefix="/interpret", tags=["Interpretations"])
 
-# Directory containing rulepacks (YAML/JSON). Defaults to built-in samples.
-RULEPACK_DIR = os.getenv(
-    "RULEPACK_DIR",
-    os.path.abspath(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "core",
-            "interpret_plus",
-            "samples",
-        )
-    ),
-)
+# Directory roots containing rulepacks (YAML/JSON).
+if env_dir := os.getenv("RULEPACK_DIR"):
+    RULEPACK_DIRS: List[str] = [os.path.abspath(env_dir)]
+else:
+    base = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    RULEPACK_DIRS = [
+        os.path.join(base, "interpret-packs", "packs"),
+        os.path.join(base, "interpret-packs", "meta"),
+        os.path.join(base, "core", "interpret_plus", "samples"),
+    ]
+
+
+def _load_pack_info(path: str) -> Optional[RulepackInfo]:
+    try:
+        pack = load_rules(path)
+    except Exception:
+        return None
+    rid = pack.get("rulepack") or os.path.splitext(os.path.basename(path))[0]
+    desc = pack.get("description")
+    return RulepackInfo(id=str(rid), path=path, description=desc)
 
 
 def _discover_rulepacks() -> List[RulepackInfo]:
     items: List[RulepackInfo] = []
-    if not os.path.isdir(RULEPACK_DIR):
-        return items
-    for fn in os.listdir(RULEPACK_DIR):
-        if not (fn.endswith(".yaml") or fn.endswith(".yml") or fn.endswith(".json")):
+    for directory in RULEPACK_DIRS:
+        if not os.path.isdir(directory):
             continue
-        rid = os.path.splitext(fn)[0]
-        path = os.path.join(RULEPACK_DIR, fn)
-        items.append(RulepackInfo(id=rid, path=path, description=None))
+        for fn in os.listdir(directory):
+            if not (fn.endswith(".yaml") or fn.endswith(".yml") or fn.endswith(".json")):
+                continue
+            path = os.path.join(directory, fn)
+            info = _load_pack_info(path)
+            if info:
+                items.append(info)
     items.sort(key=lambda x: x.id)
     return items
 
@@ -50,7 +58,13 @@ def _discover_rulepacks() -> List[RulepackInfo]:
 @router.get("/rulepacks", response_model=RulepacksResponse, summary="List available rulepacks")
 def list_rulepacks():
     items = _discover_rulepacks()
-    return RulepacksResponse(items=items, meta={"count": len(items), "dir": RULEPACK_DIR})
+    return RulepacksResponse(
+        items=items,
+        meta={
+            "count": len(items),
+            "dirs": [directory for directory in RULEPACK_DIRS if os.path.isdir(directory)],
+        },
+    )
 
 
 @router.post("/relationship", response_model=FindingsResponse, summary="Run relationship interpretations")
@@ -63,7 +77,10 @@ def relationship_findings(req: FindingsRequest):
 
     # Load rules
     if req.rules_inline is not None:
-        rules: List[Dict[str, Any]] = req.rules_inline
+        if isinstance(req.rules_inline, dict):
+            rules: Any = req.rules_inline
+        else:
+            rules = req.rules_inline
     else:
         rp = req.rulepack_id or "relationship_basic"  # default built-in
         match = next((r for r in _discover_rulepacks() if r.id == rp), None)
@@ -77,6 +94,12 @@ def relationship_findings(req: FindingsRequest):
         ireq["hits"] = req.hits
     else:
         ireq["positions"] = req.positions
+        if req.houses is not None:
+            ireq["houses"] = req.houses
+        if req.angles is not None:
+            ireq["angles"] = req.angles
+    if req.profile is not None:
+        ireq["profile"] = req.profile
 
     findings = interpret(ireq, rules)
 
@@ -86,9 +109,11 @@ def relationship_findings(req: FindingsRequest):
     if req.top_k is not None and req.top_k > 0:
         findings = findings[: req.top_k]
 
+    pack_id = rules.get("rulepack") if isinstance(rules, dict) else None
+
     return FindingsResponse(
         findings=[FindingOut(**asdict(f)) for f in findings],
-        meta={"count": len(findings)},
+        meta={"count": len(findings), "rulepack": pack_id, "profile": req.profile},
     )
 
 

--- a/app/schemas/interpret.py
+++ b/app/schemas/interpret.py
@@ -18,14 +18,17 @@ class FindingsRequest(BaseModel):
     # One of these, depending on scope
     hits: Optional[List[Dict[str, Any]]] = None
     positions: Optional[Dict[str, float]] = None
+    houses: Optional[Dict[str, Any]] = None
+    angles: Optional[Dict[str, float]] = None
 
     # Rules source
     rulepack_id: Optional[str] = None
-    rules_inline: Optional[List[Dict[str, Any]]] = None
+    rules_inline: Optional[Any] = None
 
     # Filters
     top_k: Optional[int] = Field(default=None, ge=1)
     min_score: Optional[float] = Field(default=None, ge=0.0)
+    profile: Optional[str] = None
 
 
 class FindingOut(BaseModel):

--- a/core/interpret_plus/engine.py
+++ b/core/interpret_plus/engine.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from collections import defaultdict
+from copy import deepcopy
 import json
+import math
+import os
 
 try:  # pragma: no cover - optional dependency for richer rulepacks
     import yaml  # type: ignore
@@ -27,20 +31,10 @@ class Finding:
 Rule = Dict[str, Any]
 Request = Dict[str, Any]
 SynastryHit = Dict[str, Any]
+Pack = Dict[str, Any]
 
 
-# --------------------------- Rule loading ----------------------------------
-def load_rules(path: str) -> List[Rule]:
-    """Load a rulepack from YAML or JSON."""
-
-    with open(path, "r", encoding="utf-8") as handle:
-        raw = handle.read()
-    if path.endswith(".json") or yaml is None:
-        return json.loads(raw)
-    return yaml.safe_load(raw)
-
-
-# --------------------------- Helpers ---------------------------------------
+# --------------------------- Constants -------------------------------------
 ASPECT_SYMBOLS: Dict[str, str] = {
     "conjunction": "☌",
     "opposition": "☍",
@@ -58,11 +52,46 @@ ARCHETYPES: Dict[str, str] = {
     "Mars": "Drive & Desire",
     "Jupiter": "Growth",
     "Saturn": "Structure & Commitment",
+    "Uranus": "Revolution & Freedom",
+    "Neptune": "Dreaming & Ideals",
+    "Pluto": "Transformation & Depth",
+    "Asc": "Ascendant",
+    "MC": "Midheaven",
+}
+
+ASPECT_ALIASES: Dict[Any, str] = {
+    0: "conjunction",
+    30: "semi-sextile",
+    45: "semi-square",
+    60: "sextile",
+    90: "square",
+    120: "trine",
+    135: "sesquiquadrate",
+    150: "quincunx",
+    180: "opposition",
+    "0": "conjunction",
+    "60": "sextile",
+    "90": "square",
+    "120": "trine",
+    "180": "opposition",
+}
+
+ASPECT_FAMILIES: Dict[str, Sequence[str]] = {
+    "harmonious": ("sextile", "trine"),
+    "challenging": ("square", "opposition", "sesquiquadrate", "semi-square"),
+    "neutral": ("conjunction", "quincunx", "semi-sextile"),
+}
+
+ASPECT_TO_FAMILY: Dict[str, str] = {
+    aspect: family
+    for family, aspects in ASPECT_FAMILIES.items()
+    for aspect in aspects
 }
 
 
-def _fmt(template: str, ctx: Dict[str, Any]) -> str:
-    """Best-effort format that falls back to template on error."""
+# --------------------------- Helper Functions ------------------------------
+def _fmt(template: str, ctx: Mapping[str, Any]) -> str:
+    """Best-effort format that falls back to the template on error."""
 
     try:
         return template.format(**ctx)
@@ -70,55 +99,370 @@ def _fmt(template: str, ctx: Dict[str, Any]) -> str:
         return template
 
 
-def _coerce_bodies(raw: Any) -> Sequence[str]:
+def _coerce_seq(raw: Any) -> Tuple[str, ...]:
     if raw is None:
         return ()
-    if isinstance(raw, str):
-        return (raw,)
-    return tuple(raw)
+    if isinstance(raw, (list, tuple, set)):
+        return tuple(str(item) for item in raw)
+    return (str(raw),)
+
+
+def _normalise_aspect(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return ASPECT_ALIASES.get(int(value))
+    value_str = str(value).strip().lower()
+    return ASPECT_ALIASES.get(value_str) or value_str
+
+
+def _aspect_family(aspect: Optional[str]) -> Optional[str]:
+    if aspect is None:
+        return None
+    return ASPECT_TO_FAMILY.get(aspect.lower())
+
+
+def _strength_transform(strength: float, spec: Optional[str]) -> float:
+    if spec is None or spec == "linear":
+        return strength
+    if spec.startswith("cosine"):
+        power = 1.0
+        if "^" in spec:
+            try:
+                power = float(spec.split("^", 1)[1])
+            except ValueError:
+                power = 1.0
+        # Emphasise higher strengths, flatten lower ones.
+        transformed = math.cos((1.0 - max(min(strength, 1.0), 0.0)) * math.pi / 2.0)
+        return transformed**power
+    if spec.startswith("power^"):
+        try:
+            exponent = float(spec.split("^", 1)[1])
+        except ValueError:
+            exponent = 1.0
+        return strength**exponent
+    return strength
+
+
+def _distance(a: float, b: float) -> float:
+    diff = abs((a - b + 180.0) % 360.0 - 180.0)
+    return diff
+
+
+def _ensure_profile(profiles: MutableMapping[str, Any]) -> None:
+    if "default" not in profiles:
+        profiles["default"] = {"tags": {}}
+
+
+def _merge_profiles(base: MutableMapping[str, Any], extra: Mapping[str, Any]) -> MutableMapping[str, Any]:
+    merged = dict(base)
+    for name, payload in extra.items():
+        if name not in merged:
+            merged[name] = deepcopy(payload)
+            continue
+        existing = merged[name]
+        for key, value in payload.items():
+            if isinstance(value, Mapping) and isinstance(existing.get(key), Mapping):
+                merged[name][key] = {**existing[key], **value}
+            else:
+                merged[name][key] = deepcopy(value)
+    return merged
+
+
+def _load_raw(path: str) -> Any:
+    with open(path, "r", encoding="utf-8") as handle:
+        raw = handle.read()
+    if path.endswith(".json") or yaml is None:
+        return json.loads(raw)
+    return yaml.safe_load(raw)
+
+
+def _normalise_pack(data: Any, *, source: str, stack: Sequence[str] = ()) -> Pack:
+    """Normalise raw YAML/JSON payload into a rulepack dictionary."""
+
+    pack_id = os.path.splitext(os.path.basename(source))[0]
+
+    if isinstance(data, list):
+        return {
+            "rulepack": pack_id,
+            "version": "1",
+            "rules": list(data),
+            "profiles": {"default": {"tags": {}}},
+            "tag_map": {},
+            "meta": {},
+            "source": source,
+        }
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Unsupported rulepack payload in {source!r}")
+
+    includes = data.get("includes") or []
+    base_dir = os.path.dirname(source)
+
+    combined_rules: List[Rule] = []
+    combined_tag_map: Dict[str, Any] = {}
+    combined_profiles: Dict[str, Any] = {}
+    combined_meta: Dict[str, Any] = {}
+
+    for entry in includes:
+        include_path = entry.get("path")
+        include_id = entry.get("id")
+        if include_path is None and include_id:
+            include_path = os.path.join("..", "packs", f"{include_id}.yaml")
+        if include_path is None:
+            raise ValueError(f"Meta-pack entry missing path/id in {source!r}")
+
+        resolved = os.path.normpath(os.path.join(base_dir, include_path))
+        if resolved in stack:
+            raise ValueError(f"Recursive rulepack include detected: {resolved}")
+        child = load_rules(resolved, _stack=(*stack, source))
+        weight = float(entry.get("weight", 1.0))
+
+        for rule in child.get("rules", []):
+            clone = deepcopy(rule)
+            meta = clone.setdefault("meta", {})
+            meta.setdefault("source_pack", child.get("rulepack"))
+            if weight != 1.0:
+                meta["include_weight"] = weight
+            combined_rules.append(clone)
+
+        combined_tag_map.update(child.get("tag_map", {}))
+        combined_profiles = _merge_profiles(combined_profiles, child.get("profiles", {}))
+        combined_meta.setdefault("includes", []).append(child.get("rulepack"))
+
+    rules = list(data.get("rules", []))
+    for rule in rules:
+        rule_meta = rule.setdefault("meta", {})
+        rule_meta.setdefault("source_pack", data.get("rulepack", pack_id))
+        combined_rules.append(rule)
+
+    tag_map = dict(combined_tag_map)
+    tag_map.update(data.get("tag_map") or data.get("tags") or {})
+
+    profiles = _merge_profiles(combined_profiles, data.get("profiles", {}))
+    _ensure_profile(profiles)
+
+    meta = dict(combined_meta)
+    meta.update(data.get("meta", {}))
+
+    pack: Pack = {
+        "rulepack": data.get("rulepack", pack_id),
+        "version": str(data.get("version", "1")),
+        "rules": combined_rules,
+        "profiles": profiles,
+        "tag_map": tag_map,
+        "meta": meta,
+        "source": source,
+    }
+    if "default_profile" in data:
+        pack["default_profile"] = data["default_profile"]
+    if "description" in data:
+        pack["description"] = data["description"]
+    return pack
+
+
+def load_rules(path: str, _stack: Sequence[str] = ()) -> Pack:
+    """Load a rulepack from YAML or JSON, resolving meta-pack includes."""
+
+    payload = _load_raw(path)
+    return _normalise_pack(payload, source=path, stack=_stack)
+
+
+# --------------------------- DSL Normalisation ------------------------------
+def _extract_result(rule: Rule) -> Dict[str, Any]:
+    result = rule.get("then") or {}
+    if not result:
+        result = {
+            "title": rule.get("title"),
+            "text": rule.get("text", ""),
+            "tags": rule.get("tags", []),
+            "base_score": rule.get("base_score", rule.get("score", 1.0)),
+            "score_fn": rule.get("score_fn"),
+        }
+        if "boost" in rule:
+            result["boost"] = rule["boost"]
+        if "limit" in rule:
+            result["limit"] = rule["limit"]
+    result.setdefault("title", rule.get("title") or rule.get("id", ""))
+    result.setdefault("text", rule.get("text", ""))
+    result.setdefault("tags", rule.get("tags", []))
+    result.setdefault("base_score", rule.get("base_score", rule.get("score", 1.0)))
+    if "score_fn" not in result and "score_fn" in rule:
+        result["score_fn"] = rule["score_fn"]
+    return result
+
+
+def _normalise_rule(rule: Rule) -> Rule:
+    clone = deepcopy(rule)
+    clone["then"] = _extract_result(rule)
+    return clone
 
 
 # --------------------------- Matching Primitives ---------------------------
-def _match_synastry_rule(rule: Rule, hits: Sequence[SynastryHit]) -> List[Tuple[SynastryHit, float]]:
-    """Return (hit, strength) pairs that satisfy the synastry rule."""
+def _matches_bodies(hit: SynastryHit, cond: Mapping[str, Any]) -> bool:
+    bodies = set(_coerce_seq(cond.get("bodies")))
+    bodies_a = set(_coerce_seq(cond.get("bodiesA")))
+    bodies_b = set(_coerce_seq(cond.get("bodiesB")))
 
-    cond = rule.get("when", {}) or {}
-    bodies = set(_coerce_bodies(cond.get("bodies")))
+    a = hit.get("a")
+    b = hit.get("b")
+
+    if bodies_a or bodies_b:
+        if bodies_a and "*" not in bodies_a and a not in bodies_a:
+            return False
+        if bodies_b and "*" not in bodies_b and b not in bodies_b:
+            return False
+        return True
+
+    if not bodies:
+        return True
+
+    if len(bodies) == 1:
+        return a in bodies or b in bodies
+
+    return {a, b} == bodies
+
+
+def _match_synastry_condition(cond: Mapping[str, Any], hits: Sequence[SynastryHit]) -> List[SynastryHit]:
+    aspect_names = {_normalise_aspect(item) for item in cond.get("aspects", [])}
     aspect_in = {str(name).lower() for name in cond.get("aspect_in", [])}
+    aspect_names.discard(None)
+    families = {str(name).lower() for name in cond.get("family", [])}
     min_severity = float(cond.get("min_severity", 0.0))
 
-    matches: List[Tuple[SynastryHit, float]] = []
+    matches: List[SynastryHit] = []
     for hit in hits:
-        a = hit.get("a")
-        b = hit.get("b")
-        aspect = str(hit.get("aspect", "")).lower()
-        if aspect_in and aspect not in aspect_in:
+        aspect = _normalise_aspect(hit.get("aspect"))
+        if aspect_names and aspect not in aspect_names:
             continue
-
-        if bodies:
-            pair = {a, b}
-            if len(bodies) == 1:
-                if a not in bodies and b not in bodies:
-                    continue
-            elif pair != bodies:
+        if aspect_in and (aspect or "") not in aspect_in:
+            continue
+        if families:
+            fam = _aspect_family(aspect)
+            if fam not in families:
                 continue
-
+        if not _matches_bodies(hit, cond):
+            continue
         severity = float(hit.get("severity", 0.0))
         if severity < min_severity:
             continue
-        matches.append((hit, max(severity, min_severity)))
+        enriched = dict(hit)
+        enriched["aspect"] = aspect
+        enriched["family"] = _aspect_family(aspect)
+        enriched["strength"] = max(severity, min_severity)
+        matches.append(enriched)
     return matches
 
 
-def _match_body_longitude(rule: Rule, positions: Dict[str, float]) -> List[Tuple[str, float]]:
-    cond = rule.get("when", {}) or {}
-    bodies = _coerce_bodies(cond.get("bodies") or cond.get("body"))
-    if not bodies:
+def _evaluate_group(cond: Mapping[str, Any], hits: Sequence[SynastryHit]) -> List[SynastryHit]:
+    block = cond.get("group") or {}
+    if not block:
         return []
 
+    if "any" in block:
+        subconditions = block["any"] or []
+        matched: Dict[Tuple[str, str, str], SynastryHit] = {}
+        for sub in subconditions:
+            for hit in _match_synastry_condition(sub, hits):
+                key = (hit.get("a"), hit.get("b"), hit.get("aspect"))
+                if key not in matched:
+                    matched[key] = hit
+        matches = list(matched.values())
+    elif "all" in block:
+        matches = []
+        for sub in block["all"] or []:
+            sub_matches = _match_synastry_condition(sub, hits)
+            if not sub_matches:
+                return []
+            matches.extend(sub_matches)
+    else:
+        matches = []
+
+    threshold = block.get("count") or block.get("count_at_least")
+    if threshold is not None and len(matches) < int(threshold):
+        return []
+    return matches
+
+
+def _match_synastry(rule: Rule, hits: Sequence[SynastryHit]) -> List[Dict[str, Any]]:
+    cond = rule.get("when", {}) or {}
+
+    group_matches = _evaluate_group(cond, hits)
+    if group_matches:
+        strength = sum(float(hit.get("strength", 0.0)) for hit in group_matches) / max(len(group_matches), 1)
+        return [
+            {
+                "kind": "group",
+                "hits": group_matches,
+                "strength": strength,
+                "primary": group_matches[0],
+            }
+        ]
+    if "group" in cond:
+        return []
+
+    matches = _match_synastry_condition(cond, hits)
+    results: List[Dict[str, Any]] = []
+    for hit in matches:
+        results.append(
+            {
+                "kind": "synastry",
+                "hits": [hit],
+                "strength": float(hit.get("strength", 0.0)),
+                "primary": hit,
+            }
+        )
+    return results
+
+
+def _match_chart(rule: Rule, request: Request) -> List[Dict[str, Any]]:
+    cond = rule.get("when", {}) or {}
+    positions = request.get("positions", {}) or {}
+    houses_data = request.get("houses", {}) or {}
+    angles = request.get("angles", {}) or {}
+
+    house_block = cond.get("house")
+    if house_block:
+        scope = house_block.get("scope")
+        if scope and scope != request.get("scope"):
+            return []
+        target_bodies = _coerce_seq(house_block.get("target"))
+        houses = {str(item) for item in house_block.get("in", [])}
+        angles_any = [str(item) for item in house_block.get("angles_any", house_block.get("angle", []))]
+        orb = float(house_block.get("orb", 2.0))
+
+        matches: List[Dict[str, Any]] = []
+        for body in target_bodies:
+            info = houses_data.get(body)
+            if isinstance(info, Mapping):
+                body_house = str(info.get("house", ""))
+            else:
+                body_house = str(info or "")
+            if houses and body_house not in houses:
+                continue
+            longitude = None
+            if isinstance(info, Mapping) and "longitude" in info:
+                longitude = float(info["longitude"])
+            elif body in positions:
+                longitude = float(positions[body])
+            if angles_any and longitude is not None:
+                if not any(
+                    name in angles and _distance(longitude, float(angles[name])) <= orb
+                    for name in angles_any
+                ):
+                    continue
+            matches.append({
+                "kind": "chart",
+                "body": body,
+                "longitude": longitude,
+                "house": body_house,
+            })
+        return matches
+
+    bodies = _coerce_seq(cond.get("bodies") or cond.get("body"))
     ranges = cond.get("longitude_ranges") or []
     normalised_ranges = [tuple(map(float, window)) for window in ranges]
-    matches: List[Tuple[str, float]] = []
+    matches: List[Dict[str, Any]] = []
     for body in bodies:
         if body not in positions:
             continue
@@ -127,71 +471,237 @@ def _match_body_longitude(rule: Rule, positions: Dict[str, float]) -> List[Tuple
             in_range = any(lo <= longitude < hi for lo, hi in normalised_ranges)
             if not in_range:
                 continue
-        matches.append((body, longitude))
+        matches.append({
+            "kind": "chart",
+            "body": body,
+            "longitude": longitude,
+            "house": str(houses_data.get(body, "")),
+        })
     return matches
 
 
+# --------------------------- Scoring Helpers -------------------------------
+def _profile_multiplier(tags: Sequence[str], pack: Pack, profile_name: Optional[str]) -> float:
+    profile = pack.get("profiles", {}).get(profile_name or "", {})
+    if not profile:
+        profile = pack.get("profiles", {}).get(pack.get("default_profile", "default"), {})
+    tags_weights = profile.get("tags", {}) if isinstance(profile, Mapping) else {}
+
+    tag_map = pack.get("tag_map", {})
+    weights: List[float] = []
+    for tag in tags:
+        entry = tag_map.get(tag, {})
+        bucket = entry.get("bucket") if isinstance(entry, Mapping) else None
+        sub_weight = float(entry.get("weight", 1.0)) if isinstance(entry, Mapping) else 1.0
+        bucket_weight = float(tags_weights.get(bucket, 1.0)) if bucket else 1.0
+        weights.append(sub_weight * bucket_weight)
+
+    if not weights:
+        return 1.0
+    return sum(weights) / len(weights)
+
+
+def _apply_boost(score: float, boost: Optional[Mapping[str, Any]]) -> float:
+    if not boost:
+        return score
+    factor = float(boost.get("by", 1.0))
+    cap = boost.get("cap")
+    adjusted = score * factor
+    if cap is not None:
+        adjusted = min(adjusted, float(cap))
+    return adjusted
+
+
+def _build_conflict_key(match: Mapping[str, Any], rule: Rule, scope: str) -> Tuple[Any, ...]:
+    if match.get("kind") == "synastry":
+        primary = match.get("primary", {})
+        pair = tuple(sorted((primary.get("a"), primary.get("b"))))
+        aspect = primary.get("aspect")
+        return (scope, pair, aspect)
+    if match.get("kind") == "group":
+        return (scope, rule.get("id"), "group")
+    body = match.get("body") or match.get("primary", {}).get("body")
+    return (scope, body)
+
+
+def _pair_key(match: Mapping[str, Any]) -> Optional[Tuple[str, str]]:
+    primary = match.get("primary")
+    if not isinstance(primary, Mapping):
+        return None
+    a = primary.get("a")
+    b = primary.get("b")
+    if a and b:
+        return tuple(sorted((a, b)))
+    return None
+
+
+def _prepare_candidate(
+    rule: Rule,
+    match: Mapping[str, Any],
+    pack: Pack,
+    scope: str,
+    profile: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    then = rule.get("then", {}) or {}
+    tags = list(then.get("tags", []))
+
+    base_score = float(then.get("base_score", 1.0))
+    include_weight = float(rule.get("meta", {}).get("include_weight", 1.0))
+    strength = float(match.get("strength", 1.0))
+    score_fn = then.get("score_fn")
+    transformed_strength = _strength_transform(strength, score_fn)
+    raw_score = base_score * transformed_strength
+    profile_factor = _profile_multiplier(tags, pack, profile)
+    score = raw_score * profile_factor * include_weight
+    score = _apply_boost(score, then.get("boost"))
+
+    primary = match.get("primary", {})
+    aspect = primary.get("aspect") if isinstance(primary, Mapping) else None
+
+    context = {
+        "count": len(match.get("hits", [])),
+        "strength": strength,
+        "scope": scope,
+        "rule_id": rule.get("id"),
+    }
+
+    if match.get("kind") in {"synastry", "group"}:
+        a = primary.get("a")
+        b = primary.get("b")
+        aspect = primary.get("aspect")
+        ctx = {
+            "a": a,
+            "b": b,
+            "aspect": aspect,
+            "aspect_symbol": ASPECT_SYMBOLS.get(aspect or "", aspect or ""),
+            "severity": primary.get("severity", primary.get("strength", strength)),
+            "a_arch": ARCHETYPES.get(a, a),
+            "b_arch": ARCHETYPES.get(b, b),
+            "hits": match.get("hits", []),
+        }
+        context.update(ctx)
+    elif match.get("kind") == "chart":
+        body = match.get("body")
+        ctx = {
+            "body": body,
+            "arch": ARCHETYPES.get(body, body),
+            "longitude": match.get("longitude"),
+            "house": match.get("house"),
+        }
+        context.update(ctx)
+
+    title = then.get("title") or rule.get("title") or rule.get("id", "")
+    text = _fmt(then.get("text", ""), context)
+
+    candidate = {
+        "rule_id": rule.get("id", "rule"),
+        "scope": scope,
+        "title": title,
+        "text": text,
+        "tags": tags,
+        "score": score,
+        "raw_score": raw_score,
+        "profile_factor": profile_factor,
+        "match": match,
+        "limit": then.get("limit"),
+        "has_boost": bool(then.get("boost")),
+        "meta": {
+            "rule": rule.get("id"),
+            "source_pack": rule.get("meta", {}).get("source_pack"),
+            "hits": match.get("hits", []),
+            "context": context,
+        },
+    }
+    candidate["conflict_key"] = _build_conflict_key(match, rule, scope)
+    candidate["pair_key"] = _pair_key(match)
+    return candidate
+
+
+def _resolve_conflicts(candidates: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    by_key: Dict[Tuple[Any, ...], Dict[str, Any]] = {}
+    for cand in candidates:
+        key = cand.get("conflict_key")
+        existing = by_key.get(key)
+        if existing is None:
+            by_key[key] = cand
+            continue
+        if cand.get("has_boost") and not existing.get("has_boost"):
+            by_key[key] = cand
+            continue
+        if cand["raw_score"] > existing["raw_score"]:
+            by_key[key] = cand
+    return list(by_key.values())
+
+
+def _apply_limits(candidates: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    counts: Dict[Tuple[str, str], int] = defaultdict(int)
+    results: List[Dict[str, Any]] = []
+    for cand in sorted(candidates, key=lambda item: (-item["score"], item["rule_id"])):
+        limit = cand.get("limit") or {}
+        pair_key = cand.get("pair_key")
+        if limit.get("per_pair") and pair_key:
+            max_allowed = int(limit.get("max", 1))
+            if counts[pair_key] >= max_allowed:
+                continue
+            counts[pair_key] += 1
+        results.append(cand)
+    results.sort(key=lambda item: (-item["score"], item["rule_id"]))
+    return results
+
+
 # --------------------------- Engine ----------------------------------------
-def interpret(request: Request, rules: Sequence[Rule]) -> List[Finding]:
-    """Evaluate the supplied rules against the request payload."""
+def interpret(request: Request, rules: Sequence[Rule] | Pack) -> List[Finding]:
+    """Evaluate the supplied rules or rulepack against the request payload."""
+
+    if isinstance(rules, Mapping) and "rules" in rules:
+        pack = rules  # type: ignore[assignment]
+    else:
+        pack = {
+            "rulepack": "inline",
+            "version": "1",
+            "rules": list(rules),
+            "profiles": {"default": {"tags": {}}},
+            "tag_map": {},
+            "meta": {},
+        }
 
     scope = request.get("scope")
-    findings: List[Finding] = []
+    profile = request.get("profile")
 
-    for rule in rules:
+    matches: List[Dict[str, Any]] = []
+    for raw_rule in pack.get("rules", []):
+        rule = _normalise_rule(raw_rule)
         if rule.get("scope") != scope:
             continue
 
-        base_score = float(rule.get("score", 1.0))
-        title = rule.get("title") or rule.get("id", "")
-        template = rule.get("text", "")
-        tags = list(rule.get("tags", []) or [])
-
         if scope == "synastry":
             hits = request.get("hits", []) or []
-            for hit, strength in _match_synastry_rule(rule, hits):
-                a = hit.get("a")
-                b = hit.get("b")
-                aspect = str(hit.get("aspect", "")).lower()
-                ctx = {
-                    "a": a,
-                    "b": b,
-                    "aspect": aspect,
-                    "aspect_symbol": ASPECT_SYMBOLS.get(aspect, aspect),
-                    "severity": float(hit.get("severity", 0.0)),
-                    "a_arch": ARCHETYPES.get(a, a),
-                    "b_arch": ARCHETYPES.get(b, b),
-                }
-                findings.append(
-                    Finding(
-                        id=rule.get("id", "rule"),
-                        scope=scope,
-                        title=title,
-                        text=_fmt(template, ctx),
-                        score=base_score * strength,
-                        tags=tags,
-                        meta={"hit": hit},
-                    )
-                )
+            for match in _match_synastry(rule, hits):
+                candidate = _prepare_candidate(rule, match, pack, scope, profile)
+                if candidate:
+                    matches.append(candidate)
         else:
-            positions = request.get("positions", {}) or {}
-            for body, longitude in _match_body_longitude(rule, positions):
-                ctx = {
-                    "body": body,
-                    "longitude": longitude,
-                    "arch": ARCHETYPES.get(body, body),
-                }
-                findings.append(
-                    Finding(
-                        id=rule.get("id", "rule"),
-                        scope=scope,
-                        title=title,
-                        text=_fmt(template, ctx),
-                        score=base_score,
-                        tags=tags,
-                        meta={"body": body, "longitude": longitude},
-                    )
-                )
+            for match in _match_chart(rule, request):
+                candidate = _prepare_candidate(rule, match, pack, scope, profile)
+                if candidate:
+                    matches.append(candidate)
+
+    resolved = _resolve_conflicts(matches)
+    limited = _apply_limits(resolved)
+
+    findings: List[Finding] = []
+    for cand in limited:
+        findings.append(
+            Finding(
+                id=str(cand.get("rule_id")),
+                scope=str(cand.get("scope")),
+                title=str(cand.get("title")),
+                text=str(cand.get("text")),
+                score=float(cand.get("score", 0.0)),
+                tags=list(cand.get("tags", [])),
+                meta=cand.get("meta", {}),
+            )
+        )
 
     findings.sort(key=lambda item: (-item.score, item.id))
     return findings

--- a/interpret-packs/README.md
+++ b/interpret-packs/README.md
@@ -1,0 +1,28 @@
+# Interpret Packs Catalogue
+
+This directory contains versioned interpretation rulepacks used by the
+interpretations API. Packs are authored in YAML and validated against
+`schema/dsl-extensions.schema.json`.
+
+## Contents
+
+- `packs/` — rulepacks for Saturn, outer-planet themes, luminary emphasis, and
+  house overlays.
+- `meta/` — higher level compositions that include multiple packs with weights.
+- `fixtures/` — canonical synastry hits and composite/davison charts along with
+  golden outputs that protect against score drift.
+- `tests/` — regression tests that validate pack behaviour using the engine.
+
+## Validation
+
+The packs extend the DSL with:
+- aspect family filters (`family`) and explicit `bodiesA`/`bodiesB` selectors.
+- `group` definitions for synergy and minimum hit counts.
+- `house` constraints for composite/davison overlays including angular checks.
+- post-match `boost` and `limit` controls.
+
+Run the pack regression suite with:
+
+```bash
+pytest interpret-packs/tests
+```

--- a/interpret-packs/fixtures/composite_positions.json
+++ b/interpret-packs/fixtures/composite_positions.json
@@ -1,0 +1,23 @@
+{
+  "positions": {
+    "Saturn": 210.0,
+    "Venus": 223.0,
+    "Mars": 15.0,
+    "Sun": 280.0,
+    "Moon": 45.0,
+    "North Node": 12.0,
+    "Pluto": 182.0,
+    "Jupiter": 195.0
+  },
+  "houses": {
+    "Saturn": {"house": "VII", "longitude": 210.0},
+    "Venus": "VII",
+    "Mars": {"house": "I", "longitude": 15.0},
+    "Sun": {"house": "X", "longitude": 280.0},
+    "Moon": {"house": "IV", "longitude": 45.0},
+    "North Node": {"house": "I", "longitude": 12.0},
+    "Pluto": "VII",
+    "Jupiter": "IX"
+  },
+  "angles": {"Asc": 10.0, "MC": 280.0}
+}

--- a/interpret-packs/fixtures/davison_positions.json
+++ b/interpret-packs/fixtures/davison_positions.json
@@ -1,0 +1,19 @@
+{
+  "positions": {
+    "Saturn": 198.0,
+    "Venus": 147.0,
+    "Mars": 5.0,
+    "Sun": 102.0,
+    "Moon": 12.0,
+    "North Node": 290.0
+  },
+  "houses": {
+    "Saturn": "X",
+    "Venus": "VII",
+    "Mars": {"house": "I", "longitude": 5.0},
+    "Sun": {"house": "X", "longitude": 102.0},
+    "Moon": {"house": "IV", "longitude": 12.0},
+    "North Node": {"house": "X", "longitude": 290.0}
+  },
+  "angles": {"Asc": 0.0, "MC": 100.0}
+}

--- a/interpret-packs/fixtures/golden_outputs.json
+++ b/interpret-packs/fixtures/golden_outputs.json
@@ -1,0 +1,233 @@
+{
+  "saturn": [
+    {
+      "id": "saturn_conj_moon_binding",
+      "score": 0.847,
+      "tags": [
+        "commitment",
+        "resilience",
+        "nurture"
+      ],
+      "source": "saturn-binding-growth"
+    },
+    {
+      "id": "saturn_two_contact_synergy",
+      "score": 0.7097,
+      "tags": [
+        "commitment",
+        "resilience"
+      ],
+      "source": "saturn-binding-growth"
+    },
+    {
+      "id": "saturn_trine_sun_growth",
+      "score": 0.7063,
+      "tags": [
+        "mastery",
+        "structure",
+        "growth"
+      ],
+      "source": "saturn-binding-growth"
+    },
+    {
+      "id": "saturn_three_contact_synergy",
+      "score": 0.7035,
+      "tags": [
+        "commitment",
+        "structure",
+        "discipline"
+      ],
+      "source": "saturn-binding-growth"
+    },
+    {
+      "id": "saturn_square_venus_binding",
+      "score": 0.5058,
+      "tags": [
+        "endurance",
+        "friction",
+        "sober_realism"
+      ],
+      "source": "saturn-binding-growth"
+    }
+  ],
+  "outer": [
+    {
+      "id": "uranus_conj_venus",
+      "score": 0.8495,
+      "tags": [
+        "freedom",
+        "spark",
+        "disruption"
+      ],
+      "source": "outer-planet-contacts"
+    },
+    {
+      "id": "pluto_conj_venus",
+      "score": 0.8006,
+      "tags": [
+        "transformation",
+        "intensity",
+        "devotion"
+      ],
+      "source": "outer-planet-contacts"
+    },
+    {
+      "id": "neptune_trine_moon",
+      "score": 0.7637,
+      "tags": [
+        "dreams",
+        "inspiration",
+        "empathy"
+      ],
+      "source": "outer-planet-contacts"
+    },
+    {
+      "id": "uranus_opposition_sun",
+      "score": 0.7171,
+      "tags": [
+        "freedom",
+        "disruption",
+        "awakening"
+      ],
+      "source": "outer-planet-contacts"
+    },
+    {
+      "id": "outer_uranus_node",
+      "score": 0.6442,
+      "tags": [
+        "liberation",
+        "disruption",
+        "destiny"
+      ],
+      "source": "outer-planet-contacts"
+    }
+  ],
+  "luminary": [
+    {
+      "id": "sun_moon_trine",
+      "score": 0.8223,
+      "tags": [
+        "nurture",
+        "harmony",
+        "warmth"
+      ],
+      "source": "luminary-emphasis"
+    },
+    {
+      "id": "moon_conj_moon",
+      "score": 0.7857,
+      "tags": [
+        "nurture",
+        "lunar_memory",
+        "empathy"
+      ],
+      "source": "luminary-emphasis"
+    },
+    {
+      "id": "moon_trine_moon",
+      "score": 0.7779,
+      "tags": [
+        "nurture",
+        "empathy",
+        "harmony"
+      ],
+      "source": "luminary-emphasis"
+    },
+    {
+      "id": "sun_moon_double_whammy",
+      "score": 0.716,
+      "tags": [
+        "heart_sync",
+        "nurture",
+        "resonance"
+      ],
+      "source": "luminary-emphasis"
+    },
+    {
+      "id": "sun_trine_sun",
+      "score": 0.6356,
+      "tags": [
+        "harmony",
+        "resonance",
+        "radiance"
+      ],
+      "source": "luminary-emphasis"
+    }
+  ],
+  "house_composite": [
+    {
+      "id": "composite_venus_mars_angular",
+      "score": 0.871,
+      "tags": [
+        "magnetism",
+        "libido",
+        "spark"
+      ]
+    },
+    {
+      "id": "composite_venus_mars_angular",
+      "score": 0.871,
+      "tags": [
+        "magnetism",
+        "libido",
+        "spark"
+      ]
+    },
+    {
+      "id": "composite_node_angle",
+      "score": 0.8233,
+      "tags": [
+        "destiny",
+        "alignment",
+        "growth"
+      ]
+    },
+    {
+      "id": "composite_pluto_house7",
+      "score": 0.8017,
+      "tags": [
+        "growth",
+        "magnetism",
+        "partnership"
+      ]
+    },
+    {
+      "id": "composite_moon_house4",
+      "score": 0.7967,
+      "tags": [
+        "hearth",
+        "grounding",
+        "nurture"
+      ]
+    }
+  ],
+  "house_davison": [
+    {
+      "id": "davison_sun_house10",
+      "score": 0.82,
+      "tags": [
+        "public_path",
+        "destiny",
+        "growth"
+      ]
+    },
+    {
+      "id": "davison_venus_house7",
+      "score": 0.8125,
+      "tags": [
+        "chemistry",
+        "partnership",
+        "devotion"
+      ]
+    },
+    {
+      "id": "davison_moon_house4",
+      "score": 0.786,
+      "tags": [
+        "hearth",
+        "grounding",
+        "ritual"
+      ]
+    }
+  ]
+}

--- a/interpret-packs/fixtures/hits_canonical.json
+++ b/interpret-packs/fixtures/hits_canonical.json
@@ -1,0 +1,15 @@
+[
+  {"a": "Sun", "b": "Moon", "aspect": "trine", "severity": 0.62},
+  {"a": "Moon", "b": "Sun", "aspect": "sextile", "severity": 0.58},
+  {"a": "Saturn", "b": "Venus", "aspect": "square", "severity": 0.6},
+  {"a": "Saturn", "b": "Sun", "aspect": "trine", "severity": 0.57},
+  {"a": "Saturn", "b": "Moon", "aspect": "conjunction", "severity": 0.59},
+  {"a": "Uranus", "b": "Venus", "aspect": "conjunction", "severity": 0.61},
+  {"a": "Uranus", "b": "Sun", "aspect": "opposition", "severity": 0.56},
+  {"a": "Neptune", "b": "Moon", "aspect": "trine", "severity": 0.6},
+  {"a": "Neptune", "b": "Sun", "aspect": "square", "severity": 0.57},
+  {"a": "Neptune", "b": "North Node", "aspect": "trine", "severity": 0.55},
+  {"a": "Pluto", "b": "Venus", "aspect": "conjunction", "severity": 0.63},
+  {"a": "Pluto", "b": "Mars", "aspect": "square", "severity": 0.58},
+  {"a": "Uranus", "b": "South Node", "aspect": "conjunction", "severity": 0.54}
+]

--- a/interpret-packs/meta/essentials.yaml
+++ b/interpret-packs/meta/essentials.yaml
@@ -1,0 +1,31 @@
+rulepack: relationship-essentials
+version: 1
+description: Core composite of Saturn, luminary, outer-planet, and overlay packs.
+includes:
+  - id: saturn-binding-growth
+    path: ../packs/saturn-binding-growth.yaml
+    weight: 1.0
+  - id: outer-planet-contacts
+    path: ../packs/outer-planet-contacts.yaml
+    weight: 0.95
+  - id: luminary-emphasis
+    path: ../packs/luminary-emphasis.yaml
+    weight: 1.05
+  - id: house-overlays
+    path: ../packs/house-overlays.yaml
+    weight: 1.0
+profiles:
+  default:
+    tags: {chemistry: 1.0, stability: 1.0, growth: 1.0, friction: 1.0}
+  chemistry_plus:
+    tags: {chemistry: 1.15, stability: 0.98, growth: 1.05, friction: 0.95}
+  stability_plus:
+    tags: {chemistry: 0.98, stability: 1.18, growth: 1.05, friction: 0.95}
+  growth_plus:
+    tags: {chemistry: 1.02, stability: 1.0, growth: 1.2, friction: 0.95}
+tag_map:
+  commitment: {bucket: stability, weight: 1.2}
+  spark: {bucket: chemistry, weight: 1.1}
+  destiny: {bucket: growth, weight: 1.1}
+  transformation: {bucket: growth, weight: 1.1}
+  nurture: {bucket: chemistry, weight: 1.05}

--- a/interpret-packs/packs/house-overlays.md
+++ b/interpret-packs/packs/house-overlays.md
@@ -1,0 +1,41 @@
+# House Overlays Pack
+
+## Overview
+
+`house-overlays` highlights composite and Davison placements in angular and
+relationship houses. Rules emphasise Venus, Mars, luminaries, and nodal hits on
+Asc/MC.
+
+## Tags
+
+| Sub-tag | Bucket |
+| --- | --- |
+| libido | chemistry |
+| partnership | stability |
+| destiny | growth |
+| public_path | growth |
+| hearth | stability |
+| magnetism | chemistry |
+| momentum | growth |
+| nurture | chemistry |
+
+## Profiles
+
+| Profile | Notes |
+| --- | --- |
+| `default` | Balanced overlay scoring. |
+| `chemistry_plus` | Elevates Venus/Mars overlays. |
+| `stability_plus` | Rewards home-building and devotion placements. |
+
+## Quick Start
+
+```python
+pack = load_rules("interpret-packs/packs/house-overlays.yaml")
+req = {
+    "scope": "composite",
+    "positions": {"Venus": 223.0},
+    "houses": {"Venus": "VII", "Mars": {"house": "I", "longitude": 15.0}},
+    "angles": {"Asc": 12.0, "MC": 280.0},
+}
+findings = interpret(req, pack)
+```

--- a/interpret-packs/packs/house-overlays.yaml
+++ b/interpret-packs/packs/house-overlays.yaml
@@ -1,0 +1,328 @@
+rulepack: house-overlays
+version: 1
+description: >-
+  Composite and Davison overlays emphasising angular house placements and nodal
+  alignments for relationship charts.
+tag_map:
+  chemistry: {bucket: chemistry, weight: 1.05}
+  stability: {bucket: stability, weight: 1.1}
+  growth: {bucket: growth, weight: 1.05}
+  friction: {bucket: friction, weight: 1.0}
+  libido: {bucket: chemistry, weight: 1.15}
+  spark: {bucket: chemistry, weight: 1.1}
+  devotion: {bucket: stability, weight: 1.1}
+  partnership: {bucket: stability, weight: 1.1}
+  destiny: {bucket: growth, weight: 1.15}
+  alignment: {bucket: growth, weight: 1.05}
+  hearth: {bucket: stability, weight: 1.1}
+  public_path: {bucket: growth, weight: 1.08}
+  vitality: {bucket: chemistry, weight: 1.05}
+  initiative: {bucket: growth, weight: 1.05}
+  grounding: {bucket: stability, weight: 1.08}
+  momentum: {bucket: growth, weight: 1.07}
+  magnetism: {bucket: chemistry, weight: 1.1}
+  ritual: {bucket: stability, weight: 1.05}
+  nurture: {bucket: chemistry, weight: 1.05}
+profiles:
+  default:
+    tags: {chemistry: 1.0, stability: 1.0, growth: 1.0, friction: 1.0}
+  chemistry_plus:
+    tags: {chemistry: 1.2, stability: 1.0, growth: 1.05, friction: 0.95}
+  stability_plus:
+    tags: {chemistry: 0.95, stability: 1.2, growth: 1.0, friction: 0.95}
+meta:
+  domain: overlays
+rules:
+  - id: composite_venus_house7
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Venus]
+        in: ["VII"]
+    then:
+      title: Composite Venus in 7th — Partnership Magnet
+      tags: [chemistry, partnership, devotion]
+      base_score: 0.76
+      score_fn: "linear"
+      text: "Composite Venus in the 7th keeps the relationship oriented toward loyalty."
+  - id: composite_venus_house5
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Venus]
+        in: ["V"]
+    then:
+      title: Composite Venus in 5th — Playful Romance
+      tags: [spark, chemistry, ritual]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "5th-house Venus encourages creative dates and joyful courtship."
+  - id: composite_venus_house8
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Venus]
+        in: ["VIII"]
+    then:
+      title: Composite Venus in 8th — Depth Bonding
+      tags: [chemistry, devotion, grounding]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "8th-house Venus leans into resource sharing and intimate trust."
+  - id: composite_mars_house1
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Mars]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Composite Mars Rising — Active Pair
+      tags: [libido, initiative, momentum]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Composite Mars on the Ascendant keeps momentum front and centre."
+  - id: composite_mars_house5
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Mars]
+        in: ["V"]
+    then:
+      title: Composite Mars in 5th — Creative Drive
+      tags: [spark, libido, vitality]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "5th-house Mars favours playful competition and passionate expression."
+  - id: composite_mars_house7
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Mars]
+        in: ["VII"]
+    then:
+      title: Composite Mars in 7th — Dynamic Duo
+      tags: [libido, momentum, partnership]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "7th-house Mars keeps the relationship active through shared missions."
+  - id: composite_sun_house10
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Sun]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Composite Sun on MC — Shared Spotlight
+      tags: [public_path, growth, alignment]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Sun near the composite MC draws the partnership into visible roles."
+  - id: composite_sun_house4
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Sun]
+        in: ["IV"]
+    then:
+      title: Composite Sun in 4th — Hearth Focus
+      tags: [hearth, stability, devotion]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "4th-house Sun brightens home projects and family integration."
+  - id: composite_moon_house4
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Moon]
+        in: ["IV"]
+    then:
+      title: Composite Moon in 4th — Emotional Base
+      tags: [hearth, grounding, nurture]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Moon in the 4th creates a safe space for vulnerability."
+  - id: composite_moon_house11
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Moon]
+        in: ["XI"]
+    then:
+      title: Composite Moon in 11th — Community Bond
+      tags: [growth, ritual, alignment]
+      base_score: 0.71
+      score_fn: "linear"
+      text: "11th-house Moon builds friendships and shared vision boards."
+  - id: composite_node_angle
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [North Node]
+        angles_any: [Asc, MC]
+        in: ["I", "X"]
+    then:
+      title: Composite Node on Angles — Destiny Pulse
+      tags: [destiny, alignment, growth]
+      base_score: 0.76
+      score_fn: "linear"
+      text: "Nodal contact with Asc/MC fast-tracks the purpose of the union."
+  - id: composite_pluto_house7
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Pluto]
+        in: ["VII"]
+    then:
+      title: Composite Pluto in 7th — Transformational Partnership
+      tags: [growth, magnetism, partnership]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Pluto in the 7th keeps the bond evolving through shared intensity."
+  - id: composite_jupiter_house9
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Jupiter]
+        in: ["IX"]
+    then:
+      title: Composite Jupiter in 9th — Shared Horizons
+      tags: [growth, alignment, momentum]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "9th-house Jupiter supports travel, study, and mutual expansion."
+  - id: davison_venus_house7
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Venus]
+        in: ["VII"]
+    then:
+      title: Davison Venus in 7th — Relationship Timeline of Love
+      tags: [chemistry, partnership, devotion]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Davison Venus in the 7th marks recurring phases of recommitment."
+  - id: davison_venus_house5
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Venus]
+        in: ["V"]
+    then:
+      title: Davison Venus in 5th — Date Night Milestones
+      tags: [spark, ritual, chemistry]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "5th-house Venus refreshes romance cycles along the timeline."
+  - id: davison_mars_house1
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Mars]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Davison Mars on Ascendant — Timed Action
+      tags: [libido, momentum, initiative]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Mars near the Davison Ascendant marks energetic turning points."
+  - id: davison_mars_house7
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Mars]
+        in: ["VII"]
+    then:
+      title: Davison Mars in 7th — Cooperative Drive
+      tags: [libido, partnership, alignment]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "7th-house Mars frames shared challenges that sharpen teamwork."
+  - id: davison_sun_house10
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Sun]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Davison Sun on MC — Purpose Markers
+      tags: [public_path, destiny, growth]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Sun at the Davison MC highlights pivotal achievements together."
+  - id: davison_moon_house4
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Moon]
+        in: ["IV"]
+    then:
+      title: Davison Moon in 4th — Emotional Timeline
+      tags: [hearth, grounding, ritual]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Davison Moon in the 4th tracks cycles of nesting and emotional repair."
+  - id: davison_node_mc
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [North Node]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Davison Node on MC — Destiny Appointments
+      tags: [destiny, alignment, public_path]
+      base_score: 0.76
+      score_fn: "linear"
+      text: "Node near the Davison MC emphasises timed opportunities for visibility."
+  - id: composite_venus_mars_angular
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Venus, Mars]
+        in: ["I", "VII", "X"]
+    then:
+      title: Composite Venus & Mars Angular
+      tags: [magnetism, libido, spark]
+      base_score: 0.78
+      score_fn: "linear"
+      text: "Angular Venus/Mars combinations intensify attraction and shared drive."
+  - id: composite_moon_node_alignment
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Moon]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Composite Moon Rising with Node Support
+      tags: [destiny, nurture, stability]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Moon rising with nodal emphasis sets emotional tone as a guiding star."

--- a/interpret-packs/packs/luminary-emphasis.md
+++ b/interpret-packs/packs/luminary-emphasis.md
@@ -1,0 +1,42 @@
+# Luminary Emphasis Pack
+
+## Overview
+
+`luminary-emphasis` packages Sun/Moon resonance, double whammy detections, and
+nodal overlays for composite and Davison charts.
+
+## Tags
+
+| Sub-tag | Bucket |
+| --- | --- |
+| nurture | chemistry |
+| heart_sync | chemistry |
+| resonance | stability |
+| radiance | growth |
+| cadence | stability |
+| destiny | growth |
+| roots | stability |
+| harmony | stability |
+
+## Profiles
+
+| Profile | Notes |
+| --- | --- |
+| `default` | Baseline weighting. |
+| `chemistry_plus` | Accentuates heart-spark signatures. |
+| `stability_plus` | Favors long-term lunar cadence cues. |
+
+## Quick Start
+
+```python
+pack = load_rules("interpret-packs/packs/luminary-emphasis.yaml")
+req = {
+    "scope": "synastry",
+    "profile": "chemistry_plus",
+    "hits": [
+        {"a": "Sun", "b": "Moon", "aspect": "trine", "severity": 0.6},
+        {"a": "Moon", "b": "Sun", "aspect": "sextile", "severity": 0.52},
+    ],
+}
+findings = interpret(req, pack)
+```

--- a/interpret-packs/packs/luminary-emphasis.yaml
+++ b/interpret-packs/packs/luminary-emphasis.yaml
@@ -1,0 +1,313 @@
+rulepack: luminary-emphasis
+version: 1
+description: >-
+  Luminary-driven relationship cues prioritising Sun, Moon, and nodal emphasis
+  across synastry and composite overlays.
+tag_map:
+  chemistry: {bucket: chemistry, weight: 1.0}
+  nurture: {bucket: chemistry, weight: 1.1}
+  vitality: {bucket: chemistry, weight: 1.05}
+  resonance: {bucket: stability, weight: 1.05}
+  illumination: {bucket: growth, weight: 1.05}
+  cadence: {bucket: stability, weight: 1.05}
+  empathy: {bucket: chemistry, weight: 1.05}
+  lunar_memory: {bucket: stability, weight: 1.08}
+  heart_sync: {bucket: chemistry, weight: 1.12}
+  lunar_security: {bucket: stability, weight: 1.1}
+  warmth: {bucket: chemistry, weight: 1.1}
+  harmony: {bucket: stability, weight: 1.05}
+  radiance: {bucket: growth, weight: 1.1}
+  destiny: {bucket: growth, weight: 1.1}
+  pathfinding: {bucket: growth, weight: 1.08}
+  steady_glow: {bucket: stability, weight: 1.05}
+  dreamscape: {bucket: chemistry, weight: 1.05}
+  reflection: {bucket: stability, weight: 1.05}
+  roots: {bucket: stability, weight: 1.08}
+profiles:
+  default:
+    tags: {chemistry: 1.0, stability: 1.0, growth: 1.0, friction: 1.0}
+  chemistry_plus:
+    tags: {chemistry: 1.25, stability: 1.0, growth: 1.05, friction: 0.95}
+  stability_plus:
+    tags: {chemistry: 1.05, stability: 1.2, growth: 1.0, friction: 0.95}
+meta:
+  domain: synastry
+rules:
+  - id: sun_conj_sun
+    scope: synastry
+    when:
+      bodies: [Sun]
+      aspects: [0]
+      min_severity: 0.4
+    then:
+      title: Sun conjunct Sun — Shared Radiance
+      tags: [vitality, radiance, harmony]
+      base_score: 0.78
+      score_fn: "cosine^1.05"
+      text: "Sun {aspect_symbol} Sun aligns life purpose and outward style."
+  - id: sun_trine_sun
+    scope: synastry
+    when:
+      bodies: [Sun]
+      aspects: [120]
+      min_severity: 0.4
+    then:
+      title: Sun trine Sun — Easy Alignment
+      tags: [harmony, resonance, radiance]
+      base_score: 0.76
+      score_fn: "cosine^1.05"
+      text: "Trine fosters mutual encouragement and effortless scheduling."
+  - id: sun_opposition_sun
+    scope: synastry
+    when:
+      bodies: [Sun]
+      aspects: [180]
+      min_severity: 0.4
+    then:
+      title: Sun opposition Sun — Complementary Spotlight
+      tags: [resonance, illumination, harmony]
+      base_score: 0.74
+      score_fn: "cosine^1.05"
+      text: "Opposition balances focus through alternating leadership."
+  - id: moon_conj_moon
+    scope: synastry
+    when:
+      bodies: [Moon]
+      aspects: [0]
+      min_severity: 0.45
+    then:
+      title: Moon conjunct Moon — Shared Lunar Memory
+      tags: [nurture, lunar_memory, empathy]
+      base_score: 0.8
+      score_fn: "cosine^1.1"
+      text: "Moon {aspect_symbol} Moon syncs emotional rhythms and rituals."
+  - id: moon_trine_moon
+    scope: synastry
+    when:
+      bodies: [Moon]
+      aspects: [120]
+      min_severity: 0.45
+    then:
+      title: Moon trine Moon — Emotional Flow
+      tags: [nurture, empathy, harmony]
+      base_score: 0.78
+      score_fn: "cosine^1.05"
+      text: "Trine offers intuitive understanding without many words."
+  - id: moon_square_moon
+    scope: synastry
+    when:
+      bodies: [Moon]
+      aspects: [90]
+      min_severity: 0.45
+    then:
+      title: Moon square Moon — Habit Adjustments
+      tags: [nurture, cadence, reflection]
+      base_score: 0.7
+      score_fn: "power^1.05"
+      text: "Square invites conscious co-creation of supportive routines."
+  - id: sun_moon_conjunction
+    scope: synastry
+    when:
+      bodiesA: [Sun]
+      bodiesB: [Moon]
+      aspects: [0]
+      min_severity: 0.45
+    then:
+      title: Sun conjunct Moon — Heartbeat Sync
+      tags: [heart_sync, nurture, warmth]
+      base_score: 0.83
+      score_fn: "cosine^1.15"
+      text: "{a_arch} {aspect_symbol} {b_arch} marries will and feeling."
+      limit: {per_pair: true, max: 1}
+  - id: sun_moon_trine
+    scope: synastry
+    when:
+      bodiesA: [Sun]
+      bodiesB: [Moon]
+      aspects: [120]
+      min_severity: 0.45
+    then:
+      title: Sun trine Moon — Daily Harmony
+      tags: [nurture, harmony, warmth]
+      base_score: 0.8
+      score_fn: "cosine^1.1"
+      text: "Trine between {a} and {b} brings easy emotional attunement."
+  - id: sun_moon_square
+    scope: synastry
+    when:
+      bodiesA: [Sun]
+      bodiesB: [Moon]
+      aspects: [90]
+      min_severity: 0.45
+    then:
+      title: Sun square Moon — Growth Tension
+      tags: [cadence, illumination, nurture]
+      base_score: 0.72
+      score_fn: "power^1.05"
+      text: "Square requires transparent feedback about needs vs. goals."
+  - id: sun_moon_double_whammy
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Sun], bodiesB: [Moon], aspects: [0, 60, 90, 120, 180], min_severity: 0.4}
+          - {bodiesA: [Moon], bodiesB: [Sun], aspects: [0, 60, 90, 120, 180], min_severity: 0.4}
+        count_at_least: 2
+    then:
+      title: Sun–Moon Double Emphasis
+      tags: [heart_sync, nurture, resonance]
+      base_score: 0.78
+      score_fn: "linear"
+      boost: {by: 1.2, cap: 0.99}
+      text: "{count} Sun↔Moon links magnify mutual care."
+  - id: moon_node_conj
+    scope: synastry
+    when:
+      bodiesA: [Moon]
+      bodiesB: [North Node]
+      aspects: [0]
+      min_severity: 0.45
+    then:
+      title: Moon conjunct North Node — Destined Comfort
+      tags: [destiny, nurture, roots]
+      base_score: 0.77
+      score_fn: "cosine^1.1"
+      text: "{a_arch} embracing the Node nurtures a future-building path."
+  - id: sun_node_conj
+    scope: synastry
+    when:
+      bodiesA: [Sun]
+      bodiesB: [North Node]
+      aspects: [0]
+      min_severity: 0.45
+    then:
+      title: Sun conjunct North Node — Spotlighted Path
+      tags: [destiny, radiance, pathfinding]
+      base_score: 0.76
+      score_fn: "cosine^1.05"
+      text: "{a_arch} {aspect_symbol} Node lights up shared direction."
+  - id: luminary_node_opposition
+    scope: synastry
+    when:
+      bodiesA: [Sun, Moon]
+      bodiesB: [North Node, South Node]
+      aspects: [180]
+      min_severity: 0.4
+    then:
+      title: Luminary-Node Opposition — Axis Activation
+      tags: [destiny, illumination, resonance]
+      base_score: 0.72
+      score_fn: "cosine^1.05"
+      text: "Opposition across the nodal axis binds purpose and karmic memory."
+  - id: sun_moon_progression_count
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Sun], bodiesB: [Moon], aspects: [0, 60, 90, 120, 180], min_severity: 0.4}
+          - {bodiesA: [Moon], bodiesB: [Sun], aspects: [0, 60, 90, 120, 180], min_severity: 0.4}
+        count_at_least: 3
+    then:
+      title: Sun–Moon Story Arc
+      tags: [cadence, nurture, reflection]
+      base_score: 0.74
+      score_fn: "linear"
+      boost: {by: 1.15, cap: 0.98}
+      text: "{count} luminary exchanges weave a life rhythm narrative."
+  - id: composite_sun_moon_midpoint
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Sun, Moon]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Composite Luminary Midpoint Rising
+      tags: [chemistry, heart_sync, radiance]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Composite luminary midpoint rising spotlights mutual magnetism."
+  - id: composite_sun_moon_house7
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Sun, Moon]
+        in: ["VII"]
+    then:
+      title: Composite Luminaries in 7th
+      tags: [nurture, resonance, steady_glow]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Luminaries seated in the 7th anchor partnership priorities."
+  - id: composite_sun_moon_house10
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Sun, Moon]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Composite Luminaries on MC
+      tags: [illumination, radiance, destiny]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Midheaven emphasis invites shared visibility."
+  - id: davison_sun_moon_house4
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Sun, Moon]
+        in: ["IV"]
+    then:
+      title: Davison Luminaries in 4th — Rooted Timeline
+      tags: [roots, nurture, cadence]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Davison luminaries in the 4th prioritise home creation and shared ancestry."
+  - id: davison_sun_moon_midpoint_angle
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Sun, Moon]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Davison Luminary Midpoint on Ascendant
+      tags: [chemistry, radiance, harmony]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Ascendant contact keeps the timeline aligned with heartfelt purpose."
+  - id: moon_moon_double_whammy
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Moon], bodiesB: [Moon], aspects: [0, 60, 90, 120, 180], min_severity: 0.45}
+        count_at_least: 2
+    then:
+      title: Moon–Moon Double Pulse
+      tags: [nurture, lunar_security, empathy]
+      base_score: 0.76
+      score_fn: "linear"
+      boost: {by: 1.12, cap: 0.96}
+      text: "Multiple Moon links intensify emotional attunement."
+  - id: sun_progression_cluster
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Sun], bodiesB: ['*'], aspects: [0, 60, 120], min_severity: 0.4}
+          - {bodiesA: ['*'], bodiesB: [Sun], aspects: [0, 60, 120], min_severity: 0.4}
+        count_at_least: 3
+    then:
+      title: Solar Emphasis Theme
+      tags: [illumination, radiance, vitality]
+      base_score: 0.7
+      score_fn: "linear"
+      boost: {by: 1.1, cap: 0.95}
+      text: "{count} solar contacts uplift the relationship's visibility and purpose."

--- a/interpret-packs/packs/outer-planet-contacts.md
+++ b/interpret-packs/packs/outer-planet-contacts.md
@@ -1,0 +1,43 @@
+# Outer-Planet Contacts Pack
+
+## Overview
+
+`outer-planet-contacts` captures Uranus freedom jolts, Neptune idealism, and
+Pluto transformation. Rules include compound triggers when multiple outers touch
+Venus plus saturation checks for Neptune-heavy charts.
+
+## Tags
+
+| Sub-tag | Bucket |
+| --- | --- |
+| freedom | chemistry |
+| disruption | friction |
+| dreams | chemistry |
+| ideals | growth |
+| transformation | growth |
+| intensity | chemistry |
+| liberation | chemistry |
+| destiny | growth |
+
+## Profiles
+
+| Profile | Notes |
+| --- | --- |
+| `default` | Even weighting of all buckets. |
+| `chemistry_plus` | Highlights electric/romantic signatures. |
+| `growth_plus` | Emphasises visionary and evolutionary storylines. |
+
+## Quick Start
+
+```python
+pack = load_rules("interpret-packs/packs/outer-planet-contacts.yaml")
+req = {
+    "scope": "synastry",
+    "hits": [
+        {"a": "Uranus", "b": "Venus", "aspect": "square", "severity": 0.6},
+        {"a": "Neptune", "b": "Moon", "aspect": "trine", "severity": 0.58},
+        {"a": "Pluto", "b": "Mars", "aspect": "conjunction", "severity": 0.62},
+    ],
+}
+findings = interpret(req, pack)
+```

--- a/interpret-packs/packs/outer-planet-contacts.yaml
+++ b/interpret-packs/packs/outer-planet-contacts.yaml
@@ -1,0 +1,345 @@
+rulepack: outer-planet-contacts
+version: 1
+description: >-
+  Outer-planet synastry signatures that amplify freedom quests, dreamwork, and
+  transformational pressure.
+tag_map:
+  freedom: {bucket: chemistry, weight: 1.15}
+  disruption: {bucket: friction, weight: 1.2}
+  spark: {bucket: chemistry, weight: 1.1}
+  innovation: {bucket: growth, weight: 1.1}
+  awakening: {bucket: growth, weight: 1.08}
+  turbulence: {bucket: friction, weight: 1.15}
+  ideals: {bucket: growth, weight: 1.15}
+  dreams: {bucket: chemistry, weight: 1.12}
+  empathy: {bucket: chemistry, weight: 1.05}
+  fog: {bucket: friction, weight: 1.05}
+  devotion: {bucket: stability, weight: 1.05}
+  inspiration: {bucket: growth, weight: 1.1}
+  transcendence: {bucket: growth, weight: 1.12}
+  transformation: {bucket: growth, weight: 1.2}
+  intensity: {bucket: chemistry, weight: 1.1}
+  catharsis: {bucket: growth, weight: 1.12}
+  power: {bucket: stability, weight: 1.05}
+  obsession: {bucket: friction, weight: 1.1}
+  liberation: {bucket: chemistry, weight: 1.12}
+  destiny: {bucket: growth, weight: 1.08}
+profiles:
+  default:
+    tags: {chemistry: 1.0, stability: 1.0, growth: 1.0, friction: 1.0}
+  chemistry_plus:
+    tags: {chemistry: 1.25, stability: 0.95, growth: 1.05, friction: 1.0}
+  growth_plus:
+    tags: {chemistry: 1.05, stability: 0.95, growth: 1.25, friction: 0.95}
+meta:
+  domain: synastry
+rules:
+  - id: uranus_conj_venus
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Venus]
+      aspects: [0]
+      min_severity: 0.5
+    then:
+      title: Uranus conjunct Venus — Electric Spark
+      tags: [freedom, spark, disruption]
+      base_score: 0.8
+      score_fn: "cosine^1.15"
+      text: "{a} {aspect_symbol} {b} keeps the connection unpredictable and bright."
+      limit: {per_pair: true, max: 1}
+  - id: uranus_trine_venus
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Venus]
+      aspects: [120]
+      min_severity: 0.5
+    then:
+      title: Uranus trine Venus — Creative Liberation
+      tags: [freedom, innovation, spark]
+      base_score: 0.76
+      score_fn: "cosine^1.05"
+      text: "{a_arch} harmonising {b_arch} encourages experimentation and mutual space."
+  - id: uranus_square_venus
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Venus]
+      aspects: [90]
+      min_severity: 0.5
+    then:
+      title: Uranus square Venus — Disruptive Attraction
+      tags: [disruption, turbulence, spark]
+      base_score: 0.74
+      score_fn: "power^1.1"
+      text: "Square aspect jolts affection patterns and requires flexible boundaries."
+  - id: uranus_opposition_sun
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Sun]
+      aspects: [180]
+      min_severity: 0.5
+    then:
+      title: Uranus opposing Sun — Freedom Axis
+      tags: [freedom, disruption, awakening]
+      base_score: 0.75
+      score_fn: "cosine^1.05"
+      text: "{a_arch} opposing {b_arch} insists on autonomy and evolving identity."
+  - id: uranus_trine_sun
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Sun]
+      aspects: [120]
+      min_severity: 0.5
+    then:
+      title: Uranus trine Sun — Inventive Confidence
+      tags: [innovation, freedom, growth]
+      base_score: 0.72
+      score_fn: "cosine^1.05"
+      text: "Trine uplifts the couple with inventive goals and fresh rhythm."
+  - id: uranus_conj_mars
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Mars]
+      aspects: [0]
+      min_severity: 0.5
+    then:
+      title: Uranus conjunct Mars — Adrenaline Bond
+      tags: [spark, disruption, freedom]
+      base_score: 0.79
+      score_fn: "cosine^1.1"
+      text: "{a} fused with {b} drives spontaneous adventures and hot pursuits."
+  - id: uranus_square_mars
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [Mars]
+      aspects: [90]
+      min_severity: 0.5
+    then:
+      title: Uranus square Mars — Volatile Impulse
+      tags: [disruption, turbulence, freedom]
+      base_score: 0.73
+      score_fn: "power^1.1"
+      text: "Square accentuates erratic action; channel energy into novelty instead of fights."
+  - id: neptune_conj_moon
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [Moon]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Neptune conjunct Moon — Dream Weaving
+      tags: [dreams, ideals, empathy]
+      base_score: 0.78
+      score_fn: "cosine^1.1"
+      text: "{a_arch} merging {b_arch} floods the bond with imagination and empathy."
+      limit: {per_pair: true, max: 1}
+  - id: neptune_trine_moon
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [Moon]
+      aspects: [120]
+      min_severity: 0.55
+    then:
+      title: Neptune trine Moon — Mystic Flow
+      tags: [dreams, inspiration, empathy]
+      base_score: 0.74
+      score_fn: "cosine^1.05"
+      text: "Trine softens moods and attunes partners to poetic cues."
+  - id: neptune_square_moon
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [Moon]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Neptune square Moon — Emotional Mirage
+      tags: [dreams, fog, disruption]
+      base_score: 0.7
+      score_fn: "power^1.15"
+      text: "Square can blur boundaries; align on rituals that keep both grounded."
+  - id: neptune_conj_sun
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [Sun]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Neptune conjunct Sun — Idealised Vision
+      tags: [ideals, dreams, transcendence]
+      base_score: 0.77
+      score_fn: "cosine^1.1"
+      text: "{a} {aspect_symbol} {b} infuses purpose with compassionate artistry."
+      limit: {per_pair: true, max: 1}
+  - id: neptune_square_sun
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [Sun]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Neptune square Sun — Vision vs Reality
+      tags: [fog, dreams, disruption]
+      base_score: 0.69
+      score_fn: "power^1.1"
+      text: "Square challenges clarity; schedule regular check-ins on plans."
+  - id: neptune_node_alignment
+    scope: synastry
+    when:
+      bodiesA: [Neptune]
+      bodiesB: [North Node]
+      aspects: [0, 120, 60]
+      min_severity: 0.5
+    then:
+      title: Neptune with North Node — Shared Dream Path
+      tags: [destiny, ideals, inspiration]
+      base_score: 0.72
+      score_fn: "cosine^1.05"
+      text: "{a_arch} touching the Node invites joint spiritual missions."
+  - id: pluto_conj_venus
+    scope: synastry
+    when:
+      bodiesA: [Pluto]
+      bodiesB: [Venus]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Pluto conjunct Venus — Magnetism of Depth
+      tags: [transformation, intensity, devotion]
+      base_score: 0.82
+      score_fn: "cosine^1.2"
+      text: "{a_arch} fused with {b_arch} seeks soul-level merging and shadow work."
+      limit: {per_pair: true, max: 1}
+  - id: pluto_square_venus
+    scope: synastry
+    when:
+      bodiesA: [Pluto]
+      bodiesB: [Venus]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Pluto square Venus — Intense Reform
+      tags: [transformation, obsession, disruption]
+      base_score: 0.77
+      score_fn: "power^1.15"
+      text: "Square compels honesty about attachments and power exchange."
+  - id: pluto_conj_mars
+    scope: synastry
+    when:
+      bodiesA: [Pluto]
+      bodiesB: [Mars]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Pluto conjunct Mars — Combustive Drive
+      tags: [intensity, transformation, spark]
+      base_score: 0.81
+      score_fn: "cosine^1.15"
+      text: "{a} {aspect_symbol} {b} unleashes powerful initiatives and raw desire."
+      limit: {per_pair: true, max: 1}
+  - id: pluto_square_mars
+    scope: synastry
+    when:
+      bodiesA: [Pluto]
+      bodiesB: [Mars]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Pluto square Mars — Power Calibration
+      tags: [intensity, disruption, catharsis]
+      base_score: 0.76
+      score_fn: "power^1.1"
+      text: "Square demands conscious handling of competitive urges."
+  - id: pluto_trine_sun
+    scope: synastry
+    when:
+      bodiesA: [Pluto]
+      bodiesB: [Sun]
+      aspects: [120]
+      min_severity: 0.55
+    then:
+      title: Pluto trine Sun — Regenerative Purpose
+      tags: [transformation, power, growth]
+      base_score: 0.78
+      score_fn: "cosine^1.05"
+      text: "Trine empowers shared reinvention and mutual courage."
+  - id: outer_venus_synergy
+    scope: synastry
+    when:
+      group:
+        all:
+          - {bodiesA: [Uranus], bodiesB: [Venus], aspects: [0, 120, 60, 90], min_severity: 0.5}
+          - {bodiesA: [Neptune], bodiesB: [Venus], aspects: [0, 120, 60, 90], min_severity: 0.5}
+        count_at_least: 2
+    then:
+      title: Uranus & Neptune Venus Chorus
+      tags: [inspiration, freedom, dreams]
+      base_score: 0.7
+      score_fn: "linear"
+      boost: {by: 1.18, cap: 0.97}
+      text: "Venus touched by Uranus and Neptune opens magical, free-form affection."
+  - id: outer_multiple_neptune_hits
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Neptune], bodiesB: ['*'], aspects: [0, 90, 120, 60], min_severity: 0.45}
+          - {bodiesA: ['*'], bodiesB: [Neptune], aspects: [0, 90, 120, 60], min_severity: 0.45}
+        count_at_least: 3
+    then:
+      title: Neptune Saturation — Check the Facts
+      tags: [dreams, fog, destiny]
+      base_score: 0.64
+      score_fn: "linear"
+      boost: {by: 1.1, cap: 0.92}
+      text: "{count} Neptune contacts soften reality; verify logistics to stay grounded."
+  - id: outer_uranus_node
+    scope: synastry
+    when:
+      bodiesA: [Uranus]
+      bodiesB: [South Node]
+      aspects: [0, 180]
+      min_severity: 0.5
+    then:
+      title: Uranus with South Node — Past-Life Wake-Up
+      tags: [liberation, disruption, destiny]
+      base_score: 0.7
+      score_fn: "cosine^1.05"
+      text: "Node contact shocks old patterns loose, urging growth beyond habit."
+  - id: outer_pluto_house_composite
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Pluto]
+        in: ["I", "VII"]
+    then:
+      title: Composite Pluto Angular — Transformational Axis
+      tags: [transformation, intensity, catharsis]
+      base_score: 0.75
+      score_fn: "linear"
+      text: "Angular Pluto keeps the relationship in continual rebirth."
+  - id: outer_neptune_house_davison
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Neptune]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Davison Neptune on MC — Shared Vision Quest
+      tags: [ideals, dreams, inspiration]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Neptune elevated in the Davison chart dedicates the timeline to a shared calling."

--- a/interpret-packs/packs/saturn-binding-growth.md
+++ b/interpret-packs/packs/saturn-binding-growth.md
@@ -1,0 +1,44 @@
+# Saturn Binding vs Growth Pack
+
+## Overview
+
+`saturn-binding-growth` differentiates hard aspect Saturn glue from smoother
+supportive contacts. The pack introduces synergy rules for multiple Saturn hits
+and overlays for composite/davison charts.
+
+## Tags
+
+| Sub-tag | Bucket |
+| --- | --- |
+| commitment | stability |
+| endurance | stability |
+| mastery | growth |
+| resilience | stability |
+| nurture | chemistry |
+| discipline | stability |
+| stewardship | growth |
+
+## Profiles
+
+| Profile | Notes |
+| --- | --- |
+| `default` | Balanced weighting across chemistry, stability, growth, friction. |
+| `stability_plus` | Prioritises long-term anchoring themes. |
+| `growth_plus` | Elevates Saturn-as-mentor dynamics. |
+
+## Quick Start
+
+```python
+from core.interpret_plus.engine import interpret, load_rules
+
+pack = load_rules("interpret-packs/packs/saturn-binding-growth.yaml")
+request = {
+    "scope": "synastry",
+    "profile": "stability_plus",
+    "hits": [
+        {"a": "Saturn", "b": "Venus", "aspect": "square", "severity": 0.6},
+        {"a": "Saturn", "b": "Sun", "aspect": "trine", "severity": 0.58},
+    ],
+}
+findings = interpret(request, pack)
+```

--- a/interpret-packs/packs/saturn-binding-growth.yaml
+++ b/interpret-packs/packs/saturn-binding-growth.yaml
@@ -1,0 +1,382 @@
+rulepack: saturn-binding-growth
+version: 1
+description: >-
+  Saturn contacts that distinguish binding chemistry from collaborative growth,
+  tuned for synastry and composite overlays.
+tag_map:
+  commitment: {bucket: stability, weight: 1.25}
+  endurance: {bucket: stability, weight: 1.15}
+  responsibility: {bucket: stability, weight: 1.1}
+  friction: {bucket: friction, weight: 1.05}
+  mastery: {bucket: growth, weight: 1.1}
+  structure: {bucket: stability, weight: 1.05}
+  resilience: {bucket: stability, weight: 1.1}
+  trust: {bucket: stability, weight: 1.1}
+  maturity: {bucket: growth, weight: 1.05}
+  discipline: {bucket: stability, weight: 1.05}
+  stewardship: {bucket: growth, weight: 1.05}
+  anchor: {bucket: stability, weight: 1.1}
+  mentorship: {bucket: growth, weight: 1.05}
+  milestone: {bucket: growth, weight: 1.05}
+  nurture: {bucket: chemistry, weight: 1.05}
+  caution: {bucket: friction, weight: 1.0}
+  sober_realism: {bucket: stability, weight: 1.0}
+  accountability: {bucket: stability, weight: 1.1}
+  boundaries: {bucket: stability, weight: 1.05}
+  growth: {bucket: growth, weight: 1.0}
+  stability: {bucket: stability, weight: 1.0}
+profiles:
+  default:
+    tags: {chemistry: 1.0, stability: 1.0, growth: 1.0, friction: 1.0}
+  stability_plus:
+    tags: {chemistry: 0.9, stability: 1.3, growth: 1.05, friction: 0.95}
+  growth_plus:
+    tags: {chemistry: 0.95, stability: 1.05, growth: 1.25, friction: 0.9}
+meta:
+  domain: synastry
+rules:
+  - id: saturn_conj_sun_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Sun]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Saturn conjunct Sun — Binding Focus
+      tags: [commitment, responsibility, friction]
+      base_score: 0.82
+      score_fn: "cosine^1.2"
+      text: "{a} {aspect_symbol} {b} sets shared ambitions and long-term vows."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_opposition_sun_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Sun]
+      aspects: [180]
+      min_severity: 0.55
+    then:
+      title: Saturn opposing Sun — Accountability Axis
+      tags: [commitment, accountability, friction]
+      base_score: 0.78
+      score_fn: "cosine^1.1"
+      text: "{a} opposing {b} insists on clarity of purpose and steady pacing."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_square_sun_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Sun]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Saturn square Sun — Trial by Structure
+      tags: [endurance, friction, discipline]
+      base_score: 0.76
+      score_fn: "power^1.1"
+      text: "Square between {a_arch} and {b_arch} sets pacing tests that require patience."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_conj_moon_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Moon]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Saturn conjunct Moon — Emotional Anchor
+      tags: [commitment, resilience, nurture]
+      base_score: 0.84
+      score_fn: "cosine^1.25"
+      text: "{a} {aspect_symbol} {b} steadies moods with patient reassurance."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_opposition_moon_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Moon]
+      aspects: [180]
+      min_severity: 0.55
+    then:
+      title: Saturn opposing Moon — Guarded Feelings
+      tags: [endurance, caution, friction]
+      base_score: 0.75
+      score_fn: "cosine^1.1"
+      text: "{a_arch} opposing {b_arch} heightens emotional prudence and pacing talks."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_square_moon_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Moon]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Saturn square Moon — Emotional Resilience Lesson
+      tags: [resilience, friction, boundaries]
+      base_score: 0.74
+      score_fn: "power^1.05"
+      text: "Tension between {a} and {b} requires rituals that build trust daily."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_conj_venus_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Venus]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Saturn conjunct Venus — Loyal Contract
+      tags: [commitment, trust, stability]
+      base_score: 0.83
+      score_fn: "cosine^1.2"
+      text: "{a} binding {b} formalises affection into reliable gestures."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_square_venus_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Venus]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Saturn square Venus — Slow-Build Affection
+      tags: [endurance, friction, sober_realism]
+      base_score: 0.72
+      score_fn: "power^1.15"
+      text: "Square aspect signals romance that matures through consistent effort."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_opposition_venus_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Venus]
+      aspects: [180]
+      min_severity: 0.55
+    then:
+      title: Saturn opposing Venus — Investment Dialogue
+      tags: [commitment, boundaries, friction]
+      base_score: 0.73
+      score_fn: "cosine^1.1"
+      text: "Opposition between {a_arch} and {b_arch} demands transparent agreements about desire and duty."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_conj_mars_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Mars]
+      aspects: [0]
+      min_severity: 0.55
+    then:
+      title: Saturn conjunct Mars — Purpose Alignment
+      tags: [discipline, commitment, friction]
+      base_score: 0.8
+      score_fn: "cosine^1.15"
+      text: "{a} {aspect_symbol} {b} channels drive into shared goals and patient momentum."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_square_mars_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Mars]
+      aspects: [90]
+      min_severity: 0.55
+    then:
+      title: Saturn square Mars — Heat with Tests
+      tags: [friction, endurance, discipline]
+      base_score: 0.71
+      score_fn: "power^1.1"
+      text: "Square between {a_arch} and {b_arch} channels passion through respect for timing."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_opposition_mars_binding
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Mars]
+      aspects: [180]
+      min_severity: 0.55
+    then:
+      title: Saturn opposing Mars — Productive Friction
+      tags: [discipline, friction, accountability]
+      base_score: 0.7
+      score_fn: "power^1.05"
+      text: "Opposition emphasises negotiated pace before launching initiatives."
+      limit: {per_pair: true, max: 1}
+  - id: saturn_trine_sun_growth
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Sun]
+      aspects: [120]
+      min_severity: 0.55
+    then:
+      title: Saturn trine Sun — Shared Mastery
+      tags: [mastery, structure, growth]
+      base_score: 0.77
+      score_fn: "cosine^1.05"
+      text: "{a_arch} supporting {b_arch} affirms confident stewardship of plans."
+  - id: saturn_sextile_sun_growth
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Sun]
+      aspects: [60]
+      min_severity: 0.55
+    then:
+      title: Saturn sextile Sun — Reliable Strategy
+      tags: [structure, mentorship, growth]
+      base_score: 0.74
+      score_fn: "cosine^1.05"
+      text: "Sextile fosters gentle accountability check-ins that keep the dream moving."
+  - id: saturn_trine_mercury_growth
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Mercury]
+      aspects: [120]
+      min_severity: 0.55
+    then:
+      title: Saturn trine Mercury — Thoughtful Planning
+      tags: [mastery, structure, growth]
+      base_score: 0.72
+      score_fn: "cosine^1.05"
+      text: "{a_arch} harmonising {b_arch} supports strategic conversations and careful documentation."
+  - id: saturn_trine_jupiter_growth
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Jupiter]
+      aspects: [120]
+      min_severity: 0.55
+    then:
+      title: Saturn trine Jupiter — Expansion with Backbone
+      tags: [stewardship, maturity, growth]
+      base_score: 0.79
+      score_fn: "cosine^1.05"
+      text: "{a} {aspect_symbol} {b} refines optimism with effective scaffolding."
+  - id: saturn_jupiter_synergy_two_hits
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Saturn], bodiesB: [Jupiter], aspects: [0, 120, 60], min_severity: 0.5}
+          - {bodiesA: [Jupiter], bodiesB: [Saturn], aspects: [0, 120, 60], min_severity: 0.5}
+        count_at_least: 2
+    then:
+      title: Saturn & Jupiter Resonance
+      tags: [growth, mastery, milestone]
+      base_score: 0.68
+      score_fn: "linear"
+      boost: {by: 1.15, cap: 0.96}
+      text: "{count} Saturn⇄Jupiter exchanges consolidate lessons into tangible expansion."
+  - id: saturn_two_contact_synergy
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Saturn], bodiesB: ['*'], aspects: [0, 60, 90, 120, 180], min_severity: 0.5}
+          - {bodiesA: ['*'], bodiesB: [Saturn], aspects: [0, 60, 90, 120, 180], min_severity: 0.5}
+        count_at_least: 2
+    then:
+      title: Saturn Theme Strong
+      tags: [commitment, resilience]
+      base_score: 0.66
+      score_fn: "linear"
+      boost: {by: 1.2, cap: 0.98}
+      text: "{count} significant Saturn links set an unmistakable tone of structure."
+  - id: saturn_three_contact_synergy
+    scope: synastry
+    when:
+      group:
+        any:
+          - {bodiesA: [Saturn], bodiesB: ['*'], aspects: [0, 60, 90, 120, 180], min_severity: 0.45}
+          - {bodiesA: ['*'], bodiesB: [Saturn], aspects: [0, 60, 90, 120, 180], min_severity: 0.45}
+        count_at_least: 3
+    then:
+      title: Saturn Overstory Activated
+      tags: [commitment, structure, discipline]
+      base_score: 0.7
+      score_fn: "linear"
+      boost: {by: 1.18, cap: 0.99}
+      text: "{count} Saturn exchanges produce a defining curriculum of patience."
+  - id: composite_saturn_house7
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Saturn]
+        in: ["VII"]
+    then:
+      title: Composite Saturn in the 7th — Partnership Contract
+      tags: [commitment, responsibility, stability]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Composite Saturn anchored in the 7th underscores vows and accountability."
+  - id: composite_saturn_house10
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Saturn]
+        in: ["X"]
+        angles_any: [MC]
+    then:
+      title: Composite Saturn on the Midheaven
+      tags: [structure, milestone, responsibility]
+      base_score: 0.74
+      score_fn: "linear"
+      text: "Saturn elevated toward the MC aligns the relationship around visible achievements."
+  - id: composite_saturn_house1
+    scope: composite
+    when:
+      house:
+        scope: composite
+        target: [Saturn]
+        in: ["I"]
+        angles_any: [Asc]
+    then:
+      title: Composite Saturn Rising
+      tags: [discipline, boundaries, stability]
+      base_score: 0.71
+      score_fn: "linear"
+      text: "Saturn near the composite Ascendant makes mutual structure immediately felt."
+  - id: davison_saturn_house7
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Saturn]
+        in: ["VII"]
+    then:
+      title: Davison Saturn in 7th — Timed Promises
+      tags: [commitment, maturity, responsibility]
+      base_score: 0.72
+      score_fn: "linear"
+      text: "Davison Saturn in the partnership sector defines milestones of shared duty."
+  - id: davison_saturn_house10
+    scope: davison
+    when:
+      house:
+        scope: davison
+        target: [Saturn]
+        in: ["X"]
+    then:
+      title: Davison Saturn in 10th — Legacy Work
+      tags: [stewardship, mastery, structure]
+      base_score: 0.73
+      score_fn: "linear"
+      text: "Davison Saturn in the 10th frames the timeline around public contribution."
+  - id: saturn_progress_checkpoint
+    scope: synastry
+    when:
+      bodiesA: [Saturn]
+      bodiesB: [Mercury]
+      aspects: [60]
+      min_severity: 0.55
+    then:
+      title: Saturn sextile Mercury — Planning Cadence
+      tags: [discipline, growth, structure]
+      base_score: 0.7
+      score_fn: "cosine^1.05"
+      text: "Sextile coordinates calendars and weekly accountability touch points."

--- a/interpret-packs/schema/dsl-extensions.schema.json
+++ b/interpret-packs/schema/dsl-extensions.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Interpretation DSL Extensions",
+  "type": "object",
+  "properties": {
+    "rulepack": {"type": "string"},
+    "version": {"type": ["string", "number"]},
+    "tag_map": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "bucket": {"type": "string"},
+          "weight": {"type": "number"}
+        },
+        "required": ["bucket"]
+      }
+    },
+    "profiles": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "object",
+            "additionalProperties": {"type": "number"}
+          }
+        }
+      }
+    },
+    "rules": {
+      "type": "array",
+      "items": {"$ref": "#/definitions/rule"}
+    }
+  },
+  "required": ["rulepack", "version", "rules"],
+  "definitions": {
+    "rule": {
+      "type": "object",
+      "properties": {
+        "id": {"type": "string"},
+        "scope": {"enum": ["synastry", "composite", "davison"]},
+        "when": {"$ref": "#/definitions/when"},
+        "then": {"$ref": "#/definitions/then"}
+      },
+      "required": ["id", "scope", "when"]
+    },
+    "when": {
+      "type": "object",
+      "properties": {
+        "bodies": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "bodiesA": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "bodiesB": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "aspects": {
+          "type": "array",
+          "items": {"type": ["string", "number"]}
+        },
+        "family": {
+          "type": "array",
+          "items": {"enum": ["harmonious", "challenging", "neutral"]}
+        },
+        "min_severity": {"type": "number"},
+        "group": {"$ref": "#/definitions/group"},
+        "house": {"$ref": "#/definitions/house"}
+      }
+    },
+    "group": {
+      "type": "object",
+      "properties": {
+        "any": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/when"}
+        },
+        "all": {
+          "type": "array",
+          "items": {"$ref": "#/definitions/when"}
+        },
+        "count": {"type": "integer", "minimum": 1},
+        "count_at_least": {"type": "integer", "minimum": 1}
+      }
+    },
+    "house": {
+      "type": "object",
+      "properties": {
+        "scope": {"enum": ["composite", "davison"]},
+        "target": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "in": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "angles_any": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "orb": {"type": "number", "minimum": 0}
+      },
+      "required": ["target"]
+    },
+    "then": {
+      "type": "object",
+      "properties": {
+        "title": {"type": "string"},
+        "text": {"type": "string"},
+        "tags": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "base_score": {"type": "number"},
+        "score_fn": {"type": "string"},
+        "boost": {
+          "type": "object",
+          "properties": {
+            "by": {"type": "number"},
+            "cap": {"type": "number"}
+          }
+        },
+        "limit": {
+          "type": "object",
+          "properties": {
+            "per_pair": {"type": "boolean"},
+            "max": {"type": "integer", "minimum": 1}
+          }
+        }
+      }
+    }
+  }
+}

--- a/interpret-packs/tests/test_house_pack.py
+++ b/interpret-packs/tests/test_house_pack.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.interpret_plus.engine import interpret, load_rules
+
+BASE = Path(__file__).resolve().parents[1]
+FIXTURES = BASE / "fixtures"
+
+with (FIXTURES / "composite_positions.json").open("r", encoding="utf-8") as handle:
+    COMPOSITE = json.load(handle)
+with (FIXTURES / "davison_positions.json").open("r", encoding="utf-8") as handle:
+    DAVISON = json.load(handle)
+with (FIXTURES / "golden_outputs.json").open("r", encoding="utf-8") as handle:
+    GOLDEN = json.load(handle)
+
+
+def _top(findings):
+    return [
+        {
+            "id": f.id,
+            "score": round(f.score, 4),
+            "tags": f.tags[:],
+        }
+        for f in findings[:5]
+    ]
+
+
+def test_house_overlay_composite_golden():
+    pack = load_rules(str(BASE / "packs" / "house-overlays.yaml"))
+    req = {"scope": "composite", **COMPOSITE}
+    findings = interpret(req, pack)
+    assert _top(findings) == GOLDEN["house_composite"]
+
+
+def test_house_overlay_davison_golden():
+    pack = load_rules(str(BASE / "packs" / "house-overlays.yaml"))
+    req = {"scope": "davison", **DAVISON}
+    findings = interpret(req, pack)
+    assert _top(findings) == GOLDEN["house_davison"]

--- a/interpret-packs/tests/test_luminary_pack.py
+++ b/interpret-packs/tests/test_luminary_pack.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.interpret_plus.engine import interpret, load_rules
+
+BASE = Path(__file__).resolve().parents[1]
+FIXTURES = BASE / "fixtures"
+
+with (FIXTURES / "hits_canonical.json").open("r", encoding="utf-8") as handle:
+    HITS = json.load(handle)
+with (FIXTURES / "golden_outputs.json").open("r", encoding="utf-8") as handle:
+    GOLDEN = json.load(handle)["luminary"]
+
+
+def _top(findings):
+    return [
+        {
+            "id": f.id,
+            "score": round(f.score, 4),
+            "tags": f.tags[:],
+            "source": f.meta.get("source_pack"),
+        }
+        for f in findings[:5]
+    ]
+
+
+def test_luminary_pack_matches_golden():
+    pack = load_rules(str(BASE / "packs" / "luminary-emphasis.yaml"))
+    req = {"scope": "synastry", "profile": "chemistry_plus", "hits": HITS}
+    findings = interpret(req, pack)
+    assert _top(findings) == GOLDEN

--- a/interpret-packs/tests/test_meta_pack.py
+++ b/interpret-packs/tests/test_meta_pack.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from core.interpret_plus.engine import load_rules
+
+BASE = Path(__file__).resolve().parents[1]
+
+
+def test_meta_pack_combines_rules():
+    pack = load_rules(str(BASE / "meta" / "essentials.yaml"))
+    assert pack["rulepack"] == "relationship-essentials"
+    assert len(pack["rules"]) > 60
+    assert "saturn-binding-growth" in pack["meta"].get("includes", [])
+    assert "chemistry_plus" in pack["profiles"]

--- a/interpret-packs/tests/test_outer_pack.py
+++ b/interpret-packs/tests/test_outer_pack.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.interpret_plus.engine import interpret, load_rules
+
+BASE = Path(__file__).resolve().parents[1]
+FIXTURES = BASE / "fixtures"
+
+with (FIXTURES / "hits_canonical.json").open("r", encoding="utf-8") as handle:
+    HITS = json.load(handle)
+with (FIXTURES / "golden_outputs.json").open("r", encoding="utf-8") as handle:
+    GOLDEN = json.load(handle)["outer"]
+
+
+def _top(findings):
+    return [
+        {
+            "id": f.id,
+            "score": round(f.score, 4),
+            "tags": f.tags[:],
+            "source": f.meta.get("source_pack"),
+        }
+        for f in findings[:5]
+    ]
+
+
+def test_outer_planet_pack_matches_golden():
+    pack = load_rules(str(BASE / "packs" / "outer-planet-contacts.yaml"))
+    req = {"scope": "synastry", "profile": "chemistry_plus", "hits": HITS}
+    findings = interpret(req, pack)
+    assert _top(findings) == GOLDEN

--- a/interpret-packs/tests/test_saturn_pack.py
+++ b/interpret-packs/tests/test_saturn_pack.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from core.interpret_plus.engine import interpret, load_rules
+
+BASE = Path(__file__).resolve().parents[1]
+FIXTURES = BASE / "fixtures"
+
+with (FIXTURES / "hits_canonical.json").open("r", encoding="utf-8") as handle:
+    HITS = json.load(handle)
+with (FIXTURES / "golden_outputs.json").open("r", encoding="utf-8") as handle:
+    GOLDEN = json.load(handle)["saturn"]
+
+
+def _top(findings):
+    return [
+        {
+            "id": f.id,
+            "score": round(f.score, 4),
+            "tags": f.tags[:],
+            "source": f.meta.get("source_pack"),
+        }
+        for f in findings[:5]
+    ]
+
+
+def test_saturn_pack_matches_golden():
+    pack = load_rules(str(BASE / "packs" / "saturn-binding-growth.yaml"))
+    req = {"scope": "synastry", "profile": "stability_plus", "hits": HITS}
+    findings = interpret(req, pack)
+    assert _top(findings) == GOLDEN


### PR DESCRIPTION
## Summary
- extend the interpretation engine DSL with rulepack metadata, group/family filters, composite house overlays, profile weighting, and score saturation controls
- add Saturn, outer-planet, luminary, and house overlay rulepacks plus a weighted meta-pack with documentation, fixtures, and regression tests
- update the API schema/router to expose new request fields and discover the packaged rulepacks

## Testing
- pytest interpret-packs/tests tests/test_relationship_interpret.py tests/test_api_interpret.py
- pytest *(fails: existing suite errors unrelated to these packs)*

------
https://chatgpt.com/codex/tasks/task_e_68d84cfa61e0832492b7e104758ed7f3