### PR TITLE
Add returns engine modules with precise finder and tests

### DIFF
--- a/astroengine/engine/angles/houses.py
+++ b/astroengine/engine/angles/houses.py
@@ -1,0 +1,82 @@
+"""Lightweight wrapper around Swiss Ephemeris house calculations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Mapping
+
+from ...ephemeris import HousePositions, SwissEphemerisAdapter
+
+__all__ = ["GeoLoc", "HousesResult", "compute_angles_houses"]
+
+
+@dataclass(frozen=True)
+class GeoLoc:
+    """Geographic location used when computing angles/houses."""
+
+    latitude_deg: float
+    longitude_deg: float
+    elevation_m: float = 0.0
+
+    def as_tuple(self) -> tuple[float, float, float]:
+        return (self.latitude_deg, self.longitude_deg, self.elevation_m)
+
+
+@dataclass(frozen=True)
+class HousesResult:
+    """Structured representation of house cusps and angles."""
+
+    system: str
+    ascendant: float
+    midheaven: float
+    cusps: tuple[float, ...]
+    metadata: Mapping[str, object]
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "system": self.system,
+            "ascendant": self.ascendant,
+            "midheaven": self.midheaven,
+            "cusps": self.cusps,
+            "metadata": dict(self.metadata),
+        }
+
+
+def _ensure_utc(moment: datetime) -> datetime:
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=UTC)
+    return moment.astimezone(UTC)
+
+
+def compute_angles_houses(
+    moment: datetime,
+    location: GeoLoc,
+    *,
+    system: str,
+    adapter: SwissEphemerisAdapter | None = None,
+) -> HousesResult:
+    """Compute ascendant, midheaven, and house cusps for ``moment``."""
+
+    adapter = adapter or SwissEphemerisAdapter.get_default_adapter()
+    moment_utc = _ensure_utc(moment)
+    jd = adapter.julian_day(moment_utc)
+    house_positions: HousePositions = adapter.houses(
+        jd,
+        location.latitude_deg,
+        location.longitude_deg,
+        system=system,
+    )
+    metadata = dict(house_positions.provenance or {})
+    if house_positions.fallback_from is not None:
+        metadata["fallback"] = {
+            "from": house_positions.fallback_from,
+            "reason": house_positions.fallback_reason,
+        }
+    return HousesResult(
+        system=house_positions.system_name or house_positions.system,
+        ascendant=house_positions.ascendant % 360.0,
+        midheaven=house_positions.midheaven % 360.0,
+        cusps=tuple(float(c) % 360.0 for c in house_positions.cusps),
+        metadata=metadata,
+    )

--- a/astroengine/engine/returns/__init__.py
+++ b/astroengine/engine/returns/__init__.py
@@ -1,0 +1,36 @@
+"""Return chart computation primitives for AstroEngine's predictive stack."""
+
+from __future__ import annotations
+
+from .finder import (
+    ReturnInstant,
+    ReturnNotFoundError,
+    find_return_instant,
+    guess_window,
+)
+from .scan import (
+    AttachOptions,
+    GeoLoc,
+    NatalCtx,
+    PositionSnapshot,
+    ReturnHit,
+    ScanOptions,
+    scan_returns,
+)
+from .attach import attach_aspects_to_natal, attach_transiting_aspects
+
+__all__ = [
+    "AttachOptions",
+    "GeoLoc",
+    "NatalCtx",
+    "PositionSnapshot",
+    "ReturnHit",
+    "ReturnInstant",
+    "ReturnNotFoundError",
+    "ScanOptions",
+    "attach_aspects_to_natal",
+    "attach_transiting_aspects",
+    "find_return_instant",
+    "guess_window",
+    "scan_returns",
+]

