### PR TITLE
docs: outline mundane module architecture

### DIFF
--- a/docs/module/mundane.md
+++ b/docs/module/mundane.md
@@ -1,0 +1,77 @@
+# Mundane Module — SPEC-4 Architecture
+
+**Status:** Draft specification derived from SPEC-4 requirements (Mundane Astrology)
+
+## Purpose
+
+The Mundane module delivers geopolitical and world-event analytics atop AstroEngine's
+astrological core. It provides a module → submodule → channel → subchannel structure
+that ingests vetted mundane datasets (e.g., Solar Fire exports, historical atlases,
+population grids) and exposes real-time dashboards, APIs, and exports without removing
+or degrading existing modules.
+
+## Scope & Milestones
+
+The module is partitioned according to SPEC-4 milestones:
+
+1. **M1 Registry & Geo Resolver** – Implements the National Charts Registry and
+   historical geo-resolver services.
+2. **M2 Eclipse Engine** – Adds eclipse ingestion, path modeling, and impact scoring.
+3. **M3 Outer Cycles** – Introduces outer-planet cycle analytics, ingress detection,
+   and entity trigger sweeps.
+4. **M4 Dashboard** – Publishes the interactive Streamlit dashboard and export suite.
+5. **M5 Hardening** – Finalizes caching, vector tile pipelines, QA checks, and
+   documentation.
+
+Each milestone corresponds to a submodule spec stored under
+`docs/module/mundane/submodules/` and documents the mandatory channels and
+subchannels needed for successful implementation.
+
+## Submodule Map
+
+| Submodule | Channels | Description |
+|-----------|----------|-------------|
+| [National Charts Registry](submodules/national_charts_registry.md) | `registry` → (`entities`, `versions`, `aliases`), `charts` → (`resolver`, `confidence`) | Versioned mundane charts with provenance and chart resolution utilities. |
+| [Eclipse Paths & Relevance](submodules/eclipse_paths_and_relevance.md) | `ingest` → (`besselian`, `validation`), `geospatial` → (`centerline`, `umbra`, `penumbra`), `scoring` → (`area`, `population`) | Eclipse geometry ingestion, storage, and country impact scoring. |
+| [Outer-Cycle Analytics](submodules/outer_cycle_analytics.md) | `cycles` → (`pairs`, `search`), `ingresses` → (`detection`, `timeline`), `triggers` → (`entity`, `severity`) | Outer-planet cycles, sign ingresses, and entity trigger sweeps. |
+| [Historical Geo-Temporal Mapping](submodules/historical_geo_temporal_mapping.md) | `boundaries` → (`versioning`, `indexes`), `timezone` → (`shim`, `overrides`), `resolver` → (`point-in-time`) | Historical boundary resolution and timezone inference shim. |
+| [Mundane Dashboard](submodules/mundane_dashboard.md) | `ui` → (`map`, `timeline`, `filters`), `exports` → (`csv`, `geojson`, `png`), `tiles` → (`vector`, `cache`) | Streamlit dashboard, overlay rendering, and export pathways. |
+
+## Data Integrity Guarantees
+
+* Every output must cite deterministic sources (Solar Fire archives, Swiss Ephemeris,
+  curated historical datasets). Synthetic or placeholder data is prohibited.
+* Large datasets (CSV, SQLite, raster grids) require indexed access paths documented
+  within each submodule spec. These include B-tree or GIN indexes, PostGIS spatial
+  indexes, raster tiling strategies, and Redis cache keys.
+* Provenance metadata (source, version, checksum, confidence) must be stored with
+  each record and surfaced in APIs/exports.
+
+## Integration & Dependencies
+
+* **SPEC-0 Engines:** The module reuses aspect/event engines for cycle search,
+  ensuring compatibility by exposing adapters within each submodule's channel.
+* **C10 Atlas & Timezone System:** Historical timezone fidelity is shimmed locally
+  but prepared to delegate to the C10 system via a `tz_bridge` subchannel once
+  available.
+* **PostgreSQL/PostGIS:** Required for geo-resolver, eclipse geometry, and scoring.
+* **Redis:** Provides job orchestration and cache support for long-running scans.
+* **Streamlit + pydeck:** Powers the Mundane Dashboard map and timeline overlays.
+
+## Observability & QA
+
+* Structured logs include dataset version IDs, query time ranges, and cache hit
+  ratios per channel.
+* QA harness references golden Solar Fire exports and published mundane almanacs
+  for regression checks.
+* Performance budgets and test plans defined in submodule docs feed the CI suites
+  under `tests/mundane/` (to be created alongside implementation).
+
+## Change Management
+
+* Additive only: implementing SPEC-4 must not remove existing modules or datasets.
+* New datasets must be registered under `registry/datasets/` with checksum manifests
+  and ingestion scripts referencing Solar Fire-compatible formats.
+* Documentation updates must accompany schema or API changes and remain in sync with
+  the module-submodule-channel hierarchy described above.
+

