### PR TITLE
Add traditional timing engines and lab

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -198,6 +198,19 @@ class SeverityProfile(ModuleScopeMixin, TimestampMixin, Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
+
+class TraditionalRun(ModuleScopeMixin, TimestampMixin, Base):
+    """Persisted payloads for traditional engine runs."""
+
+    __tablename__ = "traditional_runs"
+    __table_args__ = _table_args(Index("ix_traditional_runs_kind", "kind"))
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    run_id: Mapped[str] = mapped_column(String(40), nullable=False, unique=True, default=_uuid_hex)
+    kind: Mapped[str] = mapped_column(String(40), nullable=False)
+    inputs: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    result: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+
     name: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
 
     weights: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)

--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -12,11 +12,13 @@ def create_app() -> FastAPI:
     from .routers import plus as plus_router
     from .routers import scan as scan_router
     from .routers import synastry as synastry_router
+    from .routers import traditional as traditional_router
 
     app = FastAPI(title="AstroEngine API")
     app.include_router(plus_router.router)
     app.include_router(scan_router.router, prefix="/v1/scan", tags=["scan"])
     app.include_router(synastry_router.router, prefix="/v1/synastry", tags=["synastry"])
+    app.include_router(traditional_router.router)
     return app
 
 

--- a/astroengine/api/routers/__init__.py
+++ b/astroengine/api/routers/__init__.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__all__ = ["plus", "scan", "synastry"]
+__all__ = ["plus", "scan", "synastry", "traditional"]

--- a/astroengine/api/routers/traditional.py
+++ b/astroengine/api/routers/traditional.py
@@ -1,0 +1,228 @@
+"""FastAPI router exposing traditional timing engines."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+
+from ...chart.natal import ChartLocation, NatalChart, compute_natal_chart
+from core.lots_plus.catalog import Sect as LotSect
+from core.lots_plus.catalog import compute_lots
+from ...engine.traditional import (
+    Interval,
+    apply_loosing_of_bond,
+    build_chart_context,
+    find_alcocoden,
+    find_hyleg,
+    flag_peaks_fortune,
+    load_traditional_profiles,
+    profection_year_segments,
+    sect_info,
+    zr_periods,
+)
+from ...engine.traditional.models import LifeProfile
+from ...engine.traditional.zr import SIGN_ORDER
+from ..schemas_traditional import (
+    AlcocodenOut,
+    LifeMetadata,
+    LifeRequest,
+    LifeResponse,
+    ProfectionSegmentOut,
+    ProfectionsRequest,
+    ProfectionsResponse,
+    SectRequest,
+    SectResponse,
+    TraditionalChartInput,
+    ZodiacalPeriodOut,
+    ZodiacalReleasingRequest,
+    ZodiacalReleasingResponse,
+)
+
+router = APIRouter(prefix="/v1/traditional", tags=["traditional"])
+
+
+def _chart_location(data: TraditionalChartInput) -> ChartLocation:
+    return ChartLocation(latitude=float(data.latitude), longitude=float(data.longitude))
+
+
+def _lot_sect(sect: bool) -> str:
+    return LotSect.DAY if sect else LotSect.NIGHT
+
+
+def _lot_positions(chart: NatalChart) -> dict[str, float]:
+    positions = {name: pos.longitude for name, pos in chart.positions.items()}
+    positions["Asc"] = chart.houses.ascendant
+    return positions
+
+
+def _fortune_sign(lot_degree: float | None) -> str | None:
+    if lot_degree is None:
+        return None
+    index = int(lot_degree % 360.0 // 30.0)
+    return SIGN_ORDER[index]
+
+
+def _build_context(data: TraditionalChartInput) -> ChartCtx:
+    moment = data.moment
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise ValueError("Moment must be timezone-aware")
+    location = _chart_location(data)
+    chart = compute_natal_chart(moment, location)
+    sect = sect_info(moment, location)
+    lots = compute_lots(["Fortune", "Spirit"], _lot_positions(chart), _lot_sect(sect.is_day))
+    return build_chart_context(chart=chart, sect=sect, lots=lots, house_system=data.house_system or "whole_sign")
+
+
+def _segment_to_response(segment: Any) -> ProfectionSegmentOut:
+    return ProfectionSegmentOut(
+        start=segment.start.astimezone(UTC),
+        end=segment.end.astimezone(UTC),
+        house=segment.house,
+        sign=segment.sign,
+        year_lord=segment.year_lord,
+        co_rulers=dict(segment.co_rulers),
+        notes=list(segment.notes),
+    )
+
+
+@router.post("/profections", response_model=ProfectionsResponse)
+def api_profections(request: ProfectionsRequest) -> ProfectionsResponse:
+    try:
+        ctx = _build_context(request.natal)
+        interval = Interval(start=request.start.astimezone(UTC), end=request.end.astimezone(UTC))
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    segments = profection_year_segments(ctx, interval, mode=request.mode)
+    payload = [_segment_to_response(seg) for seg in segments]
+    return ProfectionsResponse(
+        segments=payload,
+        meta={
+            "count": len(payload),
+            "mode": request.mode,
+            "house_system": ctx.house_system,
+        },
+    )
+
+
+def _period_to_response(period: Any) -> ZodiacalPeriodOut:
+    metadata = dict(period.metadata)
+    return ZodiacalPeriodOut(
+        level=period.level,
+        start=period.start.astimezone(UTC),
+        end=period.end.astimezone(UTC),
+        sign=period.sign,
+        ruler=period.ruler,
+        lb=bool(period.lb),
+        lb_from=period.lb_from,
+        lb_to=period.lb_to,
+        metadata=metadata or None,
+    )
+
+
+@router.post("/zr", response_model=ZodiacalReleasingResponse)
+def api_zodiacal_releasing(request: ZodiacalReleasingRequest) -> ZodiacalReleasingResponse:
+    try:
+        ctx = _build_context(request.natal)
+        timeline = zr_periods(
+            request.lot_sign,
+            request.start.astimezone(UTC),
+            request.end.astimezone(UTC),
+            levels=request.levels,
+            source=request.source,
+        )
+        timeline = apply_loosing_of_bond(timeline)
+        fortune_sign = _fortune_sign(ctx.lot("Fortune"))
+        if request.include_peaks and fortune_sign:
+            flag_peaks_fortune(timeline, fortune_sign)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    levels_payload: dict[str, list[ZodiacalPeriodOut]] = {}
+    for level, periods in timeline.levels.items():
+        levels_payload[str(level)] = [_period_to_response(period) for period in periods]
+    return ZodiacalReleasingResponse(
+        levels=levels_payload,
+        lot=timeline.lot,
+        source=request.source,
+        meta={"levels": request.levels},
+    )
+
+
+@router.post("/sect", response_model=SectResponse)
+def api_sect(request: SectRequest) -> SectResponse:
+    moment = request.moment
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise HTTPException(status_code=400, detail="moment must be timezone-aware")
+    info = sect_info(
+        moment,
+        ChartLocation(latitude=request.latitude, longitude=request.longitude),
+    )
+    return SectResponse(
+        is_day=info.is_day,
+        luminary_of_sect=info.luminary_of_sect,
+        malefic_of_sect=info.malefic_of_sect,
+        benefic_of_sect=info.benefic_of_sect,
+        sun_altitude_deg=info.sun_altitude_deg,
+    )
+
+
+def _life_metadata(result: Any) -> LifeMetadata:
+    trace = []
+    for entry in result.trace:
+        if isinstance(entry, tuple) and len(entry) == 2:
+            trace.append({"factor": entry[0], "score": entry[1]})
+        else:
+            trace.append(entry)
+    return LifeMetadata(
+        body=result.body,
+        degree=float(result.degree),
+        sign=result.sign,
+        house=int(result.house),
+        score=float(result.score) if getattr(result, "score", None) is not None else None,
+        notes=list(result.notes),
+        trace=trace,
+    )
+
+
+def _alcocoden_metadata(result: Any) -> AlcocodenOut:
+    years = None
+    if result.indicative_years is not None:
+        years = {
+            "minor": result.indicative_years.minor_years,
+            "mean": result.indicative_years.mean_years,
+            "major": result.indicative_years.major_years,
+        }
+    return AlcocodenOut(
+        body=result.body,
+        method=result.method,
+        indicative_years=years,
+        confidence=float(result.confidence),
+        notes=list(result.notes),
+        trace=list(result.trace),
+    )
+
+
+@router.post("/life", response_model=LifeResponse)
+def api_life(request: LifeRequest) -> LifeResponse:
+    profiles = load_traditional_profiles()
+    profile: LifeProfile = profiles["life"]["profile"]
+    profile = LifeProfile(
+        house_candidates=profile.house_candidates,
+        include_fortune=request.include_fortune,
+        dignity_weights=profile.dignity_weights,
+        lifespan_years=profile.lifespan_years,
+        bounds_scheme=profile.bounds_scheme,
+        notes=profile.notes,
+    )
+    try:
+        ctx = _build_context(request.natal)
+        hyleg = find_hyleg(ctx, profile)
+        alcocoden = find_alcocoden(ctx, hyleg, profile)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return LifeResponse(
+        hyleg=_life_metadata(hyleg),
+        alcocoden=_alcocoden_metadata(alcocoden),
+        meta={"include_fortune": request.include_fortune},
+    )

--- a/astroengine/api/schemas_traditional.py
+++ b/astroengine/api/schemas_traditional.py
@@ -1,0 +1,123 @@
+"""Pydantic schemas for the traditional timing API."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+__all__ = [
+    "LifeMetadata",
+    "LifeRequest",
+    "LifeResponse",
+    "ProfectionsRequest",
+    "ProfectionsResponse",
+    "SectRequest",
+    "SectResponse",
+    "TraditionalChartInput",
+    "ZodiacalReleasingRequest",
+    "ZodiacalReleasingResponse",
+]
+
+
+class TraditionalChartInput(BaseModel):
+    moment: datetime = Field(..., description="Birth moment in ISO-8601")
+    latitude: float = Field(..., ge=-90.0, le=90.0)
+    longitude: float = Field(..., ge=-180.0, le=180.0)
+    house_system: str | None = Field(None, description="Requested house system")
+
+
+class ProfectionSegmentOut(BaseModel):
+    start: datetime
+    end: datetime
+    house: int
+    sign: str
+    year_lord: str
+    co_rulers: dict[str, Any]
+    notes: list[str]
+
+
+class ProfectionsRequest(BaseModel):
+    natal: TraditionalChartInput
+    start: datetime
+    end: datetime
+    mode: Literal["hellenistic", "medieval"] = "hellenistic"
+
+
+class ProfectionsResponse(BaseModel):
+    segments: list[ProfectionSegmentOut]
+    meta: dict[str, Any]
+
+
+class ZodiacalPeriodOut(BaseModel):
+    level: int
+    start: datetime
+    end: datetime
+    sign: str
+    ruler: str
+    lb: bool = False
+    lb_from: str | None = None
+    lb_to: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ZodiacalReleasingRequest(BaseModel):
+    natal: TraditionalChartInput
+    lot_sign: str
+    start: datetime
+    end: datetime
+    levels: int = 2
+    source: Literal["Spirit", "Fortune"] = "Spirit"
+    include_peaks: bool = True
+
+
+class ZodiacalReleasingResponse(BaseModel):
+    levels: dict[str, list[ZodiacalPeriodOut]]
+    lot: str
+    source: str
+    meta: dict[str, Any]
+
+
+class SectRequest(BaseModel):
+    moment: datetime
+    latitude: float
+    longitude: float
+
+
+class SectResponse(BaseModel):
+    is_day: bool
+    luminary_of_sect: str
+    malefic_of_sect: str
+    benefic_of_sect: str
+    sun_altitude_deg: float
+
+
+class LifeRequest(BaseModel):
+    natal: TraditionalChartInput
+    include_fortune: bool = False
+
+
+class LifeMetadata(BaseModel):
+    body: str
+    degree: float
+    sign: str
+    house: int
+    score: float | None = None
+    notes: list[str]
+    trace: list[Any]
+
+
+class AlcocodenOut(BaseModel):
+    body: str
+    method: str
+    indicative_years: dict[str, int] | None = None
+    confidence: float
+    notes: list[str]
+    trace: list[str]
+
+
+class LifeResponse(BaseModel):
+    hyleg: LifeMetadata
+    alcocoden: AlcocodenOut
+    meta: dict[str, Any]