--- a/astroengine/engine/returns/_codes.py
+++ b/astroengine/engine/returns/_codes.py
@@ -1,0 +1,78 @@
+"""Swiss ephemeris body-code helpers shared across the returns engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+
+from ...core.bodies import canonical_name
+
+try:  # pragma: no cover - optional dependency guard
+    import swisseph as swe  # type: ignore
+except Exception:  # pragma: no cover - fallback for test environments
+    swe = None  # type: ignore
+
+
+@dataclass(frozen=True)
+class BodyCode:
+    """Resolved Swiss ephemeris code and derived flag."""
+
+    code: int
+    derived: bool = False
+
+
+_BASE_CODES: dict[str, BodyCode] = {
+    "sun": BodyCode(int(getattr(swe, "SUN", 0)) if swe else 0),
+    "moon": BodyCode(int(getattr(swe, "MOON", 1)) if swe else 1),
+    "mercury": BodyCode(int(getattr(swe, "MERCURY", 2)) if swe else 2),
+    "venus": BodyCode(int(getattr(swe, "VENUS", 3)) if swe else 3),
+    "mars": BodyCode(int(getattr(swe, "MARS", 4)) if swe else 4),
+    "jupiter": BodyCode(int(getattr(swe, "JUPITER", 5)) if swe else 5),
+    "saturn": BodyCode(int(getattr(swe, "SATURN", 6)) if swe else 6),
+    "uranus": BodyCode(int(getattr(swe, "URANUS", 7)) if swe else 7),
+    "neptune": BodyCode(int(getattr(swe, "NEPTUNE", 8)) if swe else 8),
+    "pluto": BodyCode(int(getattr(swe, "PLUTO", 9)) if swe else 9),
+}
+
+if swe is not None:  # pragma: no cover - depends on pyswisseph build
+    for attr, name in (
+        ("CERES", "ceres"),
+        ("PALLAS", "pallas"),
+        ("JUNO", "juno"),
+        ("VESTA", "vesta"),
+        ("CHIRON", "chiron"),
+        ("PHOLUS", "pholus"),
+        ("NESSUS", "nessus"),
+        ("ERIS", "eris"),
+        ("HAUMEA", "haumea"),
+        ("MAKEMAKE", "makemake"),
+        ("SEDNA", "sedna"),
+        ("QUAOAR", "quaoar"),
+        ("ORCUS", "orcus"),
+        ("IXION", "ixion"),
+    ):
+        code = getattr(swe, attr, None)
+        if code is not None:
+            _BASE_CODES[name] = BodyCode(int(code))
+
+
+@lru_cache(maxsize=None)
+def resolve_body_code(name: str) -> BodyCode:
+    """Return the Swiss body code for ``name`` suitable for :class:`EphemerisAdapter`.
+
+    The helper normalises body names via :func:`canonical_name` and raises
+    :class:`ValueError` when the target is unavailable from the active Swiss
+    build.  The returns engine leans on this helper to guarantee consistent
+    mappings regardless of downstream aliases such as ``Sun`` vs ``sun``.
+    """
+
+    canonical = canonical_name(name)
+    if not canonical:
+        raise ValueError("body name must be non-empty")
+    try:
+        return _BASE_CODES[canonical]
+    except KeyError as exc:  # pragma: no cover - exercised in tests
+        raise ValueError(f"Unsupported body for return calculations: {name}") from exc
+
+
+__all__ = ["BodyCode", "resolve_body_code"]

--- a/astroengine/engine/returns/attach.py
+++ b/astroengine/engine/returns/attach.py
@@ -1,0 +1,204 @@
+"""Aspect attachment helpers for return charts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import combinations
+from typing import Iterable, Mapping, Sequence
+
+from ...core.angles import signed_delta
+from ...core.bodies import body_class, canonical_name
+from ...detectors_aspects import AspectHit
+from ...scoring.policy import OrbPolicy
+
+__all__ = [
+    "AspectDefinition",
+    "attach_transiting_aspects",
+    "attach_aspects_to_natal",
+]
+
+
+@dataclass(frozen=True)
+class AspectDefinition:
+    """Static aspect description used by the returns engine."""
+
+    name: str
+    angle_deg: float
+    harmonic: int
+    family: str
+
+
+# Core library covering the aspects used by the lab. Harmonics align with common
+# interpretive practice: harmonic 1 → conjunction, 2 → opposition, 3 → trine, etc.
+_ASPECT_LIBRARY: tuple[AspectDefinition, ...] = (
+    AspectDefinition("conjunction", 0.0, 1, "major"),
+    AspectDefinition("opposition", 180.0, 2, "major"),
+    AspectDefinition("trine", 120.0, 3, "major"),
+    AspectDefinition("square", 90.0, 4, "major"),
+    AspectDefinition("sextile", 60.0, 6, "minor"),
+    AspectDefinition("quincunx", 150.0, 6, "minor"),
+    AspectDefinition("semisextile", 30.0, 12, "minor"),
+    AspectDefinition("semisquare", 45.0, 8, "minor"),
+    AspectDefinition("sesquisquare", 135.0, 8, "minor"),
+    AspectDefinition("quintile", 72.0, 5, "harmonic"),
+    AspectDefinition("biquintile", 144.0, 5, "harmonic"),
+)
+
+
+def _normalize_timestamp(positions: Mapping[str, object]) -> str:
+    ts = positions.get("timestamp")
+    if isinstance(ts, str):
+        return ts
+    if isinstance(ts, datetime):
+        return ts.astimezone().isoformat()
+    raise ValueError("positions payload must include 'timestamp' key")
+
+
+def _positions_map(positions: Mapping[str, object]) -> Mapping[str, Mapping[str, float]]:
+    body_map = positions.get("bodies")
+    if not isinstance(body_map, Mapping):
+        raise ValueError("positions payload must include 'bodies' mapping")
+    normalized: dict[str, Mapping[str, float]] = {}
+    for name, payload in body_map.items():
+        if not isinstance(payload, Mapping):
+            continue
+        normalized[name.lower()] = payload
+    return normalized
+
+
+def _orb_allowance(policy: OrbPolicy, a: str, b: str) -> float:
+    data = policy.data if isinstance(policy.data, Mapping) else {}
+    longitudinal = data.get("longitudinal", {})
+    class_a = body_class(a)
+    class_b = body_class(b)
+    default_orb = float(longitudinal.get("outer", 3.0))
+    orb_a = float(longitudinal.get(class_a, default_orb))
+    orb_b = float(longitudinal.get(class_b, default_orb))
+    return min(orb_a, orb_b)
+
+
+def _enabled_aspects(harmonics: Sequence[int]) -> Iterable[AspectDefinition]:
+    allowed = {int(h) for h in harmonics} if harmonics else set()
+    if not allowed:
+        return _ASPECT_LIBRARY
+    return tuple(aspect for aspect in _ASPECT_LIBRARY if aspect.harmonic in allowed)
+
+
+def _build_aspect(
+    when_iso: str,
+    moving: str,
+    target: str,
+    aspect: AspectDefinition,
+    *,
+    lon_moving: float,
+    lon_target: float,
+    speed_moving: float,
+    speed_target: float,
+    orb_allow: float,
+) -> AspectHit:
+    separation = signed_delta(lon_moving - lon_target)
+    offset = signed_delta(separation - aspect.angle_deg)
+    retrograde = speed_moving < 0.0 or speed_target < 0.0
+    relative_speed = speed_moving - speed_target
+    state = "stationary"
+    if abs(relative_speed) > 1e-6:
+        state = "applying" if offset * relative_speed < 0 else "separating"
+    return AspectHit(
+        kind=f"aspect_{aspect.name}",
+        when_iso=when_iso,
+        moving=moving,
+        target=target,
+        angle_deg=float(aspect.angle_deg),
+        lon_moving=float(lon_moving % 360.0),
+        lon_target=float(lon_target % 360.0),
+        delta_lambda_deg=float(separation),
+        offset_deg=float(offset),
+        orb_abs=float(abs(offset)),
+        orb_allow=float(orb_allow),
+        is_partile=abs(offset) <= 0.1667,
+        applying_or_separating=state,
+        family=aspect.family,
+        corridor_width_deg=float(max(orb_allow, 0.1)),
+        corridor_profile="gaussian",
+        speed_deg_per_day=float(relative_speed),
+        retrograde=retrograde,
+        domain_weights=None,
+    )
+
+
+def attach_transiting_aspects(
+    positions: Mapping[str, object],
+    policy: OrbPolicy,
+    harmonics: Sequence[int] | None,
+) -> list[AspectHit]:
+    """Compute transiting aspect hits for the supplied position snapshot."""
+
+    if not positions:
+        return []
+    iso = _normalize_timestamp(positions)
+    body_map = _positions_map(positions)
+    enabled = tuple(_enabled_aspects(harmonics))
+    hits: list[AspectHit] = []
+    for moving, target in combinations(sorted(body_map), 2):
+        pos_m = body_map[moving]
+        pos_t = body_map[target]
+        lon_m = float(pos_m.get("lon", 0.0))
+        lon_t = float(pos_t.get("lon", 0.0))
+        speed_m = float(pos_m.get("speed_lon", 0.0))
+        speed_t = float(pos_t.get("speed_lon", 0.0))
+        orb_allow = _orb_allowance(policy, moving, target)
+        for aspect in enabled:
+            offset = abs(signed_delta((lon_m - lon_t) - aspect.angle_deg))
+            if offset <= orb_allow:
+                hits.append(
+                    _build_aspect(
+                        iso,
+                        moving,
+                        target,
+                        aspect,
+                        lon_moving=lon_m,
+                        lon_target=lon_t,
+                        speed_moving=speed_m,
+                        speed_target=speed_t,
+                        orb_allow=orb_allow,
+                    )
+                )
+    return hits
+
+
+def attach_aspects_to_natal(
+    transiting: Mapping[str, object],
+    natal_positions: Mapping[str, float],
+    policy: OrbPolicy,
+    harmonics: Sequence[int] | None,
+) -> list[AspectHit]:
+    """Return aspect hits between transiting bodies and natal positions."""
+
+    iso = _normalize_timestamp(transiting)
+    body_map = _positions_map(transiting)
+    enabled = tuple(_enabled_aspects(harmonics))
+    hits: list[AspectHit] = []
+    for moving, payload in body_map.items():
+        lon_m = float(payload.get("lon", 0.0))
+        speed_m = float(payload.get("speed_lon", 0.0))
+        for natal_name, natal_lon in natal_positions.items():
+            canonical = canonical_name(natal_name)
+            orb_allow = _orb_allowance(policy, moving, canonical)
+            for aspect in enabled:
+                offset = abs(signed_delta((lon_m - natal_lon) - aspect.angle_deg))
+                if offset <= orb_allow:
+                    hits.append(
+                        _build_aspect(
+                            iso,
+                            moving,
+                            f"natal_{canonical}",
+                            aspect,
+                            lon_moving=lon_m,
+                            lon_target=float(natal_lon),
+                            speed_moving=speed_m,
+                            speed_target=0.0,
+                            orb_allow=orb_allow,
+                        )
+                    )
+    return hits