--- a/docs/module/mundane/submodules/eclipse_paths_and_relevance.md
+++ b/docs/module/mundane/submodules/eclipse_paths_and_relevance.md
@@ -1,0 +1,102 @@
+# Eclipse Paths & Relevance (Submodule C-042)
+
+**Channels:** `ingest.besselian`, `ingest.validation`, `geospatial.centerline`,
+`geospatial.umbra`, `geospatial.penumbral`, `scoring.area`, `scoring.population`
+
+## Overview
+
+Captures solar and lunar eclipse geometries, stores them as PostGIS geometries,
+and computes impact scores for geopolitical entities based on spatial overlap and
+population exposure. All eclipse data must originate from published NASA GSFC
+Besselian element sets or internally computed Swiss Ephemeris solutions that can
+be cross-validated against Solar Fire reports.
+
+## Data Pipeline
+
+1. **Ingestion:** Accept JSON or CSV payloads containing Besselian elements,
+   eclipse classification, Saros series, and metadata. Each run records source
+   URLs, checksum, and curator.
+2. **Geometry Modeling:** Convert Besselian elements into geodesic centerlines
+   and polygons for umbra/penumbra footprints using WGS84. Densify polylines at
+   ≤1 km intervals to maintain fidelity.
+3. **Storage:** Persist geometries in `eclipse_geoms` with geography types.
+   Maintain indexes (`GIST`) and metadata for magnitude, duration, and maximum
+   eclipse coordinates.
+4. **Scoring:** Intersect geometries with entity polygons (version-aware) and
+   compute area overlap plus optional population-weighted impacts using raster
+   grids (GPW v4 or WorldPop). Scores are normalized (0–100) with component
+   breakdown stored in JSONB.
+
+## Channels & Subchannels
+
+### `ingest.besselian`
+
+* Parses NASA/IMCCE/USNO formatted element sets, validates timestamp continuity,
+  and stores raw elements in `eclipse_raw` table.
+* Supports batch ingestion via asynchronous jobs queued in Redis.
+
+### `ingest.validation`
+
+* Cross-checks computed centerline with published maximum eclipse coordinates.
+* Verifies polygon orientation and ensures umbra is contained within penumbra.
+* Emits validation reports stored in `eclipse_validation_log` referencing source
+  datasets.
+
+### `geospatial.centerline`
+
+* Generates centerline polylines with metadata (velocity, duration, magnitude).
+* Provides vector tiles via `ST_AsMVT` for dashboard overlay.
+
+### `geospatial.umbra` & `geospatial.penumbral`
+
+* Constructs polygon geometries for total/annular shadow and partial footprint.
+* Handles clipping against coastlines if required for rendering but preserves
+  full geometry for analysis.
+
+### `scoring.area`
+
+* Computes area-based impact scores using `ST_Area(ST_Intersection())` with
+  geography units (square meters). Normalizes by entity land area and centerline
+  proximity bonus.
+
+### `scoring.population`
+
+* Samples population rasters clipped to the intersected polygon, sums
+  inhabitants, and applies weighting factors for central path distance.
+* Supports caching of raster tiles (Cloud Optimized GeoTIFF) keyed by
+  `population:{dataset}:{tile_id}`.
+
+## APIs
+
+* `POST /mundane/eclipses/ingest` accepts dataset references and schedules
+  ingestion jobs.
+* `GET /mundane/eclipses?from=&to=&type=` returns metadata and availability of
+  geometries.
+* `GET /mundane/eclipses/{id}/impact` returns ordered impact scores by entity
+  version with breakdown of area vs. population components.
+
+## Data Governance
+
+* All Besselian datasets logged with DOI/URL, version, and Solar Fire cross-check
+  IDs.
+* Raster datasets stored under `datasets/population/` with metadata on resolution,
+  projection, and licensing.
+* Impact scores must include provenance: geometry version, population raster id,
+  scoring algorithm revision.
+
+## Testing & Validation
+
+* Unit tests confirm centerline remains within umbra polygon and endpoints match
+  published coordinates.
+* Regression tests compare scoring outputs against historical eclipses (e.g.,
+  2017-08-21 solar eclipse) with manually verified rankings.
+* Performance tests ensure scoring for ~250 entities completes within specified
+  budgets (≤300 ms area-only, ≤2 s population-weighted with cache warm).
+
+## Dependencies
+
+* Uses entity polygons and resolver from National Charts Registry & Historical
+  Geo-Temporal Mapping.
+* Requires PostGIS, GDAL, and rasterio for geospatial operations.
+* Integrates with dashboard overlays via vector tile export subchannel.
+