--- a/astroengine/engine/traditional/__init__.py
+++ b/astroengine/engine/traditional/__init__.py
@@ -1,0 +1,45 @@
+"""Traditional Hellenistic and Medieval timing engines."""
+
+from .models import (
+    AlcocodenResult,
+    ChartCtx,
+    GeoLocation,
+    HylegResult,
+    Interval,
+    LifeProfile,
+    ProfectionSegment,
+    ProfectionState,
+    SectInfo,
+    ZRPeriod,
+    ZRTimeline,
+    build_chart_context,
+)
+from .profections import current_profection, profection_year_segments
+from .zr import apply_loosing_of_bond, flag_peaks_fortune, zr_periods
+from .sect import sect_info
+from .life_lengths import find_alcocoden, find_hyleg
+from .profiles import load_traditional_profiles
+
+__all__ = [
+    "AlcocodenResult",
+    "ChartCtx",
+    "GeoLocation",
+    "HylegResult",
+    "Interval",
+    "LifeProfile",
+    "ProfectionSegment",
+    "ProfectionState",
+    "SectInfo",
+    "ZRPeriod",
+    "ZRTimeline",
+    "apply_loosing_of_bond",
+    "build_chart_context",
+    "current_profection",
+    "find_alcocoden",
+    "find_hyleg",
+    "flag_peaks_fortune",
+    "load_traditional_profiles",
+    "profection_year_segments",
+    "sect_info",
+    "zr_periods",
+]

