### PR TITLE
Add Arabic Lots engine, API, and UI tooling

### DIFF
--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -9,12 +9,14 @@ _APP_INSTANCE: FastAPI | None = None
 
 
 def create_app() -> FastAPI:
+    from .routers import lots as lots_router
     from .routers import plus as plus_router
     from .routers import scan as scan_router
     from .routers import synastry as synastry_router
 
     app = FastAPI(title="AstroEngine API")
     app.include_router(plus_router.router)
+    app.include_router(lots_router.router, prefix="/v1", tags=["lots"])
     app.include_router(scan_router.router, prefix="/v1/scan", tags=["scan"])
     app.include_router(synastry_router.router, prefix="/v1/synastry", tags=["synastry"])
     return app
@@ -27,5 +29,7 @@ def get_app() -> FastAPI:
     return _APP_INSTANCE
 
 
-__all__ = ["create_app", "get_app"]
+app = get_app()
+
+__all__ = ["create_app", "get_app", "app"]
 

--- a/astroengine/api/routers/lots.py
+++ b/astroengine/api/routers/lots.py
@@ -1,0 +1,297 @@
+"""FastAPI router for Arabic Lots compilation and evaluation."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ...chart.natal import ChartLocation
+from ...engine.lots import (
+    ChartContext,
+    LotsProfile,
+    aspects_to_lots,
+    compile_program,
+    evaluate,
+    list_builtin_profiles,
+    load_custom_profiles,
+    parse_lot_defs,
+    save_custom_profile,
+)
+from ...engine.lots.dsl import CompiledProgram
+from ...engine.lots.events import scan_lot_events
+from ...ephemeris.adapter import EphemerisAdapter
+from ...scoring.policy import load_orb_policy
+
+router = APIRouter(prefix="/lots", tags=["lots"])
+
+
+class LotCompileRequest(BaseModel):
+    source: str = Field(..., description="DSL text defining lots")
+
+
+class LotCompileResponse(BaseModel):
+    order: list[str]
+    dependencies: dict[str, list[str]]
+
+
+class ChartPoint(BaseModel):
+    value: float
+
+
+class ChartInput(BaseModel):
+    positions: dict[str, float]
+    angles: dict[str, float] | None = None
+    is_day: bool | None = None
+    sun_altitude: float | None = None
+    moment: datetime | None = None
+    latitude: float | None = None
+    longitude: float | None = None
+    zodiac: str | None = None
+    ayanamsha: str | None = None
+    house_system: str | None = None
+
+
+class LotComputeRequest(BaseModel):
+    source: str | None = None
+    profile: str | None = Field(
+        None, description="Built-in tradition to load when source omitted"
+    )
+    chart: ChartInput
+
+
+class LotComputeResponse(BaseModel):
+    lots: dict[str, float]
+    metadata: dict[str, Any]
+
+
+class LotPresetPayload(BaseModel):
+    profile_id: str
+    name: str
+    description: str | None = None
+    source: str
+    zodiac: str = "tropical"
+    house_system: str = "Placidus"
+    policy_id: str = "standard"
+    ayanamsha: str | None = None
+    tradition: str | None = None
+    source_refs: dict[str, str] | None = None
+
+
+class AspectScanRequest(BaseModel):
+    lots: dict[str, float]
+    bodies: dict[str, float]
+    harmonics: list[int] = Field(default_factory=lambda: [1, 2, 3, 4, 6])
+    policy: dict[str, Any] | None = None
+
+
+class AspectScanResponse(BaseModel):
+    hits: list[dict[str, Any]]
+
+
+class EventScanRequest(BaseModel):
+    lot_name: str
+    lot_longitude: float
+    bodies: list[str]
+    start: datetime
+    end: datetime
+    harmonics: list[int] = Field(default_factory=lambda: [1, 2])
+    policy: dict[str, Any] | None = None
+    step_hours: float | None = None
+
+
+class EventScanResponse(BaseModel):
+    events: list[dict[str, Any]]
+
+
+def _resolve_program(source: str | None, profile: str | None) -> CompiledProgram:
+    if source:
+        program = parse_lot_defs(source)
+        return compile_program(program)
+    if profile:
+        builtins = {prof.tradition: prof for prof in list_builtin_profiles() if prof.tradition}
+        custom = load_custom_profiles()
+        if profile in builtins:
+            return builtins[profile].compile()
+        if profile in custom:
+            return custom[profile].compile()
+        raise HTTPException(status_code=404, detail="Unknown profile")
+    raise HTTPException(status_code=400, detail="Either source or profile must be provided")
+
+
+def _chart_context(payload: ChartInput) -> ChartContext:
+    location = None
+    if payload.latitude is not None and payload.longitude is not None:
+        location = ChartLocation(payload.latitude, payload.longitude)
+    return ChartContext(
+        moment=payload.moment,
+        location=location,
+        positions=payload.positions,
+        angles=payload.angles or {},
+        is_day_override=payload.is_day,
+        sun_altitude=payload.sun_altitude,
+        zodiac=payload.zodiac or "tropical",
+        ayanamsha=payload.ayanamsha,
+        house_system=payload.house_system,
+    )
+
+
+@router.post("/compile", response_model=LotCompileResponse)
+def compile_lots(request: LotCompileRequest) -> LotCompileResponse:
+    program = parse_lot_defs(request.source)
+    compiled = compile_program(program)
+    dependencies = {name: sorted(list(refs)) for name, refs in compiled.dependencies.items()}
+    return LotCompileResponse(order=list(compiled.order), dependencies=dependencies)
+
+
+@router.post("/compute", response_model=LotComputeResponse)
+def compute_lots(request: LotComputeRequest) -> LotComputeResponse:
+    compiled = _resolve_program(request.source, request.profile)
+    chart_ctx = _chart_context(request.chart)
+    values = evaluate(compiled, chart_ctx)
+    metadata = {
+        "zodiac": chart_ctx.zodiac,
+        "ayanamsha": chart_ctx.ayanamsha,
+        "house_system": chart_ctx.house_system,
+    }
+    return LotComputeResponse(lots=values, metadata=metadata)
+
+
+@router.get("/presets", response_model=list[dict[str, Any]])
+def list_presets() -> list[dict[str, Any]]:
+    presets = [
+        {
+            "profile_id": profile.profile_id,
+            "name": profile.name,
+            "description": profile.description,
+            "tradition": profile.tradition,
+            "zodiac": profile.zodiac,
+            "house_system": profile.house_system,
+            "expr_text": profile.expr_text,
+            "source_refs": profile.source_refs,
+        }
+        for profile in list_builtin_profiles()
+    ]
+    custom = load_custom_profiles()
+    for profile in custom.values():
+        presets.append(
+            {
+                "profile_id": profile.profile_id,
+                "name": profile.name,
+                "description": profile.description,
+                "tradition": profile.tradition,
+                "zodiac": profile.zodiac,
+                "house_system": profile.house_system,
+                "expr_text": profile.expr_text,
+                "source_refs": profile.source_refs,
+            }
+        )
+    return presets
+
+
+@router.post("/presets", response_model=dict)
+def save_preset(payload: LotPresetPayload) -> dict[str, Any]:
+    profile = LotsProfile(
+        profile_id=payload.profile_id,
+        name=payload.name,
+        description=payload.description or "",
+        zodiac=payload.zodiac,
+        house_system=payload.house_system,
+        policy_id=payload.policy_id,
+        expr_text=payload.source,
+        source_refs=payload.source_refs or {},
+        ayanamsha=payload.ayanamsha,
+        tradition=payload.tradition,
+    )
+    save_custom_profile(profile)
+    return {"status": "ok", "profile_id": profile.profile_id}
+
+
+@router.post("/aspects", response_model=AspectScanResponse)
+def scan_aspects(request: AspectScanRequest) -> AspectScanResponse:
+    policy = load_orb_policy(overrides=request.policy) if request.policy else load_orb_policy()
+    hits = aspects_to_lots(request.lots, request.bodies, policy, request.harmonics)
+    return AspectScanResponse(
+        hits=[
+            {
+                "body": hit.body,
+                "lot": hit.lot,
+                "angle": hit.angle,
+                "orb": hit.orb,
+                "separation": hit.separation,
+                "severity": hit.severity,
+                "applying": hit.applying,
+            }
+            for hit in hits
+        ]
+    )
+
+
+try:  # pragma: no cover - optional dependency
+    import swisseph as swe
+except Exception:  # pragma: no cover
+    swe = None
+
+
+_BODY_CODES = {
+    "sun": getattr(swe, "SUN", None) if swe is not None else None,
+    "moon": getattr(swe, "MOON", None) if swe is not None else None,
+    "mercury": getattr(swe, "MERCURY", None) if swe is not None else None,
+    "venus": getattr(swe, "VENUS", None) if swe is not None else None,
+    "mars": getattr(swe, "MARS", None) if swe is not None else None,
+    "jupiter": getattr(swe, "JUPITER", None) if swe is not None else None,
+    "saturn": getattr(swe, "SATURN", None) if swe is not None else None,
+    "uranus": getattr(swe, "URANUS", None) if swe is not None else None,
+    "neptune": getattr(swe, "NEPTUNE", None) if swe is not None else None,
+    "pluto": getattr(swe, "PLUTO", None) if swe is not None else None,
+}
+
+
+class _SwissEphemerisWrapper:
+    def __init__(self) -> None:
+        if swe is None:
+            raise HTTPException(
+                status_code=503,
+                detail="Swiss Ephemeris not available; install astroengine[ephem]",
+            )
+        self._adapter = EphemerisAdapter()
+
+    def sample(self, body: str, moment: datetime):
+        code = _BODY_CODES.get(body.lower())
+        if code is None:
+            raise HTTPException(status_code=404, detail=f"Unsupported body {body}")
+        return self._adapter.sample(code, moment)
+
+
+@router.post("/events", response_model=EventScanResponse)
+def scan_events(request: EventScanRequest) -> EventScanResponse:
+    policy = load_orb_policy(overrides=request.policy) if request.policy else load_orb_policy()
+    adapter = _SwissEphemerisWrapper()
+    events = scan_lot_events(
+        adapter,
+        request.lot_longitude,
+        request.bodies,
+        request.start,
+        request.end,
+        policy,
+        request.harmonics,
+        step_hours=request.step_hours or 12.0,
+        lot_name=request.lot_name,
+    )
+    return EventScanResponse(
+        events=[
+            {
+                "lot": event.lot,
+                "body": event.body,
+                "timestamp": event.timestamp.isoformat(),
+                "angle": event.angle,
+                "orb": event.orb,
+                "severity": event.severity,
+                "applying": event.applying,
+                "metadata": dict(event.metadata),
+            }
+            for event in events
+        ]
+    )

--- a/astroengine/engine/lots/__init__.py
+++ b/astroengine/engine/lots/__init__.py
@@ -1,0 +1,49 @@
+"""Arabic Lots engine with DSL compilation, evaluation, and event scanning."""
+
+from .builtins import LotsProfile, builtin_profile, list_builtin_profiles
+from .dsl import (
+    Add,
+    Arc,
+    Expr,
+    IfDay,
+    LotDef,
+    LotProgram,
+    Number,
+    Ref,
+    Sub,
+    Wrap,
+    compile_program,
+    detect_cycles,
+    parse_lot_defs,
+)
+from .eval import ChartContext, ChartLocation, evaluate
+from .aspects import AspectHit, aspects_to_lots
+from .events import LotEvent, scan_lot_events
+from .sect import is_day
+
+__all__ = [
+    "Add",
+    "Arc",
+    "AspectHit",
+    "ChartContext",
+    "ChartLocation",
+    "Expr",
+    "IfDay",
+    "LotDef",
+    "LotEvent",
+    "LotProgram",
+    "LotsProfile",
+    "Number",
+    "Ref",
+    "Sub",
+    "Wrap",
+    "aspects_to_lots",
+    "builtin_profile",
+    "compile_program",
+    "detect_cycles",
+    "evaluate",
+    "is_day",
+    "list_builtin_profiles",
+    "parse_lot_defs",
+    "scan_lot_events",
+]

--- a/astroengine/engine/lots/aspects.py
+++ b/astroengine/engine/lots/aspects.py
@@ -1,0 +1,153 @@
+"""Aspect utilities between planetary bodies and calculated Lots."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from ...scoring.policy import OrbPolicy
+
+__all__ = ["AspectHit", "aspects_to_lots"]
+
+
+@dataclass(frozen=True)
+class AspectHit:
+    body: str
+    lot: str
+    angle: float
+    orb: float
+    separation: float
+    severity: float
+    applying: bool | None
+
+
+def _get_longitude(value: object) -> float:
+    if isinstance(value, (int, float)):
+        return float(value) % 360.0
+    longitude = getattr(value, "longitude", None)
+    if longitude is None:
+        raise TypeError(f"Cannot resolve longitude from {value!r}")
+    return float(longitude) % 360.0
+
+
+def _get_speed(value: object) -> float | None:
+    speed = getattr(value, "speed_longitude", None)
+    if speed is None:
+        return None
+    try:
+        return float(speed)
+    except (TypeError, ValueError):
+        return None
+
+
+def _angular_separation(body: float, lot: float) -> float:
+    diff = (body - lot + 180.0) % 360.0 - 180.0
+    return diff
+
+
+def _resolve_orb(policy: OrbPolicy, body: str, angle: float) -> float:
+    data = policy.to_mapping()
+    per_body = data.get("per_body")
+    if isinstance(per_body, Mapping):
+        entry = per_body.get(body)
+        if isinstance(entry, Mapping):
+            angle_key = str(int(round(angle)))
+            if angle_key in entry:
+                try:
+                    return float(entry[angle_key])
+                except (TypeError, ValueError):
+                    pass
+            default = entry.get("default")
+            if default is not None:
+                try:
+                    return float(default)
+                except (TypeError, ValueError):
+                    pass
+        elif entry is not None:
+            try:
+                return float(entry)
+            except (TypeError, ValueError):
+                pass
+    defaults = data.get("defaults")
+    if isinstance(defaults, Mapping):
+        angle_key = str(int(round(angle)))
+        if angle_key in defaults:
+            try:
+                return float(defaults[angle_key])
+            except (TypeError, ValueError):
+                pass
+        default = defaults.get("default")
+        if default is not None:
+            try:
+                return float(default)
+            except (TypeError, ValueError):
+                pass
+    return 3.0
+
+
+def _angles_from_harmonics(harmonics: Iterable[int]) -> list[float]:
+    angles: set[float] = set()
+    for harmonic in harmonics:
+        if harmonic <= 0:
+            continue
+        base = 360.0 / float(harmonic)
+        limit = harmonic // 2
+        for k in range(0, limit + 1):
+            angle = round(base * k, 6)
+            if angle <= 180.0:
+                angles.add(angle)
+    return sorted(angles)
+
+
+def _severity(orb: float, allowance: float) -> float:
+    if allowance <= 0.0:
+        return 0.0
+    tightness = max(0.0, 1.0 - orb / allowance)
+    return round(tightness, 6)
+
+
+def aspects_to_lots(
+    lots: Mapping[str, float],
+    bodies_positions: Mapping[str, object],
+    policy: OrbPolicy,
+    harmonics: Iterable[int],
+) -> list[AspectHit]:
+    """Return aspect hits for ``bodies_positions`` relative to ``lots``."""
+
+    angles = _angles_from_harmonics(harmonics)
+    hits: list[AspectHit] = []
+    for body_name, value in bodies_positions.items():
+        body_long = _get_longitude(value)
+        body_speed = _get_speed(value)
+        for lot_name, lot_long in lots.items():
+            delta = _angular_separation(body_long, lot_long)
+            separation = abs(delta)
+            for angle in angles:
+                orb = abs(separation - angle)
+                allowance = _resolve_orb(policy, body_name, angle)
+                if orb <= allowance:
+                    applying: bool | None = None
+                    if body_speed is not None:
+                        target = angle if abs(delta - angle) <= abs(delta + angle) else -angle
+                        diff = delta - target
+                        if diff > 0:
+                            applying = body_speed < 0
+                        elif diff < 0:
+                            applying = body_speed > 0
+                        else:
+                            applying = None
+                    severity = _severity(orb, allowance)
+                    hits.append(
+                        AspectHit(
+                            body=body_name,
+                            lot=lot_name,
+                            angle=angle,
+                            orb=orb,
+                            separation=separation,
+                            severity=severity,
+                            applying=applying,
+                        )
+                    )
+                    break
+    return sorted(hits, key=lambda hit: (hit.lot, hit.body, hit.angle, hit.orb))