--- a/docs/module/mundane/submodules/historical_geo_temporal_mapping.md
+++ b/docs/module/mundane/submodules/historical_geo_temporal_mapping.md
@@ -1,0 +1,82 @@
+# Historical Geo-Temporal Mapping (Submodule C-044)
+
+**Channels:** `boundaries.versioning`, `boundaries.indexes`, `timezone.shim`,
+`timezone.overrides`, `resolver.point_in_time`
+
+## Overview
+
+Resolves latitude/longitude + datetime queries to the appropriate geopolitical
+entity version and timezone offset. Provides a best-effort timezone shim until
+the dedicated C10 Atlas & Timezone system is integrated, while documenting
+confidence levels and data gaps.
+
+## Boundary Management
+
+* `boundaries.versioning` maintains historical polygons (`entity_geoms`) with
+  `valid_from/valid_to` ranges aligned to registry versions.
+* Sources include CShapes, Natural Earth, and curated historical atlases. Each
+  dataset entry records license, edition, and transformation steps.
+* Geometry validation ensures polygons are non-self-intersecting and oriented
+  correctly (right-hand rule) in WGS84.
+* Stores simplified geometries (`geom_simplified`) for rendering while retaining
+  high-resolution shapes for analysis.
+
+## Indexing Strategy
+
+* `boundaries.indexes` builds spatial indexes (GIST) on both full and simplified
+  geometries.
+* Temporal indexing uses exclusion constraints to prevent overlapping validity
+  ranges for the same entity version.
+* Precomputes tiles via Tippecanoe/PMTiles for Streamlit map consumption; tile
+  manifests capture dataset version and bounding boxes.
+
+## Timezone Shim
+
+* `timezone.shim` loads IANA zoneinfo (including backzone) and exposes
+  `guess_tz(lat, lon, at)` returning tzid, UTC offset, and confidence.
+* Logs when lookups fall back to nearest-neighbor heuristics or Solar Fire
+  annotations.
+* `timezone.overrides` allows per-entity overrides stored in
+  `tz_overrides(entity_version_id, rules, confidence)` referencing published
+  historical timezone studies.
+
+## Resolver
+
+* `resolver.point_in_time` combines spatial and temporal lookups to return the
+  governing entity version, timezone guess, and confidence rating.
+* API `GET /mundane/georesolve?lat=&lon=&at=` returns entity version metadata,
+  timezone info, and data sources (polygon set, tz rule).
+* Provides fallbacks for oceanic locations with `entity_version_id = NULL` and
+  appropriate reason codes.
+
+## Data Integrity & Provenance
+
+* All boundary datasets documented under `datasets/boundaries/` with transformation
+  scripts (`scripts/mundane/boundaries_ingest.py`).
+* Timezone overrides cite primary sources (e.g., Shanks, Steffen) and include
+  scanned references when licensing permits.
+* Confidence scoring rubric ranges from `high` (direct dataset alignment) to
+  `low` (heuristic guess); stored alongside resolver responses.
+
+## Testing & Validation
+
+* Unit tests compare resolver results against known historical events (e.g.,
+  German reunification, USSR dissolution) ensuring correct entity version selection.
+* Timezone shim tests confirm offsets match IANA data post-1970 and degrade
+  gracefully with warnings for earlier periods.
+* Geometry validation tests run via GDAL/GEOS to guarantee topological integrity.
+
+## Performance Targets
+
+* Resolver queries should complete within 40 ms on warm cache.
+* Boundary ingestion pipelines must finish under 10 minutes per dataset with
+  validation enabled.
+
+## Integration Points
+
+* Shared entity version IDs with National Charts Registry.
+* Provides timezone hints and entity resolution to Eclipse, Outer Cycle, and
+  Dashboard submodules.
+* Exposes metrics (`mundane.geo.resolve_ms`, `mundane.tzshim.confidence`) for
+  observability dashboards.
+