--- a/astroengine/engine/returns/finder.py
+++ b/astroengine/engine/returns/finder.py
@@ -1,0 +1,305 @@
+"""High precision return finder built on top of :class:`EphemerisAdapter`."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from math import sin
+from typing import Any, Callable, Iterable, Tuple
+
+from ...core.time import TimeConversion, ensure_utc, to_tt
+from ...ephemeris import EphemerisAdapter, RefineResult, refine_root
+from ._codes import resolve_body_code
+
+__all__ = [
+    "ReturnInstant",
+    "ReturnNotFoundError",
+    "find_return_instant",
+    "guess_window",
+]
+
+# Julian day helper constants shared with detectors
+_UNIX_EPOCH_JD = 2440587.5
+_SECONDS_PER_DAY = 86400.0
+
+
+@dataclass(frozen=True)
+class ReturnInstant:
+    """Precise return solution describing the perfected longitude."""
+
+    body: str
+    target_longitude_deg: float
+    exact_time: datetime
+    longitude_deg: float
+    delta_arcsec: float
+    bracket_start: datetime
+    bracket_end: datetime
+    iterations: int
+    evaluations: int
+    tolerance_seconds: float
+    achieved_tolerance_seconds: float
+    status: str
+    delta_t_seconds: float
+    diagnostics: dict[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        payload = {
+            "body": self.body,
+            "target_longitude_deg": self.target_longitude_deg,
+            "exact_time": self.exact_time.isoformat().replace("+00:00", "Z"),
+            "longitude_deg": self.longitude_deg,
+            "delta_arcsec": self.delta_arcsec,
+            "iterations": self.iterations,
+            "evaluations": self.evaluations,
+            "tolerance_seconds": self.tolerance_seconds,
+            "achieved_tolerance_seconds": self.achieved_tolerance_seconds,
+            "status": self.status,
+            "delta_t_seconds": self.delta_t_seconds,
+        }
+        payload["diagnostics"] = dict(self.diagnostics)
+        payload["bracket"] = {
+            "start": self.bracket_start.isoformat().replace("+00:00", "Z"),
+            "end": self.bracket_end.isoformat().replace("+00:00", "Z"),
+        }
+        return payload
+
+
+class ReturnNotFoundError(RuntimeError):
+    """Raised when a return cannot be bracketed inside the supplied window."""
+
+
+# Mean synodic periods expressed in days. Values loosely follow NASA/JPL data.
+_MEAN_PERIODS_DAYS: dict[str, float] = {
+    "sun": 365.2422,
+    "moon": 27.321661,
+    "mercury": 87.9691,
+    "venus": 224.7008,
+    "mars": 686.980,
+    "jupiter": 4332.589,
+    "saturn": 10759.22,
+    "uranus": 30688.5,
+    "neptune": 60182.0,
+    "pluto": 90560.0,
+}
+
+_STEP_MINUTES: dict[str, float] = {
+    "moon": 60.0,  # fast body → 1-hour sampling when bracketing
+    "mercury": 360.0,
+    "venus": 480.0,
+    "sun": 720.0,
+}
+
+
+def _norm360(angle: float) -> float:
+    wrapped = angle % 360.0
+    return wrapped + 360.0 if wrapped < 0 else wrapped
+
+
+def _signed_delta(a: float, b: float) -> float:
+    delta = (_norm360(a) - _norm360(b) + 180.0) % 360.0 - 180.0
+    return delta
+
+
+def _half_angle_metric(delta_deg: float) -> float:
+    # Use the half-angle sine method to avoid false roots at 180°.
+    from math import radians
+
+    return sin(radians(delta_deg / 2.0))
+
+
+def _jd_to_datetime(jd_ut: float) -> datetime:
+    seconds = (jd_ut - _UNIX_EPOCH_JD) * _SECONDS_PER_DAY
+    epoch = datetime(1970, 1, 1, tzinfo=UTC)
+    return epoch + timedelta(seconds=seconds)
+
+
+def _datetime_series(start: datetime, end: datetime, step: timedelta) -> Iterable[datetime]:
+    current = start
+    while current <= end:
+        yield current
+        current = current + step
+
+
+def guess_window(
+    body: str,
+    last_return: datetime | None,
+    around: datetime,
+) -> Tuple[datetime, datetime]:
+    """Return a coarse search window centred around the expected return."""
+
+    key = body.lower()
+    period = _MEAN_PERIODS_DAYS.get(key, 365.2422)
+    scale = 0.55 if last_return else 0.45
+    half_span = max(period * scale, 5.0)
+    center = last_return + timedelta(days=period) if last_return else around
+    center = ensure_utc(center)
+    return (center - timedelta(days=half_span), center + timedelta(days=half_span))
+
+
+def _step_for(body: str) -> timedelta:
+    minutes = _STEP_MINUTES.get(body.lower(), 24 * 60.0)
+    return timedelta(minutes=minutes)
+
+
+def _prepare_conversion(moment: datetime) -> TimeConversion:
+    return to_tt(ensure_utc(moment))
+
+
+def _refine_root(
+    adapter: EphemerisAdapter,
+    body: str,
+    target_lon: float,
+    *,
+    bracket: tuple[datetime, datetime],
+    tol_seconds: float,
+    evaluations: int,
+) -> tuple[ReturnInstant, int]:
+    code = resolve_body_code(body).code
+    start_dt, end_dt = bracket
+    start_conv = _prepare_conversion(start_dt)
+    end_conv = _prepare_conversion(end_dt)
+    start_jd = start_conv.jd_utc
+    end_jd = end_conv.jd_utc
+
+    conversion_cache: dict[float, TimeConversion] = {
+        start_jd: start_conv,
+        end_jd: end_conv,
+    }
+
+    def _conversion_for(jd_ut: float) -> TimeConversion:
+        try:
+            return conversion_cache[jd_ut]
+        except KeyError:
+            conv = to_tt(_jd_to_datetime(jd_ut))
+            conversion_cache[jd_ut] = conv
+            return conv
+
+    def _delta_at(jd_ut: float) -> float:
+        nonlocal evaluations
+        conv = _conversion_for(jd_ut)
+        sample = adapter.sample(code, conv)
+        evaluations += 1
+        return _half_angle_metric(_signed_delta(sample.longitude, target_lon))
+
+    refine: RefineResult = refine_root(
+        _delta_at,
+        start_jd,
+        end_jd,
+        tol_seconds=max(tol_seconds, 0.05),
+        max_iter=64,
+    )
+
+    exact_conv = _conversion_for(refine.t_exact_jd)
+    exact_sample = adapter.sample(code, exact_conv)
+    evaluations += 1
+    exact_time = ensure_utc(exact_conv.utc_datetime)
+    delta_deg = abs(_signed_delta(exact_sample.longitude, target_lon))
+    delta_arcsec = delta_deg * 3600.0
+
+    diagnostics: dict[str, Any] = {
+        "method": refine.method,
+        "status": refine.status,
+        "bracket_jd": (start_jd, end_jd),
+        "used_code": code,
+    }
+
+    config = getattr(adapter, "_config", None)
+    zodiac = "sidereal" if getattr(config, "sidereal", False) else "tropical"
+    ayanamsha = getattr(config, "sidereal_mode", None)
+    provenance = {
+        "zodiac": zodiac,
+        "ayanamsha": ayanamsha,
+    }
+
+    instant = ReturnInstant(
+        body=body,
+        target_longitude_deg=target_lon % 360.0,
+        exact_time=exact_time,
+        longitude_deg=exact_sample.longitude % 360.0,
+        delta_arcsec=delta_arcsec,
+        bracket_start=start_dt,
+        bracket_end=end_dt,
+        iterations=refine.iterations,
+        evaluations=evaluations,
+        tolerance_seconds=tol_seconds,
+        achieved_tolerance_seconds=refine.achieved_tol_sec,
+        status=refine.status,
+        delta_t_seconds=exact_conv.delta_t_seconds,
+        diagnostics={**diagnostics, "provenance": provenance},
+    )
+    return instant, evaluations
+
+
+def find_return_instant(
+    ephem: EphemerisAdapter,
+    body: str,
+    lambda_natal_deg: float,
+    t_window: Tuple[datetime, datetime],
+    *,
+    tz_hint: str | None = None,
+    tol_seconds: float = 0.25,
+) -> ReturnInstant:
+    """Locate the exact instant the transiting ``body`` returns to ``lambda_natal_deg``."""
+
+    start_raw, end_raw = t_window
+    start = ensure_utc(start_raw)
+    end = ensure_utc(end_raw)
+    if end <= start:
+        raise ValueError("t_window end must be after start")
+
+    target = lambda_natal_deg % 360.0
+    step = _step_for(body)
+
+    samples: list[tuple[datetime, float]] = []
+    evaluations = 0
+    prev_time: datetime | None = None
+    prev_metric: float | None = None
+    bracket: tuple[datetime, datetime] | None = None
+
+    code = resolve_body_code(body).code
+
+    for moment in _datetime_series(start, end, step):
+        conv = _prepare_conversion(moment)
+        sample = ephem.sample(code, conv)
+        evaluations += 1
+        delta = _signed_delta(sample.longitude, target)
+        metric = _half_angle_metric(delta)
+        samples.append((moment, delta))
+        if abs(metric) <= 1e-8:
+            bracket = (moment - timedelta(seconds=step.total_seconds()), moment)
+            break
+        if prev_time is not None and prev_metric is not None:
+            if prev_metric == 0.0 or metric == 0.0 or prev_metric * metric <= 0.0:
+                bracket = (prev_time, moment)
+                break
+        prev_time, prev_metric = moment, metric
+
+    if bracket is None:
+        raise ReturnNotFoundError(
+            f"Could not bracket {body} return between {start.isoformat()} and {end.isoformat()}"
+        )
+
+    instant, evaluations = _refine_root(
+        ephem,
+        body,
+        target,
+        bracket=bracket,
+        tol_seconds=tol_seconds,
+        evaluations=evaluations,
+    )
+
+    if tz_hint:
+        try:
+            from zoneinfo import ZoneInfo  # Python 3.9+
+
+            local_dt = instant.exact_time.astimezone(ZoneInfo(tz_hint))
+            instant.diagnostics["local_time"] = local_dt.isoformat()
+        except Exception:  # pragma: no cover - invalid tz identifiers
+            instant.diagnostics["local_time_error"] = tz_hint
+
+    instant.diagnostics["bracket_samples"] = [
+        (moment.isoformat().replace("+00:00", "Z"), value) for moment, value in samples
+    ]
+    instant.diagnostics["step_minutes"] = step.total_seconds() / 60.0
+
+    return instant

--- a/astroengine/engine/returns/scan.py
+++ b/astroengine/engine/returns/scan.py
@@ -1,0 +1,316 @@
+"""Batch return scanning orchestration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Iterable, Mapping, Sequence
+
+from ...core.bodies import canonical_name
+from ...core.charts_plus.returns import ReturnWindow as LegacyReturnWindow
+from ...core.charts_plus.returns import find_returns_in_window as legacy_find_returns
+from ...core.time import ensure_utc, to_tt
+from ...ephemeris import EphemerisAdapter
+from ...scoring.policy import OrbPolicy, load_orb_policy
+from ..angles.houses import GeoLoc, HousesResult, compute_angles_houses
+from ._codes import resolve_body_code
+from .attach import attach_aspects_to_natal, attach_transiting_aspects
+from .finder import ReturnInstant, ReturnNotFoundError, find_return_instant, guess_window
+
+__all__ = [
+    "AttachOptions",
+    "GeoLoc",
+    "NatalCtx",
+    "PositionSnapshot",
+    "ReturnHit",
+    "ScanOptions",
+    "scan_returns",
+]
+
+
+@dataclass(frozen=True)
+class PositionSnapshot:
+    """Captured ephemeris sample for a body at the return instant."""
+
+    longitude: float
+    latitude: float
+    distance_au: float
+    speed_longitude: float
+    speed_latitude: float
+    speed_distance: float
+    right_ascension: float
+    declination: float
+    speed_ra: float
+    speed_declination: float
+
+    def to_mapping(self) -> dict[str, float]:
+        return {
+            "lon": self.longitude,
+            "lat": self.latitude,
+            "distance": self.distance_au,
+            "speed_lon": self.speed_longitude,
+            "speed_lat": self.speed_latitude,
+            "speed_dist": self.speed_distance,
+            "ra": self.right_ascension,
+            "decl": self.declination,
+            "speed_ra": self.speed_ra,
+            "speed_decl": self.speed_declination,
+        }
+
+
+@dataclass(frozen=True)
+class NatalCtx:
+    """Natal context supplying longitudes and reference metadata."""
+
+    moment: datetime
+    longitudes: Mapping[str, float]
+    location: GeoLoc | None = None
+    zodiac: str = "tropical"
+    ayanamsha: str | None = None
+
+
+@dataclass(frozen=True)
+class AttachOptions:
+    """Toggle which attachments should be computed during scans."""
+
+    transiting_aspects: bool = True
+    to_natal: bool = False
+
+
+@dataclass(frozen=True)
+class ScanOptions:
+    """User-specified configuration for scanning return windows."""
+
+    location: GeoLoc | None = None
+    house_system: str = "placidus"
+    harmonics: Sequence[int] = field(default_factory=lambda: (1, 2, 3, 4, 5, 6))
+    orb_policy: OrbPolicy = field(default_factory=load_orb_policy)
+    attach: AttachOptions = field(default_factory=AttachOptions)
+    tz_hint: str | None = None
+
+
+@dataclass(frozen=True)
+class ReturnHit:
+    """Aggregated return information exposed to API/UI layers."""
+
+    body: str
+    instant: ReturnInstant
+    location: GeoLoc
+    houses: HousesResult
+    positions: Mapping[str, PositionSnapshot]
+    transiting_aspects: Sequence
+    natal_aspects: Sequence
+    metadata: Mapping[str, object]
+
+    def as_dict(self) -> dict[str, object]:
+        payload = {
+            "body": self.body,
+            "instant": self.instant.as_dict(),
+            "location": {
+                "latitude": self.location.latitude_deg,
+                "longitude": self.location.longitude_deg,
+                "elevation": self.location.elevation_m,
+            },
+            "houses": self.houses.to_mapping(),
+            "positions": {name: snap.to_mapping() for name, snap in self.positions.items()},
+            "transiting_aspects": [hit.__dict__ for hit in self.transiting_aspects],
+            "natal_aspects": [hit.__dict__ for hit in self.natal_aspects],
+            "metadata": dict(self.metadata),
+        }
+        return payload
+
+
+def _ensure_location(options: ScanOptions, natal: NatalCtx) -> GeoLoc:
+    if options.location is not None:
+        return options.location
+    if natal.location is not None:
+        return natal.location
+    raise ValueError("Return scans require a location to compute houses.")
+
+
+def _positions_payload(
+    instant: ReturnInstant,
+    adapter: EphemerisAdapter,
+    bodies: Iterable[str],
+) -> dict[str, object]:
+    payload: dict[str, object] = {"timestamp": instant.exact_time.isoformat().replace("+00:00", "Z"), "bodies": {}}
+    conversion = to_tt(instant.exact_time.astimezone(UTC))
+    for body in bodies:
+        code = resolve_body_code(body).code
+        sample = adapter.sample(code, conversion)
+        payload["bodies"][body] = {
+            "lon": sample.longitude % 360.0,
+            "lat": sample.latitude,
+            "distance": sample.distance,
+            "speed_lon": sample.speed_longitude,
+            "speed_lat": sample.speed_latitude,
+            "speed_dist": sample.speed_distance,
+            "ra": sample.right_ascension,
+            "decl": sample.declination,
+            "speed_ra": sample.speed_right_ascension,
+            "speed_decl": sample.speed_declination,
+        }
+    return payload
+
+
+def _positions_snapshots(
+    instant: ReturnInstant,
+    adapter: EphemerisAdapter,
+    bodies: Iterable[str],
+) -> dict[str, PositionSnapshot]:
+    conversion = to_tt(instant.exact_time.astimezone(UTC))
+    snapshots: dict[str, PositionSnapshot] = {}
+    for body in bodies:
+        code = resolve_body_code(body).code
+        sample = adapter.sample(code, conversion)
+        snapshots[body] = PositionSnapshot(
+            longitude=sample.longitude % 360.0,
+            latitude=sample.latitude,
+            distance_au=sample.distance,
+            speed_longitude=sample.speed_longitude,
+            speed_latitude=sample.speed_latitude,
+            speed_distance=sample.speed_distance,
+            right_ascension=sample.right_ascension,
+            declination=sample.declination,
+            speed_ra=sample.speed_right_ascension,
+            speed_declination=sample.speed_declination,
+        )
+    return snapshots
+
+
+def _metadata_for(adapter: EphemerisAdapter, instant: ReturnInstant) -> dict[str, object]:
+    config = getattr(adapter, "_config", None)
+    zodiac = "sidereal" if getattr(config, "sidereal", False) else "tropical"
+    ayanamsha = getattr(config, "sidereal_mode", None)
+    return {
+        "zodiac": zodiac,
+        "ayanamsha": ayanamsha,
+        "delta_t_seconds": instant.delta_t_seconds,
+        "tolerance_seconds": instant.tolerance_seconds,
+    }
+
+
+def _synodic_period_days(body: str) -> float:
+    from .finder import _MEAN_PERIODS_DAYS  # type: ignore[attr-defined]
+
+    return _MEAN_PERIODS_DAYS.get(body.lower(), 365.2422)
+
+
+def scan_returns(
+    ephem: EphemerisAdapter,
+    bodies: Sequence[str],
+    t_from: datetime,
+    t_to: datetime,
+    natal: NatalCtx,
+    options: ScanOptions | None = None,
+) -> list[ReturnHit]:
+    """Scan the supplied window for return hits across ``bodies``."""
+
+    if not bodies:
+        return []
+    options = options or ScanOptions()
+    location = _ensure_location(options, natal)
+    start = ensure_utc(t_from)
+    end = ensure_utc(t_to)
+    if end <= start:
+        raise ValueError("t_to must be after t_from")
+
+    hits: list[ReturnHit] = []
+    harmonics = options.harmonics
+
+    for body in bodies:
+        target_key = canonical_name(body)
+        try:
+            target_lon = natal.longitudes[target_key]
+        except KeyError as exc:
+            raise KeyError(f"Natal longitude for {body} missing from context") from exc
+
+        last_emitted: datetime | None = None
+        period_days = _synodic_period_days(body)
+        margin = timedelta(days=period_days)
+
+        code = resolve_body_code(body).code
+
+        def _provider(moment: datetime) -> dict[str, float]:
+            conversion = to_tt(moment)
+            sample = ephem.sample(code, conversion)
+            return {body: sample.longitude % 360.0}
+
+        legacy_window = LegacyReturnWindow(
+            start=start - margin,
+            end=end + margin,
+        )
+
+        step_minutes = max(15, int(period_days * 24.0 * 60.0 / 96.0))
+
+        coarse_results = legacy_find_returns(
+            body,
+            target_lon,
+            legacy_window,
+            _provider,
+            step_minutes=step_minutes,
+            tol_seconds=1.0,
+        )
+
+        for coarse in coarse_results:
+            approx = ensure_utc(coarse.exact_time)
+            refine_window = (
+                approx - timedelta(days=period_days * 0.25),
+                approx + timedelta(days=period_days * 0.25),
+            )
+            try:
+                instant = find_return_instant(
+                    ephem,
+                    body,
+                    target_lon,
+                    refine_window,
+                    tz_hint=options.tz_hint,
+                )
+            except ReturnNotFoundError:
+                continue
+
+            if instant.exact_time < start or instant.exact_time > end:
+                continue
+
+            if instant.delta_arcsec > 5.0:
+                continue
+
+            if last_emitted is not None:
+                min_spacing = max(1.0, period_days * 0.1) * 86400.0
+                if abs((instant.exact_time - last_emitted).total_seconds()) < min_spacing:
+                    continue
+
+            houses = compute_angles_houses(
+                instant.exact_time,
+                location,
+                system=options.house_system,
+            )
+            tracked_bodies = tuple(dict.fromkeys([body, *bodies]))
+            snapshots = _positions_snapshots(instant, ephem, tracked_bodies)
+            position_payload = _positions_payload(instant, ephem, tracked_bodies)
+            transiting_aspects = (
+                attach_transiting_aspects(position_payload, options.orb_policy, harmonics)
+                if options.attach.transiting_aspects
+                else []
+            )
+            natal_aspects = (
+                attach_aspects_to_natal(position_payload, natal.longitudes, options.orb_policy, harmonics)
+                if options.attach.to_natal
+                else []
+            )
+
+            hit = ReturnHit(
+                body=body,
+                instant=instant,
+                location=location,
+                houses=houses,
+                positions=snapshots,
+                transiting_aspects=transiting_aspects,
+                natal_aspects=natal_aspects,
+                metadata=_metadata_for(ephem, instant),
+            )
+            hits.append(hit)
+            last_emitted = instant.exact_time
+
+    hits.sort(key=lambda item: item.instant.exact_time)
+    return hits