--- a/astroengine/engine/lots/builtins.py
+++ b/astroengine/engine/lots/builtins.py
@@ -1,0 +1,160 @@
+"""Built-in Arabic Lots profiles."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ...infrastructure.paths import registry_dir
+from .dsl import LotProgram, compile_program, parse_lot_defs
+
+__all__ = ["LotsProfile", "builtin_profile", "list_builtin_profiles", "load_custom_profiles", "save_custom_profile"]
+
+
+@dataclass(frozen=True)
+class LotsProfile:
+    profile_id: str
+    name: str
+    description: str
+    zodiac: str
+    house_system: str
+    policy_id: str
+    expr_text: str
+    source_refs: dict[str, str]
+    ayanamsha: str | None = None
+    tradition: str | None = None
+
+    def program(self) -> LotProgram:
+        return parse_lot_defs(self.expr_text)
+
+    def compile(self):
+        return compile_program(self.program())
+
+
+_HELLENISTIC_TEXT = """
+Fortune = if_day( ASC + arc(Moon, Sun), ASC + arc(Sun, Moon) )
+Spirit = if_day( ASC + arc(Sun, Moon), ASC + arc(Moon, Sun) )
+Eros = Fortune + arc(Venus, Spirit)
+Necessity = Fortune + arc(Saturn, Spirit)
+Courage = Fortune + arc(Mars, Spirit)
+Marriage = Fortune + arc(Venus, Moon)
+Children = Fortune + arc(Jupiter, Moon)
+Travel = Fortune + arc(Mercury, Spirit)
+""".strip()
+
+_MEDIEVAL_TEXT = """
+Fortune = if_day( ASC + arc(Moon, Sun), ASC + arc(Sun, Moon) )
+Spirit = if_day( ASC + arc(Sun, Moon), ASC + arc(Moon, Sun) )
+Eros = Fortune + arc(Venus, Spirit)
+Necessity = Fortune + arc(Saturn, Spirit)
+Courage = Fortune + arc(Mars, Spirit)
+Marriage = Fortune + arc(Venus, Sun)
+Children = Fortune + arc(Jupiter, Sun)
+Travel = Fortune + arc(Mercury, Sun)
+""".strip()
+
+_BUILTINS = {
+    "Hellenistic": LotsProfile(
+        profile_id="lots_hellenistic",
+        name="Hellenistic Core Lots",
+        description="Canonical Hermetic lots per Valens and Dorotheus with day/night branches.",
+        zodiac="tropical",
+        house_system="Placidus",
+        policy_id="standard",
+        expr_text=_HELLENISTIC_TEXT,
+        source_refs={
+            "Fortune": "Valens, Anthologies II",
+            "Spirit": "Valens, Anthologies II",
+            "Eros": "Valens, Anthologies IV",
+            "Necessity": "Valens, Anthologies IV",
+            "Courage": "Valens, Anthologies IV",
+            "Marriage": "Dorotheus, Carmen Astrologicum IV",
+            "Children": "Valens, Anthologies II",
+            "Travel": "Dorotheus, Carmen Astrologicum II",
+        },
+        tradition="Hellenistic",
+    ),
+    "Medieval": LotsProfile(
+        profile_id="lots_medieval",
+        name="Medieval Core Lots",
+        description="Lots adapted for medieval authors with solar references in nocturnal charts.",
+        zodiac="tropical",
+        house_system="Placidus",
+        policy_id="standard",
+        expr_text=_MEDIEVAL_TEXT,
+        source_refs={
+            "Fortune": "Abu Ma'shar, The Great Introduction VI",
+            "Spirit": "Abu Ma'shar, The Great Introduction VI",
+            "Eros": "Bonatti, Book of Astronomy X",
+            "Necessity": "Bonatti, Book of Astronomy X",
+            "Courage": "Bonatti, Book of Astronomy X",
+            "Marriage": "Abu Ma'shar, Great Introduction VIII",
+            "Children": "Abu Ma'shar, Great Introduction VIII",
+            "Travel": "Bonatti, Book of Astronomy IX",
+        },
+        tradition="Medieval",
+    ),
+}
+
+
+def list_builtin_profiles() -> list[LotsProfile]:
+    return list(_BUILTINS.values())
+
+
+def builtin_profile(tradition: Literal["Hellenistic", "Medieval"] = "Hellenistic") -> LotsProfile:
+    try:
+        return _BUILTINS[tradition]
+    except KeyError as exc:
+        raise ValueError(f"Unknown lots tradition: {tradition}") from exc
+
+
+_CUSTOM_PATH = registry_dir() / "lots_custom_profiles.json"
+
+
+def load_custom_profiles() -> dict[str, LotsProfile]:
+    if not _CUSTOM_PATH.exists():
+        return {}
+    data = _CUSTOM_PATH.read_text(encoding="utf-8")
+    import json
+
+    payload = json.loads(data)
+    profiles: dict[str, LotsProfile] = {}
+    for item in payload:
+        profile = LotsProfile(
+            profile_id=item["profile_id"],
+            name=item["name"],
+            description=item.get("description", ""),
+            zodiac=item.get("zodiac", "tropical"),
+            house_system=item.get("house_system", "Placidus"),
+            policy_id=item.get("policy_id", "standard"),
+            expr_text=item["expr_text"],
+            source_refs=item.get("source_refs", {}),
+            ayanamsha=item.get("ayanamsha"),
+            tradition=item.get("tradition"),
+        )
+        profiles[profile.profile_id] = profile
+    return profiles
+
+
+def save_custom_profile(profile: LotsProfile) -> None:
+    import json
+
+    profiles = load_custom_profiles()
+    profiles[profile.profile_id] = profile
+    payload = [
+        {
+            "profile_id": item.profile_id,
+            "name": item.name,
+            "description": item.description,
+            "zodiac": item.zodiac,
+            "house_system": item.house_system,
+            "policy_id": item.policy_id,
+            "expr_text": item.expr_text,
+            "source_refs": item.source_refs,
+            "ayanamsha": item.ayanamsha,
+            "tradition": item.tradition,
+        }
+        for item in profiles.values()
+    ]
+    _CUSTOM_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _CUSTOM_PATH.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")

--- a/astroengine/engine/lots/dsl.py
+++ b/astroengine/engine/lots/dsl.py
@@ -1,0 +1,360 @@
+"""Domain specific language for Arabic Lots expressions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator, Sequence
+
+__all__ = [
+    "Add",
+    "Arc",
+    "CompiledProgram",
+    "Expr",
+    "IfDay",
+    "LotDef",
+    "LotProgram",
+    "Number",
+    "Ref",
+    "Sub",
+    "Wrap",
+    "compile_program",
+    "detect_cycles",
+    "parse_lot_defs",
+]
+
+
+@dataclass(frozen=True)
+class Expr:
+    """Base class for expression nodes."""
+
+
+@dataclass(frozen=True)
+class Number(Expr):
+    value: float
+
+
+@dataclass(frozen=True)
+class Ref(Expr):
+    name: str
+
+
+@dataclass(frozen=True)
+class Add(Expr):
+    left: Expr
+    right: Expr
+
+
+@dataclass(frozen=True)
+class Sub(Expr):
+    left: Expr
+    right: Expr
+
+
+@dataclass(frozen=True)
+class Arc(Expr):
+    first: Expr
+    second: Expr
+
+
+@dataclass(frozen=True)
+class Wrap(Expr):
+    value: Expr
+
+
+@dataclass(frozen=True)
+class IfDay(Expr):
+    day_expr: Expr
+    night_expr: Expr
+
+
+@dataclass(frozen=True)
+class LotDef:
+    name: str
+    expr: Expr
+
+
+@dataclass(frozen=True)
+class LotProgram:
+    definitions: Sequence[LotDef]
+
+    def names(self) -> list[str]:
+        return [definition.name for definition in self.definitions]
+
+
+@dataclass(frozen=True)
+class CompiledProgram:
+    definitions: dict[str, Expr]
+    order: Sequence[str]
+    dependencies: dict[str, set[str]]
+
+
+class _Token:
+    __slots__ = ("kind", "value")
+
+    def __init__(self, kind: str, value: str):
+        self.kind = kind
+        self.value = value
+
+    def __repr__(self) -> str:  # pragma: no cover - debug helper
+        return f"Token({self.kind!r}, {self.value!r})"
+
+
+_KEYWORDS = {"arc", "wrap", "if_day", "deg", "mean"}
+_WHITESPACE = {" ", "\t", "\r", "\n"}
+
+
+class _Tokenizer:
+    def __init__(self, text: str) -> None:
+        self._text = text
+        self._length = len(text)
+        self._index = 0
+
+    def __iter__(self) -> Iterator[_Token]:
+        while True:
+            token = self._next_token()
+            if token is None:
+                break
+            yield token
+
+    def _next_token(self) -> _Token | None:
+        self._skip_whitespace()
+        if self._index >= self._length:
+            return None
+        char = self._text[self._index]
+        if char.isalpha() or char == "_":
+            return self._identifier()
+        if char.isdigit() or char == ".":
+            return self._number()
+        self._index += 1
+        if char in "+-(),=":
+            return _Token(char, char)
+        raise ValueError(f"Unexpected character: {char!r}")
+
+    def _skip_whitespace(self) -> None:
+        while self._index < self._length and self._text[self._index] in _WHITESPACE:
+            self._index += 1
+
+    def _identifier(self) -> _Token:
+        start = self._index
+        self._index += 1
+        while (
+            self._index < self._length
+            and (self._text[self._index].isalnum() or self._text[self._index] == "_")
+        ):
+            self._index += 1
+        value = self._text[start : self._index]
+        return _Token("IDENT", value)
+
+    def _number(self) -> _Token:
+        start = self._index
+        dot_seen = False
+        while self._index < self._length:
+            char = self._text[self._index]
+            if char == ".":
+                if dot_seen:
+                    break
+                dot_seen = True
+            elif not char.isdigit():
+                break
+            self._index += 1
+        value = self._text[start : self._index]
+        return _Token("NUMBER", value)
+
+
+class _Parser:
+    def __init__(self, tokens: Iterable[_Token]):
+        self._tokens = list(tokens)
+        self._position = 0
+        self._length = len(self._tokens)
+
+    def parse(self) -> LotProgram:
+        definitions: list[LotDef] = []
+        while not self._at_end:
+            definition = self._definition()
+            definitions.append(definition)
+        return LotProgram(tuple(definitions))
+
+    @property
+    def _at_end(self) -> bool:
+        return self._position >= self._length
+
+    def _peek(self) -> _Token | None:
+        if self._position < self._length:
+            return self._tokens[self._position]
+        return None
+
+    def _consume(self, expected: str | None = None) -> _Token:
+        if self._position >= self._length:
+            raise ValueError("Unexpected end of input")
+        token = self._tokens[self._position]
+        if expected is not None and token.kind != expected and token.value != expected:
+            raise ValueError(f"Expected {expected!r} but found {token.value!r}")
+        self._position += 1
+        return token
+
+    def _definition(self) -> LotDef:
+        name_token = self._consume("IDENT")
+        self._consume("=")
+        expr = self._expression()
+        return LotDef(name_token.value, expr)
+
+    def _expression(self) -> Expr:
+        node = self._term()
+        while True:
+            token = self._peek()
+            if token is None or token.value not in {"+", "-"}:
+                break
+            op = token.value
+            self._consume()
+            right = self._term()
+            if op == "+":
+                node = Add(node, right)
+            else:
+                node = Sub(node, right)
+        return node
+
+    def _term(self) -> Expr:
+        token = self._peek()
+        if token is None:
+            raise ValueError("Unexpected end of input")
+        if token.kind == "NUMBER":
+            self._consume()
+            return Number(float(token.value))
+        if token.kind == "IDENT":
+            self._consume()
+            if token.value in _KEYWORDS:
+                return self._function(token.value)
+            return Ref(token.value)
+        if token.value == "(":
+            self._consume()
+            expr = self._expression()
+            self._consume(")")
+            return expr
+        raise ValueError(f"Unexpected token {token.value!r}")
+
+    def _function(self, name: str) -> Expr:
+        if name == "deg":
+            self._consume("(")
+            value = self._expression()
+            self._consume(")")
+            return value
+        if name == "arc":
+            self._consume("(")
+            first = self._expression()
+            self._consume(",")
+            second = self._expression()
+            self._consume(")")
+            return Arc(first, second)
+        if name == "wrap":
+            self._consume("(")
+            inner = self._expression()
+            self._consume(")")
+            return Wrap(inner)
+        if name == "if_day":
+            self._consume("(")
+            day_expr = self._expression()
+            self._consume(",")
+            night_expr = self._expression()
+            self._consume(")")
+            return IfDay(day_expr, night_expr)
+        if name == "mean":
+            raise ValueError("mean() is not supported in this implementation")
+        raise ValueError(f"Unsupported function {name!r}")
+
+
+def parse_lot_defs(text: str) -> LotProgram:
+    """Parse ``text`` into a :class:`LotProgram`."""
+
+    tokens = _Tokenizer(text)
+    parser = _Parser(tokens)
+    return parser.parse()
+
+
+def _references(expr: Expr) -> set[str]:
+    if isinstance(expr, Ref):
+        return {expr.name}
+    if isinstance(expr, Number):
+        return set()
+    if isinstance(expr, Add):
+        return _references(expr.left) | _references(expr.right)
+    if isinstance(expr, Sub):
+        return _references(expr.left) | _references(expr.right)
+    if isinstance(expr, Arc):
+        return _references(expr.first) | _references(expr.second)
+    if isinstance(expr, Wrap):
+        return _references(expr.value)
+    if isinstance(expr, IfDay):
+        return _references(expr.day_expr) | _references(expr.night_expr)
+    raise TypeError(f"Unsupported expression node {type(expr)!r}")
+
+
+def detect_cycles(program: LotProgram) -> list[list[str]]:
+    """Return dependency cycles detected in ``program``."""
+
+    dependencies: dict[str, set[str]] = {}
+    defined = set(program.names())
+    for definition in program.definitions:
+        refs = {ref for ref in _references(definition.expr) if ref in defined}
+        dependencies[definition.name] = refs
+
+    cycles: list[list[str]] = []
+    temp: set[str] = set()
+    perm: set[str] = set()
+    stack: list[str] = []
+
+    def visit(name: str) -> None:
+        if name in perm:
+            return
+        if name in temp:
+            cycle_start = stack.index(name)
+            cycles.append(stack[cycle_start:] + [name])
+            return
+        temp.add(name)
+        stack.append(name)
+        for dep in dependencies.get(name, set()):
+            visit(dep)
+        temp.remove(name)
+        perm.add(name)
+        stack.pop()
+
+    for name in program.names():
+        visit(name)
+
+    return cycles
+
+
+def compile_program(program: LotProgram) -> CompiledProgram:
+    """Compile ``program`` into a topologically sorted representation."""
+
+    seen: set[str] = set()
+    order: list[str] = []
+    dependencies: dict[str, set[str]] = {}
+    defined = {definition.name for definition in program.definitions}
+
+    for definition in program.definitions:
+        if definition.name in seen:
+            raise ValueError(f"Duplicate lot definition: {definition.name}")
+        seen.add(definition.name)
+        refs = {ref for ref in _references(definition.expr) if ref in defined}
+        dependencies[definition.name] = refs
+
+    cycles = detect_cycles(program)
+    if cycles:
+        raise ValueError(f"Cyclic dependencies detected: {cycles}")
+
+    remaining = set(seen)
+    resolved: set[str] = set()
+    while remaining:
+        progress = False
+        for name in list(remaining):
+            deps = dependencies[name]
+            if deps.issubset(resolved):
+                order.append(name)
+                resolved.add(name)
+                remaining.remove(name)
+                progress = True
+        if not progress:
+            raise ValueError("Cannot resolve dependency order")
+
+    definitions = {definition.name: definition.expr for definition in program.definitions}
+    return CompiledProgram(definitions, tuple(order), dependencies)