--- a/docs/module/mundane/submodules/mundane_dashboard.md
+++ b/docs/module/mundane/submodules/mundane_dashboard.md
@@ -1,0 +1,68 @@
+# Mundane Dashboard (Submodule C-045)
+
+**Channels:** `ui.map`, `ui.timeline`, `ui.filters`, `exports.csv`, `exports.geojson`,
+`exports.png`, `tiles.vector`, `tiles.cache`
+
+## Overview
+
+Delivers the interactive Streamlit dashboard for mundane analytics. Combines map
+visualizations (pydeck/deck.gl) with timeline controls, filters, and export
+options. All overlays and exported datasets must originate from registry,
+eclipse, cycle, and geo-temporal submodules to preserve data fidelity.
+
+## UI Architecture
+
+* `ui.map` renders base tiles plus overlay layers (eclipse paths, entity
+  polygons, triggers). Fetches vector tiles from PostGIS or PMTiles via a FastAPI
+  endpoint secured with dataset version parameters.
+* `ui.timeline` offers a scrubber linked to the selected date/time; updates map
+  overlays and trigger lists in real time.
+* `ui.filters` expose toggles for bodies, aspect families, severity thresholds,
+  and population-weighted scoring. Filter states persist via URL query params for
+  reproducible sessions.
+
+## Export Channels
+
+* `exports.csv` streams table exports (entity triggers, registry versions,
+  eclipse impacts) with provenance columns (dataset IDs, source versions).
+* `exports.geojson` packages visible map features for GIS workflows; includes
+  CRS metadata (WGS84) and timestamp of export.
+* `exports.png` captures map snapshots using pydeck screenshot utilities; embeds
+  legend, timestamp, and dataset references.
+
+## Vector Tiles & Caching
+
+* `tiles.vector` generates `ST_AsMVT` tiles or serves PMTiles created via the
+  `make tiles` pipeline. Tiles include layer metadata (geometry type, dataset
+  version) in the MVT metadata block.
+* `tiles.cache` leverages Redis to cache rendered tiles and API responses keyed by
+  filter set, with invalidation hooks triggered on dataset updates.
+
+## Interactivity & Accessibility
+
+* Tooltips display entity name, chart confidence, eclipse score, and trigger
+  details with provenance links.
+* Keyboard navigation and high-contrast modes follow `docs/UI_CONVENTIONS.md`.
+* Provide fallback table view when WebGL is unavailable.
+
+## Observability
+
+* Emits structured logs for user interactions (layer toggles, exports) with
+  anonymized session IDs.
+* Collects performance metrics (`mundane.ui.render_ms`, `mundane.export.latency`).
+
+## Testing & QA
+
+* UI integration tests run via Streamlit component harness verifying map loading,
+  timeline synchronization, and export button functionality.
+* Snapshot tests validate PNG/GeoJSON outputs against golden datasets.
+* Accessibility checks (axe-core) ensure WCAG AA compliance for color/contrast.
+
+## Deployment Considerations
+
+* Streamlit app packaged under `ui_streamlit/mundane_app.py`; configured via
+  environment variables for API endpoint, tile server URL, and Redis cache.
+* Supports offline demo mode using cached MBTiles/PMTiles for workshop scenarios.
+* Documented runbook covers dataset refresh, cache warm-up, and export location
+  management.
+