--- a/tests/returns/test_lunar_return_scan.py
+++ b/tests/returns/test_lunar_return_scan.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from astroengine.engine.returns import AttachOptions, GeoLoc, NatalCtx, ScanOptions, scan_returns
+from astroengine.engine.returns._codes import resolve_body_code
+from astroengine.ephemeris import EphemerisAdapter
+from astroengine.core.time import to_tt
+
+
+def _wrap(delta: float) -> float:
+    return ((delta + 180.0) % 360.0) - 180.0
+
+
+def test_lunar_return_scan_counts() -> None:
+    adapter = EphemerisAdapter()
+    natal_dt = datetime(1995, 3, 20, 8, 15, tzinfo=timezone.utc)
+    moon_code = resolve_body_code("Moon").code
+    natal_conv = to_tt(natal_dt)
+    natal_moon = adapter.sample(moon_code, natal_conv).longitude % 360.0
+
+    location = GeoLoc(latitude_deg=51.5074, longitude_deg=-0.1278, elevation_m=35.0)
+    natal_ctx = NatalCtx(
+        moment=natal_dt,
+        longitudes={"moon": natal_moon},
+        location=location,
+    )
+
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    end = datetime(2025, 1, 1, tzinfo=timezone.utc)
+
+    options = ScanOptions(location=location, attach=AttachOptions(transiting_aspects=False))
+    hits = scan_returns(adapter, ["Moon"], start, end, natal_ctx, options)
+
+    assert 9 <= len(hits) <= 14
+    assert hits == sorted(hits, key=lambda h: h.instant.exact_time)
+
+    first = hits[0]
+    moon_snap = first.positions["Moon"]
+    delta = abs(_wrap(moon_snap.longitude - natal_moon))
+    assert delta * 3600.0 < 1.5