--- a/astroengine/engine/traditional/dignities.py
+++ b/astroengine/engine/traditional/dignities.py
@@ -1,0 +1,121 @@
+"""Helper utilities for loading traditional dignity tables."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable
+
+from ...scoring.dignity import DignityRecord, load_dignities
+
+__all__ = [
+    "DignitySpan",
+    "SignDignities",
+    "bounds_ruler",
+    "face_ruler",
+    "sign_dignities",
+]
+
+
+@dataclass(frozen=True)
+class DignitySpan:
+    ruler: str
+    start_deg: float | None
+    end_deg: float | None
+
+    def contains(self, degree: float) -> bool:
+        if self.start_deg is None or self.end_deg is None:
+            return False
+        return float(self.start_deg) <= degree < float(self.end_deg)
+
+
+@dataclass(frozen=True)
+class SignDignities:
+    sign: str
+    exaltation: str | None
+    triplicity_day: str | None
+    triplicity_night: str | None
+    triplicity_participating: str | None
+    bounds: tuple[DignitySpan, ...]
+    decans: tuple[DignitySpan, ...]
+
+    def bounds_ruler(self, degree: float) -> str | None:
+        for span in self.bounds:
+            if span.contains(degree):
+                return span.ruler
+        return None
+
+    def face_ruler(self, degree: float) -> str | None:
+        for span in self.decans:
+            if span.contains(degree):
+                return span.ruler
+        return None
+
+    def triplicity_for_sect(self, sect: str) -> str | None:
+        sect_lower = sect.lower()
+        if sect_lower == "day":
+            return self.triplicity_day or self.triplicity_participating
+        if sect_lower == "night":
+            return self.triplicity_night or self.triplicity_participating
+        return self.triplicity_participating
+
+
+def _iter_records(sign: str) -> Iterable[DignityRecord]:
+    for record in load_dignities():
+        if record.sign == sign:
+            yield record
+
+
+@lru_cache(maxsize=32)
+def sign_dignities(sign: str) -> SignDignities:
+    sign_lower = sign.lower()
+    exaltation: str | None = None
+    triplicity_day: str | None = None
+    triplicity_night: str | None = None
+    triplicity_participating: str | None = None
+    bounds: list[DignitySpan] = []
+    decans: list[DignitySpan] = []
+    for record in _iter_records(sign_lower):
+        if record.dignity_type == "exaltation":
+            exaltation = record.planet
+        elif record.dignity_type == "triplicity_day":
+            triplicity_day = record.planet
+        elif record.dignity_type == "triplicity_night":
+            triplicity_night = record.planet
+        elif record.dignity_type == "triplicity_participating":
+            triplicity_participating = record.planet
+        elif record.dignity_type == "bounds_egyptian":
+            bounds.append(
+                DignitySpan(
+                    ruler=record.planet,
+                    start_deg=record.start_deg,
+                    end_deg=record.end_deg,
+                )
+            )
+        elif record.dignity_type == "decans_chaldean":
+            decans.append(
+                DignitySpan(
+                    ruler=record.planet,
+                    start_deg=record.start_deg,
+                    end_deg=record.end_deg,
+                )
+            )
+    bounds_sorted = tuple(sorted(bounds, key=lambda span: span.start_deg or 0.0))
+    decans_sorted = tuple(sorted(decans, key=lambda span: span.start_deg or 0.0))
+    return SignDignities(
+        sign=sign_lower,
+        exaltation=exaltation,
+        triplicity_day=triplicity_day,
+        triplicity_night=triplicity_night,
+        triplicity_participating=triplicity_participating,
+        bounds=bounds_sorted,
+        decans=decans_sorted,
+    )
+
+
+def bounds_ruler(sign: str, degree: float) -> str | None:
+    return sign_dignities(sign).bounds_ruler(degree)
+
+
+def face_ruler(sign: str, degree: float) -> str | None:
+    return sign_dignities(sign).face_ruler(degree)

--- a/astroengine/engine/traditional/life_lengths.py
+++ b/astroengine/engine/traditional/life_lengths.py
@@ -1,0 +1,220 @@
+"""Resolve Hyleg and Alcocoden according to traditional heuristics."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..traditional.dignities import bounds_ruler, sign_dignities
+from ..traditional.models import AlcocodenResult, ChartCtx, HylegResult, LifeProfile
+from ..traditional.profections import SIGN_RULERS
+
+__all__ = ["find_hyleg", "find_alcocoden"]
+
+SIGN_SEQUENCE = (
+    "aries",
+    "taurus",
+    "gemini",
+    "cancer",
+    "leo",
+    "virgo",
+    "libra",
+    "scorpio",
+    "sagittarius",
+    "capricorn",
+    "aquarius",
+    "pisces",
+)
+
+
+def _sign_from_degree(degree: float) -> str:
+    index = int(degree % 360.0 // 30.0)
+    return SIGN_SEQUENCE[index]
+
+
+def _house_from_degree(asc_degree: float, degree: float) -> int:
+    asc_index = int(asc_degree % 360.0 // 30.0)
+    sign_index = int(degree % 360.0 // 30.0)
+    return ((sign_index - asc_index) % 12) + 1
+
+
+def _candidate_names(is_day: bool, include_fortune: bool) -> Iterable[str]:
+    primary = "Sun" if is_day else "Moon"
+    secondary = "Moon" if is_day else "Sun"
+    names = [primary, secondary, "Asc"]
+    if include_fortune:
+        names.append("Fortune")
+    return names
+
+
+def _degree_for_candidate(chart: ChartCtx, candidate: str) -> float | None:
+    if candidate == "Asc":
+        return chart.natal.houses.ascendant
+    if candidate == "Fortune":
+        value = chart.lot("Fortune")
+        return value if value is not None else None
+    pos = chart.natal.positions.get(candidate)
+    return pos.longitude if pos else None
+
+
+def _planet_key(name: str) -> str:
+    return name.strip().lower()
+
+
+def _score_house(house: int, weights: dict[str, float]) -> tuple[float, str | None]:
+    if house in {1, 4, 7, 10}:
+        return weights.get("angular", 1.0), "angular"
+    if house in {2, 5, 8, 11}:
+        return weights.get("succedent", 0.5), "succedent"
+    if house in {3, 6, 9, 12}:
+        return weights.get("cadent", 0.25), "cadent"
+    return 0.0, None
+
+
+def _score_dignities(
+    candidate: str,
+    sign: str,
+    degree: float,
+    profile: LifeProfile,
+    is_day: bool,
+) -> tuple[float, list[tuple[str, float]]]:
+    weights = dict(profile.dignity_weights)
+    score = 0.0
+    trace: list[tuple[str, float]] = []
+    planet_key = _planet_key(candidate)
+    bundle = sign_dignities(sign)
+    domicile = SIGN_RULERS.get(sign)
+    if domicile == planet_key:
+        value = weights.get("rulership", 0.0)
+        score += value
+        trace.append(("rulership", value))
+    if bundle.exaltation == planet_key:
+        value = weights.get("exaltation", 0.0)
+        score += value
+        trace.append(("exaltation", value))
+    triplicity = bundle.triplicity_for_sect("day" if is_day else "night")
+    if triplicity == planet_key:
+        value = weights.get("triplicity", 0.0)
+        score += value
+        trace.append(("triplicity", value))
+    term_ruler = bundle.bounds_ruler(degree)
+    if term_ruler == planet_key:
+        value = weights.get("bounds", 0.0)
+        score += value
+        trace.append(("bounds", value))
+    face = bundle.face_ruler(degree)
+    if face == planet_key:
+        value = weights.get("face", 0.0)
+        score += value
+        trace.append(("face", value))
+    return score, trace
+
+
+def find_hyleg(chart: ChartCtx, profile: LifeProfile) -> HylegResult:
+    """Select the strongest Hyleg candidate using classical dignities."""
+
+    asc_degree = chart.natal.houses.ascendant
+    is_day = chart.sect.is_day
+    best: HylegResult | None = None
+    weights = dict(profile.dignity_weights)
+    for candidate in _candidate_names(is_day, profile.include_fortune):
+        degree = _degree_for_candidate(chart, candidate)
+        if degree is None:
+            continue
+        sign = _sign_from_degree(degree)
+        house = _house_from_degree(asc_degree, degree)
+        if house not in profile.house_candidates and candidate != "Asc":
+            continue
+        base_score, house_tag = _score_house(house, weights)
+        trace: list[tuple[str, float]] = []
+        notes: list[str] = [f"candidate={candidate}", f"sign={sign}", f"house={house}"]
+        if house_tag:
+            trace.append((house_tag, base_score))
+        score = base_score
+        if candidate in {"Sun", "Moon"}:
+            dignity_score, dignity_trace = _score_dignities(
+                candidate,
+                sign,
+                degree % 30.0,
+                profile,
+                is_day,
+            )
+            score += dignity_score
+            trace.extend(dignity_trace)
+            if candidate == chart.sect.luminary_of_sect:
+                value = weights.get("sect", 0.0)
+                score += value
+                trace.append(("sect", value))
+        elif candidate == "Asc":
+            score += weights.get("angular", 1.0)
+            trace.append(("ascendant", weights.get("angular", 1.0)))
+        if candidate == "Fortune":
+            notes.append("lot_of_fortune")
+        result = HylegResult(
+            body=candidate,
+            degree=degree % 360.0,
+            sign=sign,
+            house=house,
+            score=score,
+            notes=tuple(notes),
+            trace=tuple(trace),
+        )
+        if best is None or result.score > best.score:
+            best = result
+    if best is None:
+        raise ValueError("No suitable Hyleg candidate found")
+    return best
+
+
+def find_alcocoden(chart: ChartCtx, hyleg: HylegResult, profile: LifeProfile) -> AlcocodenResult:
+    """Return the Alcocoden (giver of years) for the supplied Hyleg."""
+
+    degree = hyleg.degree % 360.0
+    sign = hyleg.sign
+    is_day = chart.sect.is_day
+    term_ruler = bounds_ruler(sign, degree % 30.0)
+    method = "bounds"
+    confidence = 0.85 if term_ruler else 0.6
+    trace: list[str] = []
+    if term_ruler:
+        trace.append(f"bounds:{term_ruler}")
+        candidate = term_ruler
+    else:
+        bundle = sign_dignities(sign)
+        scores: dict[str, float] = {}
+        weights = dict(profile.dignity_weights)
+        domicile = SIGN_RULERS.get(sign)
+        if domicile:
+            scores[domicile] = scores.get(domicile, 0.0) + weights.get("rulership", 0.0)
+            trace.append(f"rulership:{domicile}")
+        if bundle.exaltation:
+            scores[bundle.exaltation] = scores.get(bundle.exaltation, 0.0) + weights.get(
+                "exaltation", 0.0
+            )
+            trace.append(f"exaltation:{bundle.exaltation}")
+        triplicity = bundle.triplicity_for_sect("day" if is_day else "night")
+        if triplicity:
+            scores[triplicity] = scores.get(triplicity, 0.0) + weights.get("triplicity", 0.0)
+            trace.append(f"triplicity:{triplicity}")
+        if bundle.bounds:
+            for span in bundle.bounds:
+                scores[span.ruler] = scores.get(span.ruler, 0.0) + weights.get("bounds", 0.0)
+        if bundle.decans:
+            for span in bundle.decans:
+                scores[span.ruler] = scores.get(span.ruler, 0.0) + weights.get("face", 0.0)
+        if not scores:
+            raise ValueError("Unable to determine Alcocoden ruler")
+        candidate = max(scores, key=scores.get)
+        method = "dignities"
+        confidence = 0.55
+    years = profile.lifespan_years.get(candidate, None)
+    notes = [f"method={method}", f"sign={sign}"]
+    if profile.bounds_scheme:
+        notes.append(f"bounds_scheme={profile.bounds_scheme}")
+    return AlcocodenResult(
+        body=candidate.title(),
+        method=method,
+        indicative_years=years,
+        confidence=confidence,
+        notes=tuple(notes),
+        trace=tuple(trace),
+    )

--- a/astroengine/engine/traditional/models.py
+++ b/astroengine/engine/traditional/models.py
@@ -1,0 +1,235 @@
+"""Dataclasses shared across the traditional timing engines."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from ...chart.natal import ChartLocation, NatalChart
+
+__all__ = [
+    "AlcocodenResult",
+    "ChartCtx",
+    "GeoLocation",
+    "HylegResult",
+    "Interval",
+    "LifeProfile",
+    "LifeSpanTable",
+    "ProfectionSegment",
+    "ProfectionState",
+    "SectInfo",
+    "ZRPeriod",
+    "ZRTimeline",
+    "build_chart_context",
+]
+
+GeoLocation = ChartLocation
+
+
+@dataclass(frozen=True)
+class Interval:
+    """Half-open time interval used for timeline calculations."""
+
+    start: datetime
+    end: datetime
+
+    def __post_init__(self) -> None:
+        if self.start.tzinfo is None or self.start.tzinfo.utcoffset(self.start) is None:
+            raise ValueError("Interval.start must be timezone-aware")
+        if self.end.tzinfo is None or self.end.tzinfo.utcoffset(self.end) is None:
+            raise ValueError("Interval.end must be timezone-aware")
+        if self.end <= self.start:
+            raise ValueError("Interval end must be after start")
+
+    def contains(self, moment: datetime) -> bool:
+        reference = moment.astimezone(UTC)
+        return self.start <= reference < self.end
+
+
+@dataclass(frozen=True)
+class ProfectionSegment:
+    """A profection period spanning a year or month."""
+
+    start: datetime
+    end: datetime
+    house: int
+    sign: str
+    year_lord: str
+    co_rulers: Mapping[str, Any]
+    notes: tuple[str, ...] = field(default_factory=tuple)
+
+    def duration_days(self) -> float:
+        return (self.end - self.start).total_seconds() / 86400.0
+
+
+@dataclass(frozen=True)
+class ProfectionState:
+    """Snapshot of the profected year and month at a moment."""
+
+    moment: datetime
+    year_house: int
+    year_sign: str
+    year_lord: str
+    month_house: int
+    month_sign: str
+    month_lord: str
+    co_rulers: Mapping[str, Any]
+
+
+@dataclass(frozen=True)
+class SectInfo:
+    """Sect classification metadata for a chart."""
+
+    is_day: bool
+    luminary_of_sect: str
+    malefic_of_sect: str
+    benefic_of_sect: str
+    sun_altitude_deg: float
+
+
+@dataclass(frozen=True)
+class ZRPeriod:
+    """Single zodiacal releasing period at a given level."""
+
+    level: int
+    start: datetime
+    end: datetime
+    sign: str
+    ruler: str
+    lb: bool = False
+    lb_from: str | None = None
+    lb_to: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def to_row(self) -> dict[str, Any]:
+        payload = {
+            "level": self.level,
+            "start": self.start.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "end": self.end.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            "sign": self.sign,
+            "ruler": self.ruler,
+        }
+        if self.lb:
+            payload["loosing_of_bond"] = {
+                "from": self.lb_from,
+                "to": self.lb_to,
+            }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass
+class ZRTimeline:
+    """Container for zodiacal releasing periods grouped by level."""
+
+    levels: Mapping[int, tuple[ZRPeriod, ...]]
+    lot: str
+    source: Literal["Spirit", "Fortune"]
+
+    def iter_level(self, level: int) -> Iterable[ZRPeriod]:
+        return iter(self.levels.get(level, ()))
+
+    def flatten(self) -> list[ZRPeriod]:
+        rows: list[ZRPeriod] = []
+        for key in sorted(self.levels):
+            rows.extend(self.levels[key])
+        return rows
+
+    def to_table(self) -> list[dict[str, Any]]:
+        return [period.to_row() for period in self.flatten()]
+
+
+@dataclass(frozen=True)
+class LifeSpanTable:
+    """Indicative minor/mean/major year spans for classical rulers."""
+
+    minor_years: int
+    mean_years: int
+    major_years: int
+
+
+@dataclass(frozen=True)
+class LifeProfile:
+    """Configuration bundle for Hyleg/Alcocoden resolution."""
+
+    house_candidates: tuple[int, ...] = (1, 7, 9, 10, 11)
+    include_fortune: bool = False
+    dignity_weights: Mapping[str, float] = field(
+        default_factory=lambda: {
+            "rulership": 4.0,
+            "exaltation": 3.0,
+            "triplicity": 2.0,
+            "bounds": 1.5,
+            "face": 1.0,
+            "sect": 1.5,
+            "angular": 1.0,
+            "succedent": 0.5,
+            "cadent": 0.25,
+        }
+    )
+    lifespan_years: Mapping[str, LifeSpanTable] = field(
+        default_factory=lambda: {
+            "sun": LifeSpanTable(19, 69, 120),
+            "moon": LifeSpanTable(25, 66, 108),
+            "mercury": LifeSpanTable(20, 76, 91),
+            "venus": LifeSpanTable(8, 45, 82),
+            "mars": LifeSpanTable(15, 66, 79),
+            "jupiter": LifeSpanTable(12, 45, 79),
+            "saturn": LifeSpanTable(30, 43, 57),
+        }
+    )
+    bounds_scheme: str = "egyptian"
+    notes: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class HylegResult:
+    """Selected hyleg candidate and scoring trace."""
+
+    body: str
+    degree: float
+    sign: str
+    house: int
+    score: float
+    notes: tuple[str, ...]
+    trace: tuple[tuple[str, float], ...]
+
+
+@dataclass(frozen=True)
+class AlcocodenResult:
+    """Resolved Alcocoden metadata derived from the hyleg."""
+
+    body: str
+    method: str
+    indicative_years: LifeSpanTable | None
+    confidence: float
+    notes: tuple[str, ...]
+    trace: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ChartCtx:
+    """Runtime context bundling natal chart, sect, and derived lots."""
+
+    natal: NatalChart
+    sect: SectInfo
+    lots: Mapping[str, float]
+    house_system: str = "whole_sign"
+
+    def lot(self, name: str, default: float | None = None) -> float | None:
+        return self.lots.get(name, default)
+
+
+def build_chart_context(
+    chart: NatalChart,
+    sect: SectInfo,
+    lots: Mapping[str, float],
+    *,
+    house_system: str = "whole_sign",
+) -> ChartCtx:
+    """Construct a :class:`ChartCtx` with validated metadata."""
+
+    return ChartCtx(natal=chart, sect=sect, lots=lots, house_system=house_system)

--- a/astroengine/engine/traditional/profections.py
+++ b/astroengine/engine/traditional/profections.py
@@ -1,0 +1,272 @@
+"""Annual and monthly profection helpers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from datetime import UTC, datetime, timedelta
+from typing import Any, Literal
+
+from ..traditional.dignities import sign_dignities
+from ..traditional.models import ChartCtx, Interval, ProfectionSegment, ProfectionState
+
+SIGN_SEQUENCE = (
+    "aries",
+    "taurus",
+    "gemini",
+    "cancer",
+    "leo",
+    "virgo",
+    "libra",
+    "scorpio",
+    "sagittarius",
+    "capricorn",
+    "aquarius",
+    "pisces",
+)
+
+SIGN_RULERS = {
+    "aries": "mars",
+    "taurus": "venus",
+    "gemini": "mercury",
+    "cancer": "moon",
+    "leo": "sun",
+    "virgo": "mercury",
+    "libra": "venus",
+    "scorpio": "mars",
+    "sagittarius": "jupiter",
+    "capricorn": "saturn",
+    "aquarius": "saturn",
+    "pisces": "jupiter",
+}
+
+__all__ = [
+    "current_profection",
+    "profection_year_segments",
+]
+
+
+def _sign_index(longitude: float) -> int:
+    return int(math.floor(longitude % 360.0 / 30.0)) % 12
+
+
+def _sign_from_index(idx: int) -> str:
+    return SIGN_SEQUENCE[idx % 12]
+
+
+def _co_rulers(sign: str) -> dict[str, Any]:
+    bundle = sign_dignities(sign)
+    data: dict[str, Any] = {
+        "exaltation": bundle.exaltation,
+        "triplicity": {
+            "day": bundle.triplicity_day,
+            "night": bundle.triplicity_night,
+            "participating": bundle.triplicity_participating,
+        },
+        "terms": tuple(
+            {
+                "ruler": span.ruler,
+                "start_deg": span.start_deg,
+                "end_deg": span.end_deg,
+            }
+            for span in bundle.bounds
+        ),
+        "faces": tuple(
+            {
+                "ruler": span.ruler,
+                "start_deg": span.start_deg,
+                "end_deg": span.end_deg,
+            }
+            for span in bundle.decans
+        ),
+    }
+    return data
+
+
+def _anniversary(moment: datetime, years: int) -> datetime:
+    base = moment
+    target_year = base.year + years
+    try:
+        return base.replace(year=target_year)
+    except ValueError:
+        if base.month == 2 and base.day == 29:
+            return base.replace(year=target_year, month=2, day=28)
+        return base.replace(year=target_year, day=min(base.day, 28))
+
+
+def _years_elapsed(base: datetime, moment: datetime) -> int:
+    years = max(0, moment.year - base.year)
+    anniversary = _anniversary(base, years)
+    if anniversary > moment:
+        years -= 1
+    return max(years, 0)
+
+
+def _profection_house(asc_index: int, offset: int) -> tuple[int, str]:
+    house = (offset % 12) + 1
+    sign = _sign_from_index(asc_index + offset)
+    return house, sign
+
+
+def _house_of_body(chart: ChartCtx, body: str, asc_index: int) -> int | None:
+    positions = chart.natal.positions
+    key = body.capitalize()
+    if key not in positions:
+        return None
+    sign_index = _sign_index(positions[key].longitude)
+    house = ((sign_index - asc_index) % 12) + 1
+    return house
+
+
+def _year_lord(sign: str) -> str:
+    return SIGN_RULERS.get(sign, "")
+
+
+def _monthly_base_house(
+    chart: ChartCtx,
+    asc_index: int,
+    year_house_offset: int,
+    year_lord: str,
+    mode: Literal["hellenistic", "medieval"],
+) -> int:
+    if mode == "hellenistic":
+        return year_house_offset
+    lord_house = _house_of_body(chart, year_lord, asc_index)
+    if lord_house is None:
+        return year_house_offset
+    return lord_house - 1
+
+
+def _monthly_segments(
+    chart: ChartCtx,
+    start: datetime,
+    end: datetime,
+    base_offset: int,
+    asc_index: int,
+    year_lord: str,
+    mode: Literal["hellenistic", "medieval"],
+    co_rulers: dict[str, Any],
+) -> Iterable[ProfectionSegment]:
+    span_seconds = (end - start).total_seconds()
+    month_seconds = span_seconds / 12.0
+    base_house_offset = _monthly_base_house(
+        chart, asc_index, base_offset, year_lord, mode
+    )
+    for month in range(12):
+        m_start = start + timedelta(seconds=month_seconds * month)
+        if month == 11:
+            m_end = end
+        else:
+            m_end = start + timedelta(seconds=month_seconds * (month + 1))
+        house_offset = base_house_offset + month
+        house, sign = _profection_house(asc_index, house_offset)
+        yield ProfectionSegment(
+            start=m_start,
+            end=m_end,
+            house=house,
+            sign=sign,
+            year_lord=_year_lord(sign),
+            co_rulers=_co_rulers(sign),
+            notes=(f"month={month+1}", f"mode={mode}"),
+        )
+
+
+def profection_year_segments(
+    natal: ChartCtx,
+    for_range: Interval,
+    mode: Literal["hellenistic", "medieval"] = "hellenistic",
+) -> list[ProfectionSegment]:
+    """Return profection year and month segments intersecting ``for_range``."""
+
+    chart = natal.natal
+    base = chart.moment.astimezone(UTC)
+    start = for_range.start.astimezone(UTC)
+    end = for_range.end.astimezone(UTC)
+    asc_index = _sign_index(chart.houses.ascendant)
+    segments: list[ProfectionSegment] = []
+
+    if end <= base:
+        return []
+
+    years_since_birth = _years_elapsed(base, start)
+    year_start = _anniversary(base, years_since_birth)
+    age = years_since_birth
+    while year_start < end:
+        next_anniversary = _anniversary(base, age + 1)
+        year_end = min(next_anniversary, end)
+        house_offset = age
+        house, sign = _profection_house(asc_index, house_offset)
+        year_lord = _year_lord(sign)
+        co_rulers = _co_rulers(sign)
+        segments.append(
+            ProfectionSegment(
+                start=year_start,
+                end=year_end,
+                house=house,
+                sign=sign,
+                year_lord=year_lord,
+                co_rulers=co_rulers,
+                notes=(f"age={age}",),
+            )
+        )
+        segments.extend(
+            _monthly_segments(
+                natal,
+                year_start,
+                year_end,
+                house_offset,
+                asc_index,
+                year_lord,
+                mode,
+                co_rulers,
+            )
+        )
+        age += 1
+        year_start = next_anniversary
+        if year_start >= end:
+            break
+    return [seg for seg in segments if seg.end > start and seg.start < end]
+
+
+def _active_month_segment(
+    segments: Iterable[ProfectionSegment], moment: datetime
+) -> ProfectionSegment | None:
+    for segment in segments:
+        if not segment.notes or not segment.notes[0].startswith("month="):
+            continue
+        if segment.start <= moment < segment.end:
+            return segment
+    return None
+
+
+def current_profection(moment: datetime, natal: ChartCtx) -> ProfectionState:
+    """Return the profected year/month state at ``moment``."""
+
+    base = natal.natal.moment.astimezone(UTC)
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise ValueError("Moment must be timezone-aware")
+    moment_utc = moment.astimezone(UTC)
+    if moment_utc < base:
+        raise ValueError("Moment precedes natal chart")
+    years_since = _years_elapsed(base, moment_utc)
+    year_start = _anniversary(base, years_since)
+    year_end = _anniversary(base, years_since + 1)
+    full_segments = profection_year_segments(
+        natal, Interval(start=year_start, end=year_end)
+    )
+    year_segment = next((seg for seg in full_segments if seg.notes and seg.notes[0].startswith("age=")), None)
+    if year_segment is None:
+        raise ValueError("Unable to resolve profection year")
+    month_segment = _active_month_segment(full_segments, moment_utc)
+    if month_segment is None:
+        raise ValueError("Unable to resolve profection month")
+    return ProfectionState(
+        moment=moment_utc,
+        year_house=year_segment.house,
+        year_sign=year_segment.sign,
+        year_lord=year_segment.year_lord,
+        month_house=month_segment.house,
+        month_sign=month_segment.sign,
+        month_lord=month_segment.year_lord,
+        co_rulers=year_segment.co_rulers,
+    )

--- a/astroengine/engine/traditional/profiles.py
+++ b/astroengine/engine/traditional/profiles.py
@@ -1,0 +1,38 @@
+"""Load configuration bundles for the traditional timing engines."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Any
+
+from ..traditional.models import LifeProfile
+from ..traditional.profections import SIGN_RULERS
+from ..traditional.zr import PERIOD_YEARS
+
+__all__ = ["load_traditional_profiles"]
+
+
+@lru_cache(maxsize=1)
+def load_traditional_profiles() -> dict[str, Any]:
+    """Return profile defaults for profections, ZR, and life-lengths."""
+
+    life_profile = LifeProfile()
+    profections = {
+        "default_mode": "hellenistic",
+        "house_system": "whole_sign",
+        "rulers": dict(SIGN_RULERS),
+    }
+    zr_profile = {
+        "period_years": dict(PERIOD_YEARS),
+        "levels": (1, 2, 3, 4),
+        "lots": ("Spirit", "Fortune"),
+        "loosing_of_bond": True,
+    }
+    life = {
+        "profile": life_profile,
+        "notes": {
+            "lifespan_table_source": "Ptolemy Tetrabiblos III + Lilly (1647)",
+            "bounds_scheme": life_profile.bounds_scheme,
+        },
+    }
+    return {"profections": profections, "zr": zr_profile, "life": life}

--- a/astroengine/engine/traditional/sect.py
+++ b/astroengine/engine/traditional/sect.py
@@ -1,0 +1,46 @@
+"""Sect classification helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import swisseph as swe
+
+from ...ephemeris.swisseph_adapter import SwissEphemerisAdapter
+from ...ux.maps.astrocartography import _horizontal_coordinates, _sidereal_time_degrees
+from ..traditional.models import GeoLocation, SectInfo
+
+__all__ = ["sect_info"]
+
+
+def _sun_altitude(moment: datetime, location: GeoLocation, adapter: SwissEphemerisAdapter | None) -> float:
+    adapter = adapter or SwissEphemerisAdapter.get_default_adapter()
+    jd_ut = adapter.julian_day(moment.astimezone(UTC))
+    sun_equatorial = adapter.body_equatorial(jd_ut, swe.SUN)
+    lst = _sidereal_time_degrees(jd_ut, location.longitude)
+    hour_angle = (lst - sun_equatorial.right_ascension) % 360.0
+    _, altitude = _horizontal_coordinates(
+        hour_angle_deg=hour_angle,
+        decl_deg=sun_equatorial.declination,
+        latitude_deg=location.latitude,
+    )
+    return altitude
+
+
+def sect_info(moment: datetime, loc: GeoLocation) -> SectInfo:
+    """Return sect metadata for the supplied chart moment and location."""
+
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise ValueError("Moment must be timezone-aware")
+    altitude = _sun_altitude(moment, loc, None)
+    is_day = altitude > 0.0
+    luminary = "Sun" if is_day else "Moon"
+    benefic = "Jupiter" if is_day else "Venus"
+    malefic = "Saturn" if is_day else "Mars"
+    return SectInfo(
+        is_day=is_day,
+        luminary_of_sect=luminary,
+        malefic_of_sect=malefic,
+        benefic_of_sect=benefic,
+        sun_altitude_deg=altitude,
+    )

--- a/astroengine/engine/traditional/zr.py
+++ b/astroengine/engine/traditional/zr.py
@@ -1,0 +1,212 @@
+"""Zodiacal releasing timelines with loosing of the bond support."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Literal
+
+from .models import ZRPeriod, ZRTimeline
+from .profections import SIGN_RULERS
+
+__all__ = [
+    "PERIOD_YEARS",
+    "apply_loosing_of_bond",
+    "flag_peaks_fortune",
+    "zr_periods",
+]
+
+SIGN_ORDER = (
+    "Aries",
+    "Taurus",
+    "Gemini",
+    "Cancer",
+    "Leo",
+    "Virgo",
+    "Libra",
+    "Scorpio",
+    "Sagittarius",
+    "Capricorn",
+    "Aquarius",
+    "Pisces",
+)
+
+PERIOD_YEARS = {
+    "Aries": 15.0,
+    "Taurus": 8.0,
+    "Gemini": 20.0,
+    "Cancer": 25.0,
+    "Leo": 19.0,
+    "Virgo": 20.0,
+    "Libra": 8.0,
+    "Scorpio": 15.0,
+    "Sagittarius": 12.0,
+    "Capricorn": 27.0,
+    "Aquarius": 30.0,
+    "Pisces": 12.0,
+}
+
+TOTAL_UNITS = sum(PERIOD_YEARS.values())
+YEAR_DAYS = 365.2425
+
+MODALITY = {
+    "Aries": "cardinal",
+    "Cancer": "cardinal",
+    "Libra": "cardinal",
+    "Capricorn": "cardinal",
+    "Taurus": "fixed",
+    "Leo": "fixed",
+    "Scorpio": "fixed",
+    "Aquarius": "fixed",
+    "Gemini": "mutable",
+    "Virgo": "mutable",
+    "Sagittarius": "mutable",
+    "Pisces": "mutable",
+}
+
+
+def _normalize_sign(sign: str) -> str:
+    key = sign.strip().lower()
+    for candidate in SIGN_ORDER:
+        if candidate.lower() == key:
+            return candidate
+    raise ValueError(f"Unknown zodiac sign: {sign}")
+
+
+def _next_sign(current: str, previous: str | None) -> tuple[str, tuple[str, str] | None]:
+    idx = SIGN_ORDER.index(current)
+    default_next = SIGN_ORDER[(idx + 1) % len(SIGN_ORDER)]
+    if current == "Cancer" and previous != "Capricorn":
+        return "Capricorn", ("Cancer", "Capricorn")
+    if current == "Capricorn" and previous != "Cancer":
+        return "Cancer", ("Capricorn", "Cancer")
+    return default_next, None
+
+
+def _build_level(
+    level: int,
+    start: datetime,
+    end: datetime,
+    start_sign: str,
+    max_level: int,
+) -> list[ZRPeriod]:
+    periods: list[ZRPeriod] = []
+    current_sign = start_sign
+    previous_sign: str | None = None
+    pending_lb: tuple[str, str] | None = None
+    cursor = start
+    epsilon = timedelta(seconds=1)
+    while cursor < end - epsilon:
+        if level == 1:
+            span_days = PERIOD_YEARS[current_sign] * YEAR_DAYS
+        else:
+            parent_days = (end - start).total_seconds() / 86400.0
+            span_days = parent_days * (PERIOD_YEARS[current_sign] / TOTAL_UNITS)
+        next_end = cursor + timedelta(days=span_days)
+        if next_end > end:
+            next_end = end
+        lb_flag = False
+        lb_from: str | None = None
+        lb_to: str | None = None
+        if pending_lb and pending_lb[1] == current_sign:
+            lb_flag = True
+            lb_from, lb_to = pending_lb
+            pending_lb = None
+        period = ZRPeriod(
+            level=level,
+            start=cursor,
+            end=next_end,
+            sign=current_sign,
+            ruler=SIGN_RULERS[current_sign.lower()],
+            lb=lb_flag,
+            lb_from=lb_from,
+            lb_to=lb_to,
+            metadata={},
+        )
+        periods.append(period)
+        if level < max_level:
+            sub_periods = _build_level(level + 1, cursor, next_end, current_sign, max_level)
+            periods.extend(sub_periods)
+        next_sign, lob = _next_sign(current_sign, previous_sign)
+        if lob:
+            pending_lb = lob
+        previous_sign = current_sign
+        current_sign = next_sign
+        cursor = next_end
+        if cursor >= end:
+            break
+    return periods
+
+
+def zr_periods(
+    lot_sign: str,
+    start: datetime,
+    end: datetime,
+    *,
+    levels: int = 2,
+    source: Literal["Spirit", "Fortune"] = "Spirit",
+) -> ZRTimeline:
+    """Compute zodiacal releasing periods for ``lot_sign`` between ``start`` and ``end``."""
+
+    if levels < 1 or levels > 4:
+        raise ValueError("levels must be between 1 and 4")
+    if start.tzinfo is None or start.tzinfo.utcoffset(start) is None:
+        raise ValueError("start must be timezone-aware")
+    if end.tzinfo is None or end.tzinfo.utcoffset(end) is None:
+        raise ValueError("end must be timezone-aware")
+    if end <= start:
+        raise ValueError("end must be after start")
+    lot = _normalize_sign(lot_sign)
+    start_utc = start.astimezone(UTC)
+    end_utc = end.astimezone(UTC)
+    levels_map: dict[int, list[ZRPeriod]] = {level: [] for level in range(1, levels + 1)}
+    level_periods = _build_level(1, start_utc, end_utc, lot, levels)
+    for period in level_periods:
+        if period.level <= levels:
+            levels_map[period.level].append(period)
+    packed = {key: tuple(value) for key, value in levels_map.items()}
+    return ZRTimeline(levels=packed, lot=lot, source=source)
+
+
+def apply_loosing_of_bond(timeline: ZRTimeline) -> ZRTimeline:
+    """Return a timeline with Loosing of the Bond metadata normalised."""
+
+    updated: dict[int, list[ZRPeriod]] = {}
+    for level, periods in timeline.levels.items():
+        updated[level] = []
+        for period in periods:
+            updated[level].append(period)
+    timeline.levels = {key: tuple(value) for key, value in updated.items()}
+    return timeline
+
+
+def flag_peaks_fortune(timeline: ZRTimeline, fortune_sign: str) -> None:
+    """Annotate level-1 periods that coincide with Lot of Fortune peaks."""
+
+    fortune = _normalize_sign(fortune_sign)
+    fortune_modality = MODALITY[fortune]
+    updated: list[ZRPeriod] = []
+    for period in timeline.levels.get(1, ()):  # type: ignore[arg-type]
+        metadata = dict(period.metadata)
+        peak: str | None = None
+        if period.sign == fortune:
+            peak = "major"
+        elif MODALITY.get(period.sign) == fortune_modality:
+            peak = "moderate"
+        if peak:
+            metadata["peak"] = peak
+        updated.append(
+            ZRPeriod(
+                level=period.level,
+                start=period.start,
+                end=period.end,
+                sign=period.sign,
+                ruler=period.ruler,
+                lb=period.lb,
+                lb_from=period.lb_from,
+                lb_to=period.lb_to,
+                metadata=metadata,
+            )
+        )
+    if updated:
+        timeline.levels = dict(timeline.levels)
+        timeline.levels[1] = tuple(updated)

--- a/migrations/versions/20241108_0002_traditional_runs.py
+++ b/migrations/versions/20241108_0002_traditional_runs.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "20241108_0002"
+down_revision = "20241006_0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    timestamp_default = sa.text("CURRENT_TIMESTAMP")
+    op.create_table(
+        "traditional_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, nullable=False),
+        sa.Column("run_id", sa.String(length=40), nullable=False),
+        sa.Column("kind", sa.String(length=40), nullable=False),
+        sa.Column("inputs", sa.JSON(), nullable=False),
+        sa.Column("result", sa.JSON(), nullable=False),
+        sa.Column("module", sa.String(length=64), nullable=False, server_default=sa.text("'traditional'")),
+        sa.Column("submodule", sa.String(length=64), nullable=True),
+        sa.Column("channel", sa.String(length=64), nullable=False, server_default=sa.text("'timelords'")),
+        sa.Column("subchannel", sa.String(length=64), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=timestamp_default, nullable=False),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=timestamp_default,
+            server_onupdate=timestamp_default,
+            nullable=False,
+        ),
+        sa.UniqueConstraint("run_id", name="uq_traditional_runs_run_id"),
+    )
+    op.create_index(
+        "ix_traditional_runs_kind",
+        "traditional_runs",
+        ["kind"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_traditional_runs_kind", table_name="traditional_runs")
+    op.drop_table("traditional_runs")

--- a/streamlit/traditional_lab/__init__.py
+++ b/streamlit/traditional_lab/__init__.py
@@ -1,0 +1,7 @@
+"""Streamlit interface for the traditional timing lab."""
+
+from __future__ import annotations
+
+from .app import render
+
+__all__ = ["render"]

--- a/streamlit/traditional_lab/app.py
+++ b/streamlit/traditional_lab/app.py
@@ -1,0 +1,304 @@
+"""Streamlit application providing a traditional timing lab."""
+
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import altair as alt
+import pandas as pd
+import streamlit as st
+
+from ...chart.natal import ChartLocation, compute_natal_chart
+from core.lots_plus.catalog import Sect as LotSect
+from core.lots_plus.catalog import compute_lots
+from ...engine.traditional import (
+    Interval,
+    apply_loosing_of_bond,
+    build_chart_context,
+    find_alcocoden,
+    find_hyleg,
+    flag_peaks_fortune,
+    load_traditional_profiles,
+    profection_year_segments,
+    sect_info,
+    zr_periods,
+)
+from ...engine.traditional.models import ChartCtx, LifeProfile
+from ...engine.traditional.zr import SIGN_ORDER
+
+
+def _parse_iso(value: str) -> datetime:
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:  # pragma: no cover - user input driven
+        raise ValueError(f"Invalid ISO datetime: {value}") from exc
+
+
+def _build_ctx(moment: datetime, latitude: float, longitude: float, house_system: str) -> ChartCtx:
+    location = ChartLocation(latitude=latitude, longitude=longitude)
+    chart = compute_natal_chart(moment, location)
+    sect = sect_info(moment, location)
+    lots = compute_lots(["Fortune", "Spirit"], _lot_positions(chart), LotSect.DAY if sect.is_day else LotSect.NIGHT)
+    return build_chart_context(chart=chart, sect=sect, lots=lots, house_system=house_system)
+
+
+def _lot_positions(chart) -> dict[str, float]:
+    positions = {name: pos.longitude for name, pos in chart.positions.items()}
+    positions["Asc"] = chart.houses.ascendant
+    return positions
+
+
+def _profection_dataframe(segments) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for segment in segments:
+        note = segment.notes[0] if segment.notes else ""
+        kind = "year" if note.startswith("age=") else "month"
+        rows.append(
+            {
+                "kind": kind,
+                "start": segment.start,
+                "end": segment.end,
+                "house": segment.house,
+                "sign": segment.sign,
+                "year_lord": segment.year_lord,
+                "co_rulers": segment.co_rulers,
+                "notes": list(segment.notes),
+            }
+        )
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df["start"] = pd.to_datetime(df["start"], utc=True)
+        df["end"] = pd.to_datetime(df["end"], utc=True)
+    return df
+
+
+def _zr_dataframe(timeline) -> pd.DataFrame:
+    rows: list[dict[str, Any]] = []
+    for period in timeline.flatten():
+        metadata = dict(period.metadata)
+        rows.append(
+            {
+                "level": period.level,
+                "start": period.start,
+                "end": period.end,
+                "sign": period.sign,
+                "ruler": period.ruler,
+                "lb": bool(period.lb),
+                "lb_from": period.lb_from,
+                "lb_to": period.lb_to,
+                "peak": metadata.get("peak"),
+            }
+        )
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df["start"] = pd.to_datetime(df["start"], utc=True)
+        df["end"] = pd.to_datetime(df["end"], utc=True)
+    return df
+
+
+def _fortune_sign(ctx: ChartCtx) -> str | None:
+    degree = ctx.lot("Fortune")
+    if degree is None:
+        return None
+    return SIGN_ORDER[int(degree % 360.0 // 30.0)]
+
+
+def _life_profile(include_fortune: bool) -> LifeProfile:
+    base_profile: LifeProfile = load_traditional_profiles()["life"]["profile"]
+    return LifeProfile(
+        house_candidates=base_profile.house_candidates,
+        include_fortune=include_fortune,
+        dignity_weights=base_profile.dignity_weights,
+        lifespan_years=base_profile.lifespan_years,
+        bounds_scheme=base_profile.bounds_scheme,
+        notes=base_profile.notes,
+    )
+
+
+def _export_dataframe(df: pd.DataFrame, name: str) -> None:
+    if df.empty:
+        return
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+    st.download_button(
+        label=f"Download {name} CSV",
+        data=csv_bytes,
+        file_name=f"{name}.csv",
+        mime="text/csv",
+    )
+    json_bytes = df.to_json(orient="records", date_format="iso").encode("utf-8")
+    st.download_button(
+        label=f"Download {name} JSON",
+        data=json_bytes,
+        file_name=f"{name}.json",
+        mime="application/json",
+    )
+
+
+def _export_chart_png(chart: alt.Chart) -> None:
+    try:
+        import altair_saver  # type: ignore  # noqa: F401
+        from altair_saver import save  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        st.info("Install altair-saver[kaleido] to enable PNG export.")
+        return
+    try:
+        buffer = io.BytesIO()
+        save(chart, fp=buffer, fmt="png")
+        buffer.seek(0)
+    except Exception as exc:  # pragma: no cover - optional dependency issues
+        st.warning(f"PNG export failed: {exc}")
+        return
+    st.download_button(
+        label="Download bands chart PNG",
+        data=buffer.read(),
+        file_name="traditional_bands.png",
+        mime="image/png",
+    )
+
+
+def _timeline_chart(df: pd.DataFrame, overlays: pd.DataFrame | None = None) -> alt.Chart:
+    base = alt.Chart(df).encode(x="start:T", x2="end:T", tooltip=["sign", "ruler", "level", "lb", "peak"])
+    level1 = base.transform_filter(alt.datum.level == 1).mark_bar(size=18).encode(y=alt.value(0), color=alt.value("#1f77b4"))
+    level2 = base.transform_filter(alt.datum.level == 2).mark_bar(size=12, opacity=0.6).encode(y=alt.value(22), color=alt.value("#ff7f0e"))
+    chart = alt.layer(level1, level2).properties(height=120, width=800)
+    if overlays is not None and not overlays.empty:
+        overlay = (
+            alt.Chart(overlays)
+            .mark_tick(color="red", thickness=2, size=40)
+            .encode(x="moment:T", tooltip=["label", "kind"])
+        )
+        chart = alt.layer(chart, overlay)
+    return chart
+
+
+def render() -> None:
+    st.set_page_config(page_title="Traditional Lab", layout="wide")
+    st.title("Traditional Timing Lab")
+
+    with st.sidebar:
+        st.header("Natal Configuration")
+        birth_iso = st.text_input("Birth moment (ISO)", "1990-01-01T12:00:00+00:00")
+        latitude = st.number_input("Latitude", value=40.7128, format="%.4f")
+        longitude = st.number_input("Longitude", value=-74.0060, format="%.4f")
+        house_system = st.selectbox("House system", options=["whole_sign", "placidus", "koch"], index=0)
+        range_start_iso = st.text_input("Timeline start", "2023-01-01T00:00:00+00:00")
+        range_end_iso = st.text_input("Timeline end", "2025-01-01T00:00:00+00:00")
+        include_fortune = st.checkbox("Include Lot of Fortune for Hyleg", value=False)
+        run_button = st.button("Generate timelines")
+
+    if not run_button:
+        st.info("Provide chart details and click 'Generate timelines'.")
+        return
+
+    try:
+        birth_moment = _parse_iso(birth_iso)
+        start = _parse_iso(range_start_iso)
+        end = _parse_iso(range_end_iso)
+        if end <= start:
+            raise ValueError("Timeline end must be after start.")
+        ctx = _build_ctx(birth_moment, latitude, longitude, house_system)
+        interval = Interval(start=start.astimezone(UTC), end=end.astimezone(UTC))
+        prof_segments = profection_year_segments(ctx, interval)
+        timeline = zr_periods(
+            lot_sign=_fortune_sign(ctx) or SIGN_ORDER[int(ctx.natal.houses.ascendant % 360.0 // 30.0)],
+            start=start.astimezone(UTC),
+            end=end.astimezone(UTC),
+            levels=2,
+        )
+        timeline = apply_loosing_of_bond(timeline)
+        fortune_sign = _fortune_sign(ctx)
+        if fortune_sign:
+            flag_peaks_fortune(timeline, fortune_sign)
+        life_profile = _life_profile(include_fortune)
+        hyleg = find_hyleg(ctx, life_profile)
+        alcocoden = find_alcocoden(ctx, hyleg, life_profile)
+    except Exception as exc:  # pragma: no cover - user interaction path
+        st.error(f"Unable to generate timelines: {exc}")
+        return
+
+    prof_df = _profection_dataframe(prof_segments)
+    zr_df = _zr_dataframe(timeline)
+
+    tab_profections, tab_zr, tab_life, tab_overlays = st.tabs(
+        ["Profections", "Zodiacal Releasing", "Sect/Hyleg", "Overlays & Export"]
+    )
+
+    with tab_profections:
+        st.subheader("Annual & Monthly Profections")
+        kind_filter = st.multiselect("Filter kinds", options=sorted(prof_df["kind"].unique()), default=list(prof_df["kind"].unique()))
+        filtered = prof_df[prof_df["kind"].isin(kind_filter)] if kind_filter else prof_df
+        st.dataframe(filtered)
+        _export_dataframe(filtered, "profections")
+
+    with tab_zr:
+        st.subheader("Zodiacal Releasing Levels 1-2")
+        sign_filter = st.multiselect("Signs", options=sorted(zr_df["sign"].unique()), default=list(zr_df["sign"].unique()))
+        lb_only = st.checkbox("Loosing of the Bond only", value=False)
+        peaks_only = st.checkbox("Peaks only", value=False)
+        filtered = zr_df
+        if sign_filter:
+            filtered = filtered[filtered["sign"].isin(sign_filter)]
+        if lb_only:
+            filtered = filtered[filtered["lb"]]
+        if peaks_only:
+            filtered = filtered[filtered["peak"].notna()]
+        st.dataframe(filtered)
+        _export_dataframe(filtered, "zr_periods")
+
+    with tab_life:
+        st.subheader("Sect, Hyleg, Alcocoden")
+        st.markdown(
+            f"**Sect:** {'Day' if ctx.sect.is_day else 'Night'} — Luminary: {ctx.sect.luminary_of_sect} — Benefic of sect: {ctx.sect.benefic_of_sect}"
+        )
+        st.json(
+            {
+                "hyleg": {
+                    "body": hyleg.body,
+                    "degree": round(hyleg.degree, 2),
+                    "sign": hyleg.sign,
+                    "house": hyleg.house,
+                    "score": round(hyleg.score, 2),
+                    "notes": list(hyleg.notes),
+                    "trace": list(hyleg.trace),
+                },
+                "alcocoden": {
+                    "body": alcocoden.body,
+                    "method": alcocoden.method,
+                    "indicative_years": (
+                        {
+                            "minor": alcocoden.indicative_years.minor_years,
+                            "mean": alcocoden.indicative_years.mean_years,
+                            "major": alcocoden.indicative_years.major_years,
+                        }
+                        if alcocoden.indicative_years
+                        else None
+                    ),
+                    "confidence": alcocoden.confidence,
+                    "notes": list(alcocoden.notes),
+                    "trace": list(alcocoden.trace),
+                },
+            }
+        )
+
+    with tab_overlays:
+        st.subheader("Timeline Bands & Overlays")
+        uploaded = st.file_uploader("Upload overlay CSV (columns: moment,label,kind)")
+        overlay_df: pd.DataFrame | None = None
+        if uploaded:
+            try:
+                overlay_df = pd.read_csv(uploaded)
+                overlay_df["moment"] = pd.to_datetime(overlay_df["moment"], utc=True)
+            except Exception as exc:  # pragma: no cover - user upload path
+                st.warning(f"Could not parse overlay CSV: {exc}")
+                overlay_df = None
+        chart = _timeline_chart(zr_df, overlay_df)
+        st.altair_chart(chart, use_container_width=True)
+        _export_chart_png(chart)
+        st.markdown("### Raw payload")
+        st.code(json.dumps(timeline.to_table(), indent=2), language="json")
+
+
+__all__ = ["render"]

--- a/tests/traditional/test_hyleg_alcocoden.py
+++ b/tests/traditional/test_hyleg_alcocoden.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from astroengine.chart.natal import ChartLocation, compute_natal_chart
+from core.lots_plus.catalog import Sect as LotSect
+from core.lots_plus.catalog import compute_lots
+from astroengine.engine.traditional import build_chart_context, find_alcocoden, find_hyleg, load_traditional_profiles
+from astroengine.engine.traditional.sect import sect_info
+
+
+def _context(include_fortune: bool = False):
+    moment = datetime(1984, 10, 26, 18, 15, tzinfo=UTC)
+    location = ChartLocation(latitude=34.0522, longitude=-118.2437)
+    chart = compute_natal_chart(moment, location)
+    sect = sect_info(moment, location)
+    positions = {name: pos.longitude for name, pos in chart.positions.items()}
+    positions["Asc"] = chart.houses.ascendant
+    lots = compute_lots(["Fortune", "Spirit"], positions, LotSect.DAY if sect.is_day else LotSect.NIGHT)
+    ctx = build_chart_context(chart=chart, sect=sect, lots=lots)
+    profile = load_traditional_profiles()["life"]["profile"]
+    if include_fortune:
+        profile = type(profile)(
+            house_candidates=profile.house_candidates,
+            include_fortune=True,
+            dignity_weights=profile.dignity_weights,
+            lifespan_years=profile.lifespan_years,
+            bounds_scheme=profile.bounds_scheme,
+            notes=profile.notes,
+        )
+    return ctx, profile
+
+
+def test_find_hyleg_prefers_sect_luminary() -> None:
+    ctx, profile = _context()
+    result = find_hyleg(ctx, profile)
+    assert result.body in {"Sun", "Moon", "Asc"}
+    assert result.score > 0
+    assert result.notes
+
+
+def test_find_alcocoden_from_hyleg() -> None:
+    ctx, profile = _context(include_fortune=True)
+    hyleg = find_hyleg(ctx, profile)
+    alcocoden = find_alcocoden(ctx, hyleg, profile)
+    assert alcocoden.body
+    if alcocoden.indicative_years is not None:
+        assert alcocoden.indicative_years.minor_years > 0
+    assert alcocoden.confidence > 0.0

--- a/tests/traditional/test_profections_year_month.py
+++ b/tests/traditional/test_profections_year_month.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from astroengine.chart.natal import ChartLocation, compute_natal_chart
+from core.lots_plus.catalog import Sect as LotSect
+from core.lots_plus.catalog import compute_lots
+from astroengine.engine.traditional import (
+    Interval,
+    build_chart_context,
+    current_profection,
+    profection_year_segments,
+)
+from astroengine.engine.traditional.profections import SIGN_SEQUENCE
+from astroengine.engine.traditional.sect import sect_info
+
+
+def _context() -> tuple:
+    moment = datetime(1990, 5, 15, 12, 0, tzinfo=UTC)
+    location = ChartLocation(latitude=51.5074, longitude=-0.1278)
+    chart = compute_natal_chart(moment, location)
+    sect = sect_info(moment, location)
+    positions = {name: pos.longitude for name, pos in chart.positions.items()}
+    positions["Asc"] = chart.houses.ascendant
+    lots = compute_lots(["Fortune", "Spirit"], positions, LotSect.DAY if sect.is_day else LotSect.NIGHT)
+    ctx = build_chart_context(chart=chart, sect=sect, lots=lots)
+    return ctx, moment
+
+
+def test_profection_year_progression() -> None:
+    ctx, _ = _context()
+    start = datetime(2020, 5, 15, 12, 0, tzinfo=UTC)
+    end = datetime(2022, 5, 15, 12, 0, tzinfo=UTC)
+    interval = Interval(start=start, end=end)
+    segments = profection_year_segments(ctx, interval)
+    years = [seg for seg in segments if seg.notes and seg.notes[0].startswith("age=")]
+    assert years, "expected annual profection segments"
+    first_year = years[0]
+    assert first_year.house == 7
+    asc_index = int(ctx.natal.houses.ascendant % 360.0 // 30.0)
+    expected_sign = SIGN_SEQUENCE[(asc_index + 30) % 12]
+    assert first_year.sign == expected_sign
+    months = [seg for seg in segments if seg.notes and seg.notes[0].startswith("month=")]
+    month1 = next(seg for seg in months if seg.notes[0] == "month=1")
+    month6 = next(seg for seg in months if seg.notes[0] == "month=6")
+    assert month1.house == first_year.house
+    assert month6.house == ((first_year.house + 5 - 1) % 12) + 1
+
+
+def test_medieval_month_mode_differs() -> None:
+    ctx, _ = _context()
+    start = datetime(2020, 5, 15, 12, 0, tzinfo=UTC)
+    end = datetime(2021, 5, 15, 12, 0, tzinfo=UTC)
+    interval = Interval(start=start, end=end)
+    hellenistic = profection_year_segments(ctx, interval, mode="hellenistic")
+    medieval = profection_year_segments(ctx, interval, mode="medieval")
+    hell_months = {seg.notes[0]: seg.house for seg in hellenistic if seg.notes and seg.notes[0].startswith("month=")}
+    med_months = {seg.notes[0]: seg.house for seg in medieval if seg.notes and seg.notes[0].startswith("month=")}
+    assert hell_months and med_months
+    assert hell_months != med_months
+
+
+def test_current_profection_matches_timeline() -> None:
+    ctx, _ = _context()
+    moment = datetime(2021, 1, 1, 0, 0, tzinfo=UTC)
+    state = current_profection(moment, ctx)
+    assert state.year_house == 7
+    year_start = datetime(2020, 5, 15, 12, 0, tzinfo=UTC)
+    year_end = datetime(2021, 5, 15, 12, 0, tzinfo=UTC)
+    full_interval = Interval(start=year_start, end=year_end)
+    segments = profection_year_segments(ctx, full_interval)
+    month_segment = next(
+        seg for seg in segments if seg.notes and seg.notes[0].startswith("month=") and seg.start <= moment < seg.end
+    )
+    assert state.month_house == month_segment.house

--- a/tests/traditional/test_sect.py
+++ b/tests/traditional/test_sect.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from astroengine.chart.natal import ChartLocation
+from astroengine.engine.traditional.sect import sect_info
+
+
+def test_day_and_night_sect_classification() -> None:
+    location = ChartLocation(latitude=0.0, longitude=0.0)
+    day_moment = datetime(2023, 7, 1, 12, 0, tzinfo=UTC)
+    night_moment = datetime(2023, 7, 1, 0, 0, tzinfo=UTC)
+    day_info = sect_info(day_moment, location)
+    night_info = sect_info(night_moment, location)
+    assert day_info.is_day is True
+    assert day_info.luminary_of_sect == "Sun"
+    assert night_info.is_day is False
+    assert night_info.luminary_of_sect == "Moon"
+
+
+def test_high_latitude_edge_case() -> None:
+    location = ChartLocation(latitude=70.0, longitude=-50.0)
+    moment = datetime(2023, 12, 21, 0, 0, tzinfo=UTC)
+    info = sect_info(moment, location)
+    assert info.sun_altitude_deg < 0.0
+    assert info.is_day is False

--- a/tests/traditional/test_traditional_api.py
+++ b/tests/traditional/test_traditional_api.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi.testclient import TestClient
+
+from astroengine.api import create_app
+
+client = TestClient(create_app())
+
+
+_DEF_NATAL = {
+    "moment": "1990-05-15T12:00:00+00:00",
+    "latitude": 51.5074,
+    "longitude": -0.1278,
+}
+
+
+def test_profections_api() -> None:
+    body = {
+        "natal": _DEF_NATAL,
+        "start": "2020-05-15T12:00:00+00:00",
+        "end": "2021-05-15T12:00:00+00:00",
+        "mode": "hellenistic",
+    }
+    resp = client.post("/v1/traditional/profections", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["segments"]
+    assert data["meta"]["mode"] == "hellenistic"
+
+
+def test_zodiacal_releasing_api() -> None:
+    body = {
+        "natal": _DEF_NATAL,
+        "lot_sign": "aries",
+        "start": "2020-01-01T00:00:00+00:00",
+        "end": "2030-01-01T00:00:00+00:00",
+        "levels": 2,
+        "source": "Spirit",
+        "include_peaks": True,
+    }
+    resp = client.post("/v1/traditional/zr", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "1" in data["levels"]
+    assert data["lot"] == "Aries"
+    assert data["levels"]["1"][0]["sign"]
+
+
+def test_sect_api() -> None:
+    body = {
+        "moment": "2023-07-01T12:00:00+00:00",
+        "latitude": 0.0,
+        "longitude": 0.0,
+    }
+    resp = client.post("/v1/traditional/sect", json=body)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_day"] is True
+
+
+def test_life_api() -> None:
+    body = {
+        "natal": _DEF_NATAL,
+        "include_fortune": True,
+    }
+    resp = client.post("/v1/traditional/life", json=body)
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["hyleg"]["body"]
+    assert payload["alcocoden"]["body"]

--- a/tests/traditional/test_zr_periods.py
+++ b/tests/traditional/test_zr_periods.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from astroengine.engine.traditional import apply_loosing_of_bond, flag_peaks_fortune, zr_periods
+
+
+def test_zodiacal_releasing_l1_sequences_with_lob() -> None:
+    start = datetime(2000, 1, 1, tzinfo=UTC)
+    end = datetime(2035, 1, 1, tzinfo=UTC)
+    timeline = zr_periods("Cancer", start, end, levels=2)
+    timeline = apply_loosing_of_bond(timeline)
+    level1 = list(timeline.levels[1])
+    assert level1[0].sign == "Cancer"
+    span_years = (level1[0].end - level1[0].start).total_seconds() / 86400.0 / 365.2425
+    assert 24.5 < span_years < 25.5
+    assert level1[1].sign == "Capricorn"
+    assert level1[1].lb and level1[1].lb_from == "Cancer" and level1[1].lb_to == "Capricorn"
+    level2 = [period for period in timeline.levels[2] if period.start >= level1[0].start]
+    assert level2, "expected second-level releasing periods"
+
+
+def test_flag_peaks_by_fortune_modality() -> None:
+    start = datetime(2000, 1, 1, tzinfo=UTC)
+    end = datetime(2025, 1, 1, tzinfo=UTC)
+    timeline = zr_periods("Aries", start, end, levels=1)
+    flag_peaks_fortune(timeline, "Libra")
+    peaks = [period for period in timeline.levels[1] if period.metadata.get("peak")]
+    assert peaks, "expected peak annotations"
+    for period in peaks:
+        if period.sign == "Libra":
+            assert period.metadata["peak"] == "major"
+        else:
+            assert period.metadata["peak"] == "moderate"


### PR DESCRIPTION
## Summary
- add a dedicated traditional engine package covering profections, zodiacal releasing, sect, and life-length helpers with reusable models and profiles
- expose new FastAPI routes and pydantic schemas for traditional workflows and add persistence for traditional run payloads
- build a Streamlit “Traditional Lab” UI and seed tests that cover engines, API responses, and visualization helpers

## Testing
- pytest tests/traditional

------
https://chatgpt.com/codex/tasks/task_e_68d88c80e07c83248dbe340707315856