--- a/docs/module/mundane/submodules/national_charts_registry.md
+++ b/docs/module/mundane/submodules/national_charts_registry.md
@@ -1,0 +1,113 @@
+# National Charts Registry (Submodule C-041)
+
+**Channels:** `registry.entities`, `registry.versions`, `registry.aliases`,
+`charts.resolver`, `charts.confidence`
+
+## Overview
+
+Implements the versioned mundane chart registry for geopolitical entities. Each
+entity can host multiple founding or reform moments, all sourced from verifiable
+records (Solar Fire exports, national archives, research monographs). The
+submodule ensures lossless provenance and supports time-aware resolution of the
+applicable chart for analytic scans.
+
+## Data Model & Storage
+
+* **PostgreSQL + PostGIS:** Primary store with schema:
+  * `entities` table capturing metadata, ISO codes, and canonical names.
+  * `entity_versions` table storing chart moments, coordinates, timezone hints,
+    source references, and validity intervals (`valid_from`, `valid_to`).
+  * `entity_aliases` table handling multilingual and historical names.
+  * `entity_geoms` (shared with geo-temporal submodule) linking versions to
+    historical polygons.
+* **Indexes:**
+  * B-tree on `entity_versions(entity_id, valid_from, valid_to)` for fast
+    temporal resolution.
+  * GIST on `entity_geoms.geom` (geography) for spatial lookup.
+  * GIN on `entities.iso_codes` for ISO/IOC searching.
+* **Provenance:**
+  * `source_refs` JSONB includes citation id, title, publication date, Solar Fire
+    export checksum, and curator contact.
+  * `confidence` integer (0–100) with rubric documented in appendix.
+
+## Channels & Subchannels
+
+### `registry.entities`
+
+* Upsert operations for entity metadata.
+* Validates ISO codes, ensures dataset references exist under
+  `registry/datasets/entities/` with checksums.
+
+### `registry.versions`
+
+* Handles creation of chart versions; enforces UTC timestamps and location
+  precision to at least 0.01 arcminutes.
+* Generates `tz_hint` using the historical timezone shim, recording source and
+  confidence.
+* Validates that Solar Fire or equivalent datasets provide natal chart exports
+  matching the event timestamp and location.
+
+### `registry.aliases`
+
+* Maintains alias ranges for search and historical labeling; prevents overlap
+  conflicts using exclusion constraints.
+
+### `charts.resolver`
+
+* `get_effective_chart(entity_id, at_datetime)` resolves the applicable version
+  based on `valid_from/valid_to` and returns chart metadata with provenance.
+* `resolve_entity(lat, lon, at_datetime)` delegates to the geo-temporal mapper to
+  determine the controlling entity version and returns registry metadata for
+  downstream analysis.
+
+### `charts.confidence`
+
+* Computes blended confidence scores combining source reliability, timezone
+  certainty, and alias clarity; surfaces in APIs and dashboard tooltips.
+
+## APIs
+
+* `POST /mundane/entities` (bulk upsert via JSONL referencing dataset IDs).
+* `GET /mundane/entities/search?q=` supporting text, ISO code, and alias lookup.
+* `POST /mundane/entities/{id}/versions` for curated submissions; enforces audit
+  trail via `registry_change_log` table.
+* `GET /mundane/entities/{id}/chart?at=` returning the resolved version, chart
+  metadata, `tz_hint`, and provenance bundle.
+
+## Data Governance
+
+* Required dataset manifests live under `registry/datasets/mundane_registry/` with
+  SHA256 checksums and last-verified timestamps.
+* Import scripts must reference Solar Fire export filenames and embed the
+  original timezone specification used in Solar Fire to avoid drift.
+* Any conflicting chart submissions require curatorial review; the API returns
+  `409 Conflict` with payload summarizing existing versions.
+
+## Indexing & Caching Strategy
+
+* Redis cache keyed by `entity:{id}:chart:{at_iso}` storing resolution results
+  (TTL 1 hour, invalidated on version updates).
+* Materialized view `entity_versions_active` for common `valid_to IS NULL`
+  lookups, refreshed on ingestion batches.
+
+## Testing & Validation
+
+* Unit tests ensure temporal resolution picks the highest-confidence version
+  when overlapping ranges exist.
+* Integration tests compare registry output with Solar Fire natal exports for
+  canonical countries (e.g., USA 1776-07-04 17:10 LMT).
+* Data quality checks verify every version has at least one source reference and
+  non-null geolocation.
+
+## Performance Budget
+
+* `GET /mundane/entities/search` must return top 20 results within 150 ms under
+  cached conditions.
+* `resolve_entity` should complete <50 ms for index-backed lookups.
+
+## Dependencies
+
+* Shares `entity_geoms` with Historical Geo-Temporal Mapping submodule.
+* Consumes timezone hints from the `timezone.shim` subchannel until C10 replaces
+  it via `tz_bridge` integration.
+