--- a/tests/returns/test_planetary_returns.py
+++ b/tests/returns/test_planetary_returns.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from astroengine.engine.returns import AttachOptions, GeoLoc, NatalCtx, ScanOptions, scan_returns
+from astroengine.engine.returns._codes import resolve_body_code
+from astroengine.ephemeris import EphemerisAdapter
+from astroengine.core.time import to_tt
+
+
+def test_mars_returns_are_ordered() -> None:
+    adapter = EphemerisAdapter()
+    natal_dt = datetime(1988, 7, 12, 5, 0, tzinfo=timezone.utc)
+    mars_code = resolve_body_code("Mars").code
+    natal_conv = to_tt(natal_dt)
+    natal_mars = adapter.sample(mars_code, natal_conv).longitude % 360.0
+
+    location = GeoLoc(latitude_deg=34.0522, longitude_deg=-118.2437, elevation_m=89.0)
+    natal_ctx = NatalCtx(
+        moment=natal_dt,
+        longitudes={"mars": natal_mars},
+        location=location,
+    )
+
+    start = datetime(1995, 1, 1, tzinfo=timezone.utc)
+    end = start + timedelta(days=365 * 9)
+
+    options = ScanOptions(location=location, attach=AttachOptions(transiting_aspects=False))
+    hits = scan_returns(adapter, ["Mars"], start, end, natal_ctx, options)
+
+    assert len(hits) >= 3
+    times = [hit.instant.exact_time for hit in hits]
+    assert times == sorted(times)
+    for prev, current in zip(times, times[1:]):
+        assert (current - prev).days > 500