--- a/astroengine/engine/lots/eval.py
+++ b/astroengine/engine/lots/eval.py
@@ -1,0 +1,119 @@
+"""Evaluation of compiled Arabic Lots programs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Mapping, MutableMapping
+
+from ...chart.natal import ChartLocation
+from .dsl import (
+    Add,
+    Arc,
+    CompiledProgram,
+    Expr,
+    IfDay,
+    LotProgram,
+    Number,
+    Ref,
+    Sub,
+    Wrap,
+    compile_program,
+    parse_lot_defs,
+)
+from .sect import GeoLocation, is_day as _is_day
+
+__all__ = [
+    "ChartContext",
+    "ChartLocation",
+    "evaluate",
+    "prepare_program",
+]
+
+
+@dataclass(frozen=True)
+class ChartContext:
+    """Context required to evaluate Arabic Lots."""
+
+    moment: datetime | None
+    location: ChartLocation | None
+    positions: Mapping[str, float]
+    angles: Mapping[str, float] = field(default_factory=dict)
+    is_day_override: bool | None = None
+    sun_altitude: float | None = None
+    zodiac: str = "tropical"
+    ayanamsha: str | None = None
+    house_system: str | None = None
+
+    def get_point(self, name: str) -> float:
+        key = name.strip()
+        if key in self.positions:
+            return float(self.positions[key]) % 360.0
+        if key in self.angles:
+            return float(self.angles[key]) % 360.0
+        raise KeyError(f"Unknown point: {name}")
+
+    def is_day(self) -> bool:
+        if self.is_day_override is not None:
+            return bool(self.is_day_override)
+        if self.moment is None or self.location is None:
+            raise ValueError("moment and location are required for sect determination")
+        geo = GeoLocation(self.location.latitude, self.location.longitude)
+        return _is_day(self.moment, geo, sun_altitude=self.sun_altitude)
+
+
+def prepare_program(text: str | LotProgram | CompiledProgram) -> CompiledProgram:
+    if isinstance(text, CompiledProgram):
+        return text
+    if isinstance(text, LotProgram):
+        return compile_program(text)
+    program = parse_lot_defs(text)
+    return compile_program(program)
+
+
+def _wrap(value: float) -> float:
+    return value % 360.0
+
+
+def _arc(first: float, second: float) -> float:
+    return (first - second) % 360.0
+
+
+def _evaluate_expr(
+    expr: Expr,
+    ctx: ChartContext,
+    results: MutableMapping[str, float],
+) -> float:
+    if isinstance(expr, Number):
+        return _wrap(expr.value)
+    if isinstance(expr, Ref):
+        name = expr.name
+        if name in results:
+            return results[name]
+        return ctx.get_point(name)
+    if isinstance(expr, Add):
+        return _wrap(_evaluate_expr(expr.left, ctx, results) + _evaluate_expr(expr.right, ctx, results))
+    if isinstance(expr, Sub):
+        return _wrap(_evaluate_expr(expr.left, ctx, results) - _evaluate_expr(expr.right, ctx, results))
+    if isinstance(expr, Arc):
+        return _arc(
+            _evaluate_expr(expr.first, ctx, results),
+            _evaluate_expr(expr.second, ctx, results),
+        )
+    if isinstance(expr, Wrap):
+        return _wrap(_evaluate_expr(expr.value, ctx, results))
+    if isinstance(expr, IfDay):
+        branch = expr.day_expr if ctx.is_day() else expr.night_expr
+        return _wrap(_evaluate_expr(branch, ctx, results))
+    raise TypeError(f"Unsupported expression {expr!r}")
+
+
+def evaluate(program: CompiledProgram, chart: ChartContext) -> dict[str, float]:
+    """Evaluate ``program`` returning normalized lot positions."""
+
+    results: dict[str, float] = {}
+    for name in program.order:
+        expr = program.definitions[name]
+        value = _evaluate_expr(expr, chart, results)
+        results[name] = _wrap(value)
+    return results

--- a/astroengine/engine/lots/events.py
+++ b/astroengine/engine/lots/events.py
@@ -1,0 +1,150 @@
+"""Event scanning for Arabic Lots aspects."""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from ...scoring.policy import OrbPolicy
+from .aspects import _angles_from_harmonics, _resolve_orb, _severity
+
+__all__ = ["LotEvent", "scan_lot_events"]
+
+
+@dataclass(frozen=True)
+class LotEvent:
+    lot: str
+    body: str
+    kind: str
+    timestamp: _dt.datetime
+    angle: float
+    orb: float
+    severity: float
+    applying: bool | None
+    metadata: Mapping[str, object]
+
+
+def _get_longitude(ephem: object, body: str, moment: _dt.datetime) -> tuple[float, float | None]:
+    if hasattr(ephem, "longitude"):
+        lon = getattr(ephem, "longitude")(body, moment)
+        return float(lon) % 360.0, None
+    if hasattr(ephem, "sample"):
+        sample = getattr(ephem, "sample")(body, moment)
+        longitude = getattr(sample, "longitude")
+        speed = getattr(sample, "speed_longitude", None)
+        return float(longitude) % 360.0, float(speed) if speed is not None else None
+    raise TypeError("Ephemeris adapter must expose 'longitude' or 'sample'")
+
+
+def _angular_separation(body: float, lot: float) -> float:
+    return (body - lot + 180.0) % 360.0 - 180.0
+
+
+def _bisect(
+    ephem: object,
+    body: str,
+    lot: float,
+    target: float,
+    start: _dt.datetime,
+    end: _dt.datetime,
+    *,
+    iterations: int = 12,
+) -> _dt.datetime:
+    low = start
+    high = end
+    for _ in range(iterations):
+        mid = low + (high - low) / 2
+        body_low, _ = _get_longitude(ephem, body, low)
+        body_mid, _ = _get_longitude(ephem, body, mid)
+        diff_low = _angular_separation(body_low, lot) - target
+        diff_mid = _angular_separation(body_mid, lot) - target
+        if diff_low == 0.0:
+            return low
+        if diff_mid == 0.0:
+            return mid
+        if diff_low * diff_mid <= 0:
+            high = mid
+        else:
+            low = mid
+    return low + (high - low) / 2
+
+
+def _event_metadata(angle: float, harmonic: int) -> dict[str, object]:
+    return {"aspect_angle": angle, "harmonic": harmonic}
+
+
+def scan_lot_events(
+    ephem: object,
+    lot_lambda: float,
+    bodies: Iterable[str],
+    t0: _dt.datetime,
+    t1: _dt.datetime,
+    policy: OrbPolicy,
+    harmonics: Iterable[int],
+    *,
+    kind: str = "transit",
+    step_hours: float = 12.0,
+    lot_name: str = "Lot",
+) -> list[LotEvent]:
+    """Scan ``bodies`` for aspect hits to a single lot between ``t0`` and ``t1``."""
+
+    if t1 <= t0:
+        return []
+    angles = _angles_from_harmonics(harmonics)
+    step = _dt.timedelta(hours=max(0.1, float(step_hours)))
+    lot_lambda = lot_lambda % 360.0
+
+    events: list[LotEvent] = []
+    for body in bodies:
+        current = t0
+        body_val, body_speed = _get_longitude(ephem, body, current)
+        for angle in angles:
+            allowance = _resolve_orb(policy, body, angle)
+            target = angle if abs(_angular_separation(body_val, lot_lambda) - angle) <= abs(_angular_separation(body_val, lot_lambda) + angle) else -angle
+            diff_prev = _angular_separation(body_val, lot_lambda) - target
+            while current <= t1:
+                next_time = min(current + step, t1)
+                body_next, _ = _get_longitude(ephem, body, next_time)
+                diff_next = _angular_separation(body_next, lot_lambda) - target
+                if diff_prev == 0.0:
+                    root = current
+                elif diff_prev * diff_next <= 0.0:
+                    root = _bisect(ephem, body, lot_lambda, target, current, next_time)
+                else:
+                    root = None
+                if root is not None:
+                    body_root, body_speed = _get_longitude(ephem, body, root)
+                    separation = abs(_angular_separation(body_root, lot_lambda))
+                    orb = abs(separation - angle)
+                    if orb <= allowance:
+                        severity = _severity(orb, allowance)
+                        applying: bool | None = None
+                        if body_speed is not None:
+                            delta = _angular_separation(body_root, lot_lambda)
+                            target = angle if abs(delta - angle) <= abs(delta + angle) else -angle
+                            diff = delta - target
+                            if diff > 0:
+                                applying = body_speed < 0
+                            elif diff < 0:
+                                applying = body_speed > 0
+                        events.append(
+                            LotEvent(
+                                lot=lot_name,
+                                body=body,
+                                kind=kind,
+                                timestamp=root,
+                                angle=angle,
+                                orb=orb,
+                                severity=severity,
+                                applying=applying,
+                                metadata=_event_metadata(angle, int(round(360 / angle)) if angle else 0),
+                            )
+                        )
+                    diff_prev = diff_next
+                else:
+                    diff_prev = diff_next
+                current = next_time
+                body_val = body_next
+    events.sort(key=lambda event: event.timestamp)
+    return events

--- a/astroengine/engine/lots/sect.py
+++ b/astroengine/engine/lots/sect.py
@@ -1,0 +1,102 @@
+"""Sect determination helpers for Arabic Lots evaluation."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import math
+from dataclasses import dataclass
+
+__all__ = ["GeoLocation", "is_day"]
+
+
+@dataclass(frozen=True)
+class GeoLocation:
+    """Simple latitude/longitude container used for sect checks."""
+
+    latitude: float
+    longitude: float
+    elevation: float = 0.0
+
+
+def _to_utc(moment: _dt.datetime) -> _dt.datetime:
+    if moment.tzinfo is None:
+        raise ValueError("datetime must be timezone-aware for sect determination")
+    return moment.astimezone(_dt.timezone.utc)
+
+
+def _julian_day(moment: _dt.datetime) -> float:
+    utc = _to_utc(moment)
+    year = utc.year
+    month = utc.month
+    day = utc.day + (utc.hour + utc.minute / 60.0 + utc.second / 3600.0) / 24.0
+    if month <= 2:
+        year -= 1
+        month += 12
+    a = math.floor(year / 100)
+    b = 2 - a + math.floor(a / 4)
+    jd = math.floor(365.25 * (year + 4716))
+    jd += math.floor(30.6001 * (month + 1))
+    jd += day + b - 1524.5
+    return jd
+
+
+def _solar_declination(jd: float) -> float:
+    t = (jd - 2451545.0) / 36525.0
+    mean_long = math.radians((280.46646 + 36000.76983 * t) % 360.0)
+    mean_anom = math.radians((357.52911 + 35999.05029 * t) % 360.0)
+    ecliptic_long = mean_long + math.radians(1.914602 - 0.004817 * t) * math.sin(mean_anom)
+    ecliptic_long += math.radians(0.019993 - 0.000101 * t) * math.sin(2 * mean_anom)
+    obliquity = math.radians(23.439291 - 0.0130042 * t)
+    return math.asin(math.sin(obliquity) * math.sin(ecliptic_long))
+
+
+def _equation_of_time(jd: float) -> float:
+    t = (jd - 2451545.0) / 36525.0
+    epsilon = math.radians(23.439291 - 0.0130042 * t)
+    l0 = math.radians((280.46646 + 36000.76983 * t) % 360.0)
+    e = 0.016708634 - 0.000042037 * t
+    m = math.radians((357.52911 + 35999.05029 * t) % 360.0)
+    y = math.tan(epsilon / 2.0) ** 2
+    sin2l0 = math.sin(2 * l0)
+    sinm = math.sin(m)
+    cos2l0 = math.cos(2 * l0)
+    sin4l0 = math.sin(4 * l0)
+    sin2m = math.sin(2 * m)
+    return (
+        y * sin2l0
+        - 2 * e * sinm
+        + 4 * e * y * sinm * cos2l0
+        - 0.5 * y * y * sin4l0
+        - 1.25 * e * e * sin2m
+    ) * (180.0 / math.pi) * 4.0
+
+
+def _solar_altitude(moment: _dt.datetime, location: GeoLocation) -> float:
+    jd = _julian_day(moment)
+    decl = _solar_declination(jd)
+    eq_time = _equation_of_time(jd)
+    utc = _to_utc(moment)
+    minutes = utc.hour * 60 + utc.minute + utc.second / 60.0
+    true_solar_time = (minutes + eq_time + 4 * location.longitude) % 1440
+    hour_angle = true_solar_time / 4.0 - 180.0
+    if hour_angle < -180.0:
+        hour_angle += 360.0
+    ha_rad = math.radians(hour_angle)
+    lat_rad = math.radians(location.latitude)
+    sin_alt = math.sin(lat_rad) * math.sin(decl) + math.cos(lat_rad) * math.cos(decl) * math.cos(ha_rad)
+    sin_alt = max(-1.0, min(1.0, sin_alt))
+    return math.degrees(math.asin(sin_alt))
+
+
+def is_day(
+    moment: _dt.datetime,
+    location: GeoLocation,
+    *,
+    sun_altitude: float | None = None,
+) -> bool:
+    """Return ``True`` when the chart is diurnal at ``moment`` and ``location``."""
+
+    if sun_altitude is not None:
+        return sun_altitude > 0.0
+    altitude = _solar_altitude(moment, location)
+    return altitude > 0.0