--- a/docs/module/mundane/submodules/outer_cycle_analytics.md
+++ b/docs/module/mundane/submodules/outer_cycle_analytics.md
@@ -1,0 +1,81 @@
+# Outer-Cycle Analytics (Submodule C-043)
+
+**Channels:** `cycles.pairs`, `cycles.search`, `ingresses.detection`,
+`ingresses.timeline`, `triggers.entity`, `triggers.severity`
+
+## Overview
+
+Extends the SPEC-0 aspect engines to deliver mundane-focused timelines for outer
+planet combinations (Saturn, Jupiter, Uranus, Neptune, Pluto). It documents
+cycle computations, ingress detection, and entity trigger sweeps, ensuring
+results can be reconciled against Solar Fire transits and authoritative
+almanacs.
+
+## Cycle Detection
+
+* `cycles.pairs` defines supported pairings, harmonic families, and default
+  aspect sets (conjunction, opposition, square, trine, sextile, semi-square,
+  sesquiquadrate).
+* `cycles.search` orchestrates calls into the dynamic aspect search engine,
+  streaming results into `outer_hits` table with metadata (severity, retrograde,
+  speed differentials).
+* Time ranges default to 1800–2200 but accept narrower windows per request.
+
+## Ingress Detection
+
+* `ingresses.detection` tracks sign changes for outer planets, capturing degree,
+  sign, motion direction, and station flags.
+* `ingresses.timeline` groups ingresses into sequences for visualization and
+  exports to CSV/GeoJSON.
+* All timestamps remain in UTC with fractional seconds when required.
+
+## Entity Trigger Sweeps
+
+* `triggers.entity` loops through entity charts (from the registry) and computes
+  aspects between transiting outers and key natal points (Sun, Moon, ASC, MC,
+  angles) within configured orbs.
+* `triggers.severity` assigns weights based on orb tightness, body significance,
+  and applying/separating status using SPEC-0 severity models.
+* Outputs stored in `entity_triggers` include event metadata, aspect, orb,
+  severity band, and provenance fields referencing the natal chart checksum.
+
+## APIs
+
+* `POST /mundane/cycles/search` accepts body pairs, aspect families, and time
+  range; returns job ID and later results via polling or websocket channel.
+* `POST /mundane/ingresses/search` accepts list of bodies and date range.
+* `POST /mundane/triggers/scan` ingests entity lists (or `all`) and scheduling
+  parameters, supporting resumable jobs via Redis queues.
+
+## Data Integrity
+
+* All calculations must reference the same ephemeris set as Solar Fire (Swiss
+  Ephemeris or NASA JPL) with recorded version and checksum.
+* Severity policies link to rulesets documented in `docs/module/core-transit-math.md`.
+* Each trigger stores `source_run_id`, ephemeris version, orb policy, and profile
+  ID to guarantee reproducibility.
+
+## Performance & Caching
+
+* Use incremental stepping with root-finding to converge on exact aspect times.
+* Cache repeated cycle searches per `(pair, aspects, range, policy)` key for 12
+  hours in Redis.
+* Batch entity triggers by timezone to reuse ephemeris sweeps, streaming results
+  to PostgreSQL via COPY for efficiency.
+
+## Testing & Validation
+
+* Unit tests assert conjunction/opposition sequences for Jupiter-Saturn match
+  published dates (e.g., 1842, 1861, …, 2020).
+* Integration tests compare ingress detection with Solar Fire exports for recent
+  outer planet sign changes.
+* Trigger regression harness cross-checks severity scores against curated Solar
+  Fire mundane reports.
+
+## Dependencies
+
+* Requires access to SPEC-0 dynamic aspect engine APIs.
+* Depends on National Charts Registry for natal chart metadata and Historical
+  Geo-Temporal Mapping for timezone verification.
+* Outputs consumed by Mundane Dashboard timeline overlays and CSV exports.
+


### PR DESCRIPTION
## Summary
- add a module-level SPEC-4 architecture document for the mundane engine
- document submodule channel layouts for registry, eclipse modeling, outer cycles, geo-temporal resolver, and dashboard
- capture data integrity, provenance, and performance guidance aligned with Solar Fire sourced datasets

## Testing
- not run (documentation changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d88afd0ac883248ce5b92efea70a38