--- a/tests/returns/test_solar_return_precision.py
+++ b/tests/returns/test_solar_return_precision.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from astroengine.engine.returns import find_return_instant, guess_window
+from astroengine.engine.returns._codes import resolve_body_code
+from astroengine.ephemeris import EphemerisAdapter
+from astroengine.core.time import to_tt
+
+
+def _wrap(delta: float) -> float:
+    return ((delta + 180.0) % 360.0) - 180.0
+
+
+def test_solar_return_precision() -> None:
+    adapter = EphemerisAdapter()
+    natal_dt = datetime(1990, 5, 4, 12, 30, tzinfo=timezone.utc)
+    code = resolve_body_code("Sun").code
+    natal_conv = to_tt(natal_dt)
+    natal_lon = adapter.sample(code, natal_conv).longitude % 360.0
+
+    around = datetime(2026, 5, 4, 12, 30, tzinfo=timezone.utc)
+    window = guess_window("Sun", None, around)
+    instant = find_return_instant(adapter, "Sun", natal_lon, window)
+
+    assert instant.status == "ok"
+    conv_exact = to_tt(instant.exact_time)
+    lon_exact = adapter.sample(code, conv_exact).longitude % 360.0
+    delta = abs(_wrap(lon_exact - natal_lon))
+    assert delta * 3600.0 < 0.5
+    assert instant.achieved_tolerance_seconds <= 0.3