--- a/streamlit/lots_app.py
+++ b/streamlit/lots_app.py
@@ -1,0 +1,226 @@
+"""Streamlit UI for building and exploring Arabic Lots."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import streamlit as st
+
+from astroengine.engine.lots import (
+    ChartContext,
+    ChartLocation,
+    aspects_to_lots,
+    builtin_profile,
+    compile_program,
+    evaluate,
+    list_builtin_profiles,
+    load_custom_profiles,
+    parse_lot_defs,
+    save_custom_profile,
+    scan_lot_events,
+)
+from astroengine.scoring.policy import load_orb_policy
+
+try:  # pragma: no cover - optional dependency
+    from astroengine.api.routers.lots import _SwissEphemerisWrapper as SwissWrapper
+    HAVE_SWE = True
+except Exception:  # pragma: no cover
+    SwissWrapper = None
+    HAVE_SWE = False
+
+st.set_page_config(page_title="Arabic Lots Builder", layout="wide")
+st.title("Arabic Lots Builder")
+
+DEFAULT_DSL = builtin_profile("Hellenistic").expr_text
+
+if "lots_dsl" not in st.session_state:
+    st.session_state["lots_dsl"] = DEFAULT_DSL
+if "compiled_program" not in st.session_state:
+    st.session_state["compiled_program"] = compile_program(parse_lot_defs(DEFAULT_DSL))
+if "lot_results" not in st.session_state:
+    st.session_state["lot_results"] = {}
+
+builder_tab, presets_tab, aspects_tab, events_tab = st.tabs(
+    ["Builder", "Presets", "Aspects", "Events"]
+)
+
+
+with builder_tab:
+    st.subheader("Lot Definitions")
+    source = st.text_area(
+        "Lots DSL",
+        st.session_state["lots_dsl"],
+        height=220,
+        help="Define lots using the arc/wrap/if_day DSL",
+    )
+    compile_col, eval_col = st.columns(2)
+    with compile_col:
+        if st.button("Compile", key="compile_button"):
+            try:
+                program = compile_program(parse_lot_defs(source))
+            except Exception as exc:  # pragma: no cover - user feedback
+                st.error(f"Compilation failed: {exc}")
+            else:
+                st.success("Program compiled")
+                st.session_state["compiled_program"] = program
+                st.session_state["lots_dsl"] = source
+    with eval_col:
+        positions_json = st.text_area(
+            "Chart Positions (JSON)",
+            json.dumps({"Sun": 120.0, "Moon": 15.0, "ASC": 100.0}, indent=2),
+            height=220,
+        )
+        is_day = st.selectbox("Sect", ["Auto", "Day", "Night"], index=0)
+        latitude = st.number_input("Latitude", value=0.0)
+        longitude = st.number_input("Longitude", value=0.0)
+        moment = st.text_input(
+            "Moment (ISO UTC)",
+            value=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        )
+        if st.button("Evaluate", key="eval_button"):
+            try:
+                positions = json.loads(positions_json)
+                moment_dt = datetime.fromisoformat(moment.replace("Z", "+00:00"))
+                location = ChartLocation(latitude, longitude)
+                ctx = ChartContext(
+                    moment=moment_dt,
+                    location=location,
+                    positions=positions,
+                    is_day_override=(
+                        True if is_day == "Day" else False if is_day == "Night" else None
+                    ),
+                )
+                results = evaluate(st.session_state["compiled_program"], ctx)
+            except Exception as exc:  # pragma: no cover - user feedback
+                st.error(f"Evaluation failed: {exc}")
+            else:
+                st.session_state["lot_results"] = results
+                st.success("Lots computed")
+                st.json(results)
+
+
+with presets_tab:
+    st.subheader("Built-in Profiles")
+    builtin_cols = st.columns(2)
+    for idx, profile in enumerate(list_builtin_profiles()):
+        col = builtin_cols[idx % 2]
+        with col:
+            st.markdown(f"**{profile.name}**")
+            st.caption(profile.description)
+            if st.button(f"Load {profile.tradition}", key=f"load_{profile.profile_id}"):
+                st.session_state["lots_dsl"] = profile.expr_text
+                st.session_state["compiled_program"] = profile.compile()
+                st.experimental_rerun()
+    st.divider()
+    st.subheader("Custom Presets")
+    custom_profiles = load_custom_profiles()
+    if custom_profiles:
+        for profile in custom_profiles.values():
+            with st.expander(profile.name):
+                st.code(profile.expr_text)
+    with st.form("save_preset_form"):
+        st.write("Save current DSL as preset")
+        pid = st.text_input("Profile ID", value="user_profile")
+        name = st.text_input("Name", value="Custom Lots")
+        description = st.text_area("Description", value="User defined lots")
+        if st.form_submit_button("Save Preset"):
+            profile = builtin_profile("Hellenistic")
+            from astroengine.engine.lots import LotsProfile
+
+            new_profile = LotsProfile(
+                profile_id=pid,
+                name=name,
+                description=description,
+                zodiac=profile.zodiac,
+                house_system=profile.house_system,
+                policy_id=profile.policy_id,
+                expr_text=st.session_state["lots_dsl"],
+                source_refs={},
+                ayanamsha=profile.ayanamsha,
+                tradition="Custom",
+            )
+            save_custom_profile(new_profile)
+            st.success("Preset saved")
+
+
+with aspects_tab:
+    st.subheader("Aspects to Lots")
+    lots = st.session_state.get("lot_results", {})
+    if not lots:
+        st.info("Compute lots on the Builder tab to enable aspect analysis.")
+    else:
+        bodies_json = st.text_area(
+            "Body Positions (JSON)",
+            json.dumps({"Mars": 45.0, "Venus": 210.0}, indent=2),
+            height=180,
+        )
+        harmonics = st.multiselect(
+            "Harmonics", [1, 2, 3, 4, 6, 8, 12], default=[1, 2, 3, 4]
+        )
+        if st.button("Compute Aspects", key="aspect_button"):
+            try:
+                bodies = json.loads(bodies_json)
+                policy = load_orb_policy()
+                hits = aspects_to_lots(lots, bodies, policy, harmonics)
+            except Exception as exc:  # pragma: no cover - user feedback
+                st.error(f"Aspect computation failed: {exc}")
+            else:
+                if not hits:
+                    st.info("No aspects found within orb allowances.")
+                else:
+                    for hit in hits:
+                        st.write(
+                            f"{hit.body} → {hit.lot} at {hit.angle:.1f}° (orb {hit.orb:.2f}°)"
+                        )
+
+
+with events_tab:
+    st.subheader("Transit Events")
+    if not HAVE_SWE:
+        st.warning("Swiss Ephemeris not available; install astroengine[ephem] for event scanning.")
+    else:
+        lot_name = st.text_input("Lot Name", value="Fortune")
+        lot_value = st.number_input(
+            "Lot Longitude", value=float(st.session_state.get("lot_results", {}).get(lot_name, 0.0))
+        )
+        bodies = st.multiselect(
+            "Bodies",
+            ["Sun", "Moon", "Mercury", "Venus", "Mars", "Jupiter", "Saturn"],
+            default=["Sun", "Mars"],
+        )
+        start = st.text_input(
+            "Start (ISO UTC)", value=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        )
+        end = st.text_input(
+            "End (ISO UTC)",
+            value=(datetime.now(timezone.utc).replace(hour=0, minute=0, second=0) + timedelta(days=30)).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            ),
+        )
+        harmonics = st.multiselect("Harmonics", [1, 2, 3, 4, 6], default=[1, 2])
+        step = st.slider("Step Hours", min_value=1.0, max_value=24.0, value=12.0)
+        if st.button("Scan Events", key="event_button"):
+            try:
+                adapter = SwissWrapper()
+                events = scan_lot_events(
+                    adapter,
+                    lot_value,
+                    bodies,
+                    datetime.fromisoformat(start.replace("Z", "+00:00")),
+                    datetime.fromisoformat(end.replace("Z", "+00:00")),
+                    load_orb_policy(),
+                    harmonics,
+                    step_hours=step,
+                    lot_name=lot_name,
+                )
+            except Exception as exc:  # pragma: no cover - user feedback
+                st.error(f"Event scan failed: {exc}")
+            else:
+                if not events:
+                    st.info("No events detected in interval.")
+                else:
+                    for event in events:
+                        st.write(
+                            f"{event.timestamp.isoformat()} — {event.body} {event.angle:.1f}° {event.lot} (severity {event.severity:.2f})"
+                        )

--- a/tests/test_aspects_events.py
+++ b/tests/test_aspects_events.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timedelta, timezone
+
+from astroengine.engine.lots import aspects_to_lots, scan_lot_events
+from astroengine.engine.lots.aspects import AspectHit
+from astroengine.engine.lots.events import LotEvent
+from astroengine.scoring.policy import OrbPolicy
+
+
+def _policy(default: float = 5.0) -> OrbPolicy:
+    return OrbPolicy({"defaults": {"default": default}})
+
+
+def test_aspects_detection():
+    lots = {"Fortune": 100.0}
+    bodies = {"Mars": 100.5}
+    hits = aspects_to_lots(lots, bodies, _policy(), [1])
+    assert hits, "expected conjunction"
+    hit = hits[0]
+    assert isinstance(hit, AspectHit)
+    assert hit.angle == 0.0
+    assert hit.orb == 0.5
+    assert hit.severity > 0
+
+
+class LinearEphemeris:
+    def __init__(self, start: datetime, base: float, speed: float) -> None:
+        self.start = start
+        self.base = base
+        self.speed = speed
+
+    class Sample:
+        def __init__(self, longitude: float, speed_longitude: float) -> None:
+            self.longitude = longitude
+            self.speed_longitude = speed_longitude
+
+    def sample(self, body: str, moment: datetime):
+        delta_days = (moment - self.start).total_seconds() / 86400.0
+        longitude = (self.base + self.speed * delta_days) % 360.0
+        return self.Sample(longitude, self.speed)
+
+
+def test_event_scan_linear_motion():
+    start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    ephem = LinearEphemeris(start, base=0.0, speed=1.0)
+    lot_lambda = 10.0
+    events = scan_lot_events(
+        ephem,
+        lot_lambda,
+        ["Mars"],
+        start,
+        start + timedelta(days=20),
+        _policy(),
+        [1],
+        step_hours=12.0,
+        lot_name="Fortune",
+    )
+    assert events, "expected conjunction event"
+    event = events[0]
+    assert isinstance(event, LotEvent)
+    assert abs(event.angle - 0.0) < 1e-6
+    assert event.timestamp >= start + timedelta(days=9)
+    assert event.timestamp <= start + timedelta(days=11)

--- a/tests/test_cycle_detection.py
+++ b/tests/test_cycle_detection.py
@@ -1,0 +1,21 @@
+import pytest
+
+from astroengine.engine.lots import compile_program, detect_cycles, parse_lot_defs
+
+
+def test_detects_simple_cycle():
+    program = parse_lot_defs("A = B\nB = A")
+    cycles = detect_cycles(program)
+    assert cycles, "cycle should be detected"
+
+
+def test_compile_raises_on_cycle():
+    program = parse_lot_defs("A = B\nB = A")
+    with pytest.raises(ValueError):
+        compile_program(program)
+
+
+def test_compile_resolves_acyclic():
+    program = parse_lot_defs("A = B\nB = Sun")
+    compiled = compile_program(program)
+    assert list(compiled.order) == ["B", "A"]

--- a/tests/test_dsl_parse.py
+++ b/tests/test_dsl_parse.py
@@ -1,0 +1,45 @@
+from astroengine.engine.lots import (
+    Add,
+    Arc,
+    IfDay,
+    LotDef,
+    Number,
+    Ref,
+    Sub,
+    parse_lot_defs,
+)
+
+
+def test_parse_simple_expression():
+    program = parse_lot_defs("Fortune = ASC + arc(Moon, Sun)")
+    assert len(program.definitions) == 1
+    fortune = program.definitions[0]
+    assert isinstance(fortune, LotDef)
+    assert fortune.name == "Fortune"
+    assert isinstance(fortune.expr, Add)
+
+
+def test_parse_nested_if_day():
+    program = parse_lot_defs(
+        "Spirit = if_day(ASC + arc(Sun, Moon), ASC + arc(Moon, Sun))"
+    )
+    spirit = program.definitions[0]
+    assert isinstance(spirit.expr, IfDay)
+    assert isinstance(spirit.expr.day_expr, Add)
+    assert isinstance(spirit.expr.day_expr.right, Arc)
+    assert isinstance(spirit.expr.night_expr, Add)
+
+
+def test_parse_subtraction():
+    program = parse_lot_defs("Lot = Moon - Sun - ASC")
+    expr = program.definitions[0].expr
+    assert isinstance(expr, Sub)
+    assert isinstance(expr.left, Sub)
+    assert isinstance(expr.right, Ref)
+
+
+def test_parse_number_literal():
+    program = parse_lot_defs("Test = 15.5")
+    expr = program.definitions[0].expr
+    assert isinstance(expr, Number)
+    assert expr.value == 15.5

--- a/tests/test_eval_fortune_spirit.py
+++ b/tests/test_eval_fortune_spirit.py
@@ -1,0 +1,52 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from astroengine.engine.lots import ChartContext, ChartLocation, builtin_profile, evaluate
+
+
+def _chart_context(positions: dict[str, float], *, is_day: bool) -> ChartContext:
+    location = ChartLocation(latitude=0.0, longitude=0.0)
+    return ChartContext(
+        moment=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        location=location,
+        positions=positions,
+        angles={"ASC": positions["ASC"]},
+        is_day_override=is_day,
+    )
+
+
+def test_fortune_day_formula():
+    profile = builtin_profile("Hellenistic").compile()
+    positions = {
+        "Sun": 100.0,
+        "Moon": 10.0,
+        "ASC": 50.0,
+        "Mercury": 30.0,
+        "Venus": 80.0,
+        "Mars": 150.0,
+        "Jupiter": 200.0,
+        "Saturn": 250.0,
+    }
+    ctx = _chart_context(positions, is_day=True)
+    values = evaluate(profile, ctx)
+    assert pytest.approx(values["Fortune"], rel=1e-6) == 320.0
+    assert pytest.approx(values["Spirit"], rel=1e-6) == 140.0
+
+
+def test_fortune_night_formula():
+    profile = builtin_profile("Hellenistic").compile()
+    positions = {
+        "Sun": 100.0,
+        "Moon": 10.0,
+        "ASC": 50.0,
+        "Mercury": 30.0,
+        "Venus": 80.0,
+        "Mars": 150.0,
+        "Jupiter": 200.0,
+        "Saturn": 250.0,
+    }
+    ctx = _chart_context(positions, is_day=False)
+    values = evaluate(profile, ctx)
+    assert pytest.approx(values["Fortune"], rel=1e-6) == 140.0
+    assert pytest.approx(values["Spirit"], rel=1e-6) == 320.0

--- a/tests/test_is_day.py
+++ b/tests/test_is_day.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from astroengine.engine.lots.sect import GeoLocation, is_day
+
+
+def test_is_day_equator_noon():
+    moment = datetime(2023, 6, 21, 12, 0, tzinfo=timezone.utc)
+    location = GeoLocation(latitude=0.0, longitude=0.0)
+    assert is_day(moment, location)
+
+
+def test_is_day_equator_midnight():
+    moment = datetime(2023, 6, 21, 0, 0, tzinfo=timezone.utc)
+    location = GeoLocation(latitude=0.0, longitude=0.0)
+    assert not is_day(moment, location)
+
+
+def test_is_day_with_override_altitude():
+    moment = datetime(2023, 6, 21, 0, 0, tzinfo=timezone.utc)
+    location = GeoLocation(latitude=0.0, longitude=0.0)
+    assert is_day(moment, location, sun_altitude=5.0)
+    assert not is_day(moment, location, sun_altitude=-1.0)
+
+
+def test_requires_timezone():
+    naive = datetime(2023, 6, 21, 12, 0)
+    location = GeoLocation(latitude=0.0, longitude=0.0)
+    with pytest.raises(ValueError):
+        is_day(naive, location)


### PR DESCRIPTION
## Summary
- implement a dedicated `astroengine.engine.lots` package with DSL parsing, compilation, evaluation, built-in profiles, aspect scoring, and event scanning helpers
- expose new /lots endpoints via FastAPI and add a Streamlit lot builder UI with preset management and aspect/event tools
- add unit tests covering DSL parsing, cycle detection, evaluation, sect resolution, and aspect/event scanning helpers

## Testing
- `pytest tests/test_dsl_parse.py tests/test_cycle_detection.py tests/test_eval_fortune_spirit.py tests/test_is_day.py tests/test_aspects_events.py`


------
https://chatgpt.com/codex/tasks/task_e_68d88c08a99483249c143bc4557ec09d