--- a/tests/returns/test_transiting_aspects_attach.py
+++ b/tests/returns/test_transiting_aspects_attach.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from astroengine.engine.returns.attach import attach_transiting_aspects
+from astroengine.scoring.policy import load_orb_policy
+
+
+def test_transiting_aspects_harmonic_filter() -> None:
+    policy = load_orb_policy()
+    positions = {
+        "timestamp": "2024-01-01T00:00:00Z",
+        "bodies": {
+            "Sun": {"lon": 0.0, "speed_lon": 0.9856},
+            "Saturn": {"lon": 180.1, "speed_lon": 0.033},
+            "Mars": {"lon": 90.0, "speed_lon": 0.6},
+        },
+    }
+
+    hits = attach_transiting_aspects(positions, policy, (1, 2, 4))
+    kinds = {hit.kind for hit in hits}
+    assert "aspect_opposition" in kinds
+    assert "aspect_square" in kinds
+
+    conj_only = attach_transiting_aspects(positions, policy, (1,))
+    assert conj_only == []


### PR DESCRIPTION
## Summary
- add a dedicated returns engine package with precise root finding backed by Swiss Ephemeris
- include aspect attachment utilities and a houses wrapper for return charts
- provide regression tests covering solar precision, lunar scan counts, planetary ordering, and aspect filtering

## Testing
- pytest tests/returns -q

------
https://chatgpt.com/codex/tasks/task_e_68d88a43d7288324abeb21271c7be47d