### PR TITLE
Add normalized ICS export module

### DIFF
--- a/astroengine/export/__init__.py
+++ b/astroengine/export/__init__.py
@@ -1,0 +1,11 @@
+"""Export helpers for ICS calendars and related interchange formats."""
+
+from .ics import Alarm, CalendarEvent, EventLike, to_csv, to_ics
+
+__all__ = [
+    "Alarm",
+    "CalendarEvent",
+    "EventLike",
+    "to_csv",
+    "to_ics",
+]

--- a/astroengine/export/ics.py
+++ b/astroengine/export/ics.py
@@ -1,0 +1,383 @@
+"""ICS calendar exports aligned with the AstroEngine normalized event model."""
+from __future__ import annotations
+
+import csv
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from io import StringIO
+from typing import Any, Iterable, Mapping, MutableMapping, Sequence, Tuple
+from zoneinfo import ZoneInfo
+
+from .timezone_blocks import build_vtimezone
+
+PRODID = "-//AstroEngine//Exports 1.0//EN"
+DEFAULT_CALENDAR_NAME = "AstroEngine Events"
+
+
+@dataclass(slots=True)
+class Alarm:
+    """Representation of an iCalendar ``VALARM`` entry."""
+
+    trigger: str
+    action: str = "DISPLAY"
+    description: str | None = None
+    duration: str | None = None
+    repeat: int | None = None
+
+
+@dataclass(slots=True)
+class CalendarEvent:
+    """Normalized calendar event for ICS/CSV export."""
+
+    uid: str
+    kind: str
+    summary: str
+    start: datetime | str
+    end: datetime | str | None = None
+    description: str | None = None
+    all_day: bool = False
+    location: str | None = None
+    categories: Sequence[str] = field(default_factory=tuple)
+    alarms: Sequence[Alarm] = field(default_factory=tuple)
+    meta: Mapping[str, Any] = field(default_factory=dict)
+    rdates: Sequence[datetime | str] = field(default_factory=tuple)
+    rrule: str | None = None
+    url: str | None = None
+    status: str | None = None
+    transparency: str | None = None
+    priority: int | None = None
+    created: datetime | str | None = None
+    last_modified: datetime | str | None = None
+
+
+EventLike = CalendarEvent | Mapping[str, Any]
+
+
+def to_ics(
+    events: Iterable[EventLike],
+    tz: str | ZoneInfo | None = "UTC",
+    calendar_name: str = DEFAULT_CALENDAR_NAME,
+    *,
+    color: str | None = None,
+    generated_ts: datetime | None = None,
+) -> bytes:
+    """Return ICS bytes for ``events`` using the normalized export contract."""
+
+    normalized = [_coerce_event(event) for event in events]
+    tzinfo, tzid = _resolve_timezone(tz)
+    dtstamp = (generated_ts or datetime.now(UTC)).astimezone(UTC)
+
+    lines: list[str] = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        f"PRODID:{PRODID}",
+        "CALSCALE:GREGORIAN",
+        f"X-WR-CALNAME:{_escape(calendar_name)}",
+    ]
+    if color:
+        lines.append(f"X-APPLE-CALENDAR-COLOR:{color}")
+    if tzid and tzid.upper() != "UTC":
+        tz_block = build_vtimezone(tzid, normalized)
+        if tz_block:
+            lines.extend(tz_block)
+
+    for event in normalized:
+        lines.extend(_render_event(event, tzinfo, tzid, dtstamp))
+
+    lines.append("END:VCALENDAR")
+    payload = "\r\n".join(lines) + "\r\n"
+    return payload.encode("utf-8")
+
+
+def to_csv(events: Iterable[EventLike]) -> bytes:
+    """Return CSV bytes mirroring the normalized event model."""
+
+    normalized = [_coerce_event(event) for event in events]
+    buffer = StringIO()
+    fieldnames = [
+        "uid",
+        "kind",
+        "summary",
+        "description",
+        "start",
+        "end",
+        "all_day",
+        "location",
+        "categories",
+        "alarms",
+        "meta",
+        "rdates",
+        "rrule",
+        "url",
+        "status",
+        "transparency",
+        "priority",
+    ]
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames)
+    writer.writeheader()
+    for event in normalized:
+        writer.writerow(
+            {
+                "uid": event.uid,
+                "kind": event.kind,
+                "summary": event.summary,
+                "description": event.description or "",
+                "start": _to_iso(event.start),
+                "end": _to_iso(event.end),
+                "all_day": "true" if event.all_day else "false",
+                "location": event.location or "",
+                "categories": ",".join(event.categories),
+                "alarms": json.dumps([_alarm_to_json(alarm) for alarm in event.alarms]),
+                "meta": json.dumps(event.meta, sort_keys=True, ensure_ascii=False),
+                "rdates": ",".join(_to_iso(value) for value in event.rdates),
+                "rrule": event.rrule or "",
+                "url": event.url or "",
+                "status": event.status or "",
+                "transparency": event.transparency or "",
+                "priority": "" if event.priority is None else str(event.priority),
+            }
+        )
+    return buffer.getvalue().encode("utf-8")
+
+
+def _coerce_event(payload: EventLike) -> CalendarEvent:
+    if isinstance(payload, CalendarEvent):
+        return payload
+    if not isinstance(payload, Mapping):  # pragma: no cover - defensive
+        raise TypeError(f"Unsupported event payload: {payload!r}")
+    data: MutableMapping[str, Any] = dict(payload)
+    alarms_raw = data.get("alarms") or []
+    alarms = [_coerce_alarm(alarm) for alarm in alarms_raw]
+    categories = tuple(str(value) for value in data.get("categories") or [])
+    meta = data.get("meta") or {}
+    rdates_raw = data.get("rdates") or []
+    return CalendarEvent(
+        uid=str(data["uid"]),
+        kind=str(data.get("kind", "event")),
+        summary=str(data.get("summary", "")),
+        description=data.get("description"),
+        start=data.get("start"),
+        end=data.get("end"),
+        all_day=bool(data.get("all_day", False)),
+        location=data.get("location"),
+        categories=categories,
+        alarms=tuple(alarms),
+        meta=dict(meta),
+        rdates=tuple(rdates_raw),
+        rrule=data.get("rrule"),
+        url=data.get("url"),
+        status=data.get("status"),
+        transparency=data.get("transparency"),
+        priority=data.get("priority"),
+        created=data.get("created"),
+        last_modified=data.get("last_modified"),
+    )
+
+
+def _coerce_alarm(payload: Mapping[str, Any]) -> Alarm:
+    if isinstance(payload, Alarm):  # pragma: no cover - handled earlier
+        return payload
+    return Alarm(
+        trigger=str(payload["trigger"]),
+        action=str(payload.get("action", "DISPLAY")),
+        description=payload.get("description"),
+        duration=payload.get("duration"),
+        repeat=payload.get("repeat"),
+    )
+
+
+def _resolve_timezone(tz: str | ZoneInfo | None) -> Tuple[ZoneInfo, str]:
+    if isinstance(tz, ZoneInfo):
+        return tz, getattr(tz, "key", "UTC") or "UTC"
+    if tz in (None, "UTC", "utc"):
+        return ZoneInfo("UTC"), "UTC"
+    zone = ZoneInfo(str(tz))
+    return zone, str(tz)
+
+
+def _render_event(
+    event: CalendarEvent,
+    tzinfo: ZoneInfo,
+    tzid: str,
+    dtstamp: datetime,
+) -> list[str]:
+    lines = ["BEGIN:VEVENT"]
+    dtstamp_formatted = dtstamp.strftime("%Y%m%dT%H%M%SZ")
+    lines.extend(_fold(f"DTSTAMP:{dtstamp_formatted}"))
+    lines.extend(_fold(f"UID:{_escape(event.uid)}"))
+    lines.extend(_fold(f"SUMMARY:{_escape(event.summary)}"))
+
+    start_fmt, start_utc = _format_event_dt(event.start, event.all_day, tzinfo, tzid)
+    end_fmt, end_utc = _format_event_dt(event.end, event.all_day, tzinfo, tzid)
+
+    if event.all_day:
+        lines.extend(_fold(f"DTSTART;VALUE=DATE:{start_fmt}"))
+        if end_fmt:
+            lines.extend(_fold(f"DTEND;VALUE=DATE:{end_fmt}"))
+        else:
+            # all-day events default to a single day; DTEND is exclusive so add one day
+            fallback = _format_date(_parse_datetime(event.start) + timedelta(days=1))
+            lines.extend(_fold(f"DTEND;VALUE=DATE:{fallback}"))
+    else:
+        if start_utc:
+            lines.extend(_fold(f"DTSTART:{start_fmt}"))
+        else:
+            lines.extend(_fold(f"DTSTART;TZID={tzid}:{start_fmt}"))
+        if end_fmt:
+            if end_utc:
+                lines.extend(_fold(f"DTEND:{end_fmt}"))
+            else:
+                lines.extend(_fold(f"DTEND;TZID={tzid}:{end_fmt}"))
+
+    if event.description:
+        lines.extend(_fold(f"DESCRIPTION:{_escape(event.description)}"))
+    if event.location:
+        lines.extend(_fold(f"LOCATION:{_escape(event.location)}"))
+    if event.categories:
+        categories = ",".join(_escape(cat) for cat in event.categories)
+        lines.extend(_fold(f"CATEGORIES:{categories}"))
+    if event.url:
+        lines.extend(_fold(f"URL:{_escape(event.url)}"))
+    if event.status:
+        lines.extend(_fold(f"STATUS:{_escape(event.status)}"))
+    if event.transparency:
+        lines.extend(_fold(f"TRANSP:{_escape(event.transparency)}"))
+    if event.priority is not None:
+        lines.extend(_fold(f"PRIORITY:{int(event.priority)}"))
+    if event.created:
+        created_dt = _parse_datetime(event.created).astimezone(UTC)
+        lines.extend(_fold(f"CREATED:{created_dt.strftime('%Y%m%dT%H%M%SZ')}"))
+    if event.last_modified:
+        modified_dt = _parse_datetime(event.last_modified).astimezone(UTC)
+        lines.extend(_fold(f"LAST-MODIFIED:{modified_dt.strftime('%Y%m%dT%H%M%SZ')}"))
+
+    lines.extend(_fold(f"X-ASTROENGINE-KIND:{_escape(event.kind)}"))
+    if event.meta:
+        meta_text = json.dumps(event.meta, sort_keys=True, ensure_ascii=False)
+        lines.extend(_fold(f"X-ASTROENGINE-META:{_escape(meta_text)}"))
+
+    if event.rdates:
+        if event.all_day:
+            all_day_values: list[str] = []
+            for value in event.rdates:
+                formatted, _ = _format_event_dt(value, True, tzinfo, tzid)
+                if formatted:
+                    all_day_values.append(formatted)
+            if all_day_values:
+                lines.extend(_fold(f"RDATE;VALUE=DATE:{','.join(all_day_values)}"))
+        else:
+            utc_values: list[str] = []
+            local_values: list[str] = []
+            for value in event.rdates:
+                formatted, is_utc = _format_event_dt(value, False, tzinfo, tzid)
+                if formatted is None:
+                    continue
+                if is_utc:
+                    utc_values.append(formatted)
+                else:
+                    local_values.append(formatted)
+            if utc_values:
+                lines.extend(_fold(f"RDATE:{','.join(utc_values)}"))
+            if local_values:
+                lines.extend(_fold(f"RDATE;TZID={tzid}:{','.join(local_values)}"))
+    if event.rrule:
+        lines.extend(_fold(f"RRULE:{event.rrule}"))
+
+    for alarm in event.alarms:
+        lines.append("BEGIN:VALARM")
+        lines.extend(_fold(f"ACTION:{_escape(alarm.action)}"))
+        lines.extend(_fold(f"TRIGGER:{alarm.trigger}"))
+        if alarm.description:
+            lines.extend(_fold(f"DESCRIPTION:{_escape(alarm.description)}"))
+        if alarm.duration:
+            lines.extend(_fold(f"DURATION:{alarm.duration}"))
+        if alarm.repeat is not None:
+            lines.extend(_fold(f"REPEAT:{int(alarm.repeat)}"))
+        lines.append("END:VALARM")
+
+    lines.append("END:VEVENT")
+    return lines
+
+
+def _format_event_dt(
+    value: datetime | str | None,
+    all_day: bool,
+    tzinfo: ZoneInfo,
+    tzid: str,
+) -> tuple[str | None, bool]:
+    if value is None:
+        if all_day:
+            return None, True
+        return None, True
+    dt = _parse_datetime(value)
+    if all_day:
+        return _format_date(dt), True
+    localized = dt.astimezone(tzinfo)
+    if tzid.upper() == "UTC":
+        return localized.astimezone(UTC).strftime("%Y%m%dT%H%M%SZ"), True
+    return localized.strftime("%Y%m%dT%H%M%S"), False
+
+
+def _parse_datetime(value: datetime | str) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+    text = str(value)
+    if text.endswith("Z"):
+        text = text.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Invalid ISO timestamp: {value!r}") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _format_date(dt: datetime) -> str:
+    return dt.date().strftime("%Y%m%d")
+
+
+def _fold(text: str) -> list[str]:
+    if len(text) <= 75:
+        return [text]
+    output: list[str] = []
+    remaining = text
+    while len(remaining) > 75:
+        chunk = remaining[:75]
+        output.append(chunk)
+        remaining = " " + remaining[75:]
+    output.append(remaining)
+    return output
+
+
+def _escape(value: str) -> str:
+    return (
+        value.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace(";", "\\;")
+        .replace(",", "\\,")
+    )
+
+
+def _alarm_to_json(alarm: Alarm) -> dict[str, Any]:
+    payload: dict[str, Any] = {"trigger": alarm.trigger, "action": alarm.action}
+    if alarm.description is not None:
+        payload["description"] = alarm.description
+    if alarm.duration is not None:
+        payload["duration"] = alarm.duration
+    if alarm.repeat is not None:
+        payload["repeat"] = alarm.repeat
+    return payload
+
+
+def _to_iso(value: datetime | str | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.isoformat()
+        return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+    return str(value)

--- a/astroengine/export/timezone_blocks.py
+++ b/astroengine/export/timezone_blocks.py
@@ -1,0 +1,149 @@
+"""Utilities for generating RFC-5545 VTIMEZONE components."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Sequence
+from zoneinfo import ZoneInfo
+
+if False:  # pragma: no cover - typing helper
+    from .ics import CalendarEvent
+
+
+@dataclass
+class _Transition:
+    moment: datetime
+    offset_from: timedelta
+    offset_to: timedelta
+    name_from: str
+    name_to: str
+
+    @property
+    def component(self) -> str:
+        # Determine whether the transition ends in daylight time.
+        return "DAYLIGHT" if self.offset_to > self.offset_from else "STANDARD"
+
+
+def build_vtimezone(tzid: str, events: Sequence["CalendarEvent"]) -> list[str]:
+    """Return a list of ICS lines describing ``tzid`` for the event window."""
+
+    if not events:
+        return []
+
+    tz = ZoneInfo(tzid)
+    start, end = _window(events)
+    start_local = start.astimezone(tz)
+    end_local = end.astimezone(tz)
+
+    transitions = _collect_transitions(tz, start_local, end_local)
+    if not transitions:
+        offset = tz.utcoffset(start_local) or timedelta(0)
+        name = tz.tzname(start_local) or tzid
+        return [
+            "BEGIN:VTIMEZONE",
+            f"TZID:{tzid}",
+            "BEGIN:STANDARD",
+            f"DTSTART:{start_local.strftime('%Y%m%dT%H%M%S')}",
+            f"TZOFFSETFROM:{_format_offset(offset)}",
+            f"TZOFFSETTO:{_format_offset(offset)}",
+            f"TZNAME:{name}",
+            "END:STANDARD",
+            "END:VTIMEZONE",
+        ]
+
+    lines = ["BEGIN:VTIMEZONE", f"TZID:{tzid}"]
+    for transition in transitions:
+        block_type = transition.component
+        local_moment = transition.moment.astimezone(tz)
+        lines.extend(
+            [
+                f"BEGIN:{block_type}",
+                f"DTSTART:{local_moment.strftime('%Y%m%dT%H%M%S')}",
+                f"TZOFFSETFROM:{_format_offset(transition.offset_from)}",
+                f"TZOFFSETTO:{_format_offset(transition.offset_to)}",
+                f"TZNAME:{transition.name_to}",
+                "END:DAYLIGHT" if block_type == "DAYLIGHT" else "END:STANDARD",
+            ]
+        )
+    lines.append("END:VTIMEZONE")
+    return lines
+
+
+def _window(events: Sequence["CalendarEvent"]) -> tuple[datetime, datetime]:
+    earliest = datetime.max.replace(tzinfo=UTC)
+    latest = datetime.min.replace(tzinfo=UTC)
+    for event in events:
+        start = getattr(event, "start", None)
+        end = getattr(event, "end", None)
+        if start is not None:
+            dt_start = _ensure_datetime(start)
+            if dt_start < earliest:
+                earliest = dt_start
+        if end is not None:
+            dt_end = _ensure_datetime(end)
+            if dt_end > latest:
+                latest = dt_end
+    if latest <= earliest:
+        latest = earliest + timedelta(days=1)
+    return earliest, latest
+
+
+def _ensure_datetime(value) -> datetime:
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+    text = str(value)
+    if text.endswith("Z"):
+        text = text.replace("Z", "+00:00")
+    parsed = datetime.fromisoformat(text)
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=UTC)
+    return parsed
+
+
+def _collect_transitions(tz: ZoneInfo, start: datetime, end: datetime) -> list[_Transition]:
+    # Expand window to capture boundary transitions.
+    cursor = start - timedelta(days=370)
+    stop = end + timedelta(days=370)
+    transitions: list[_Transition] = []
+    previous_offset = tz.utcoffset(cursor) or timedelta(0)
+    previous_name = tz.tzname(cursor) or tz.key
+    while cursor < stop:
+        cursor += timedelta(days=1)
+        current_offset = tz.utcoffset(cursor) or timedelta(0)
+        current_name = tz.tzname(cursor) or tz.key
+        if current_offset != previous_offset or current_name != previous_name:
+            moment = _bisect_transition(tz, cursor - timedelta(days=1), cursor)
+            transitions.append(
+                _Transition(
+                    moment=moment,
+                    offset_from=previous_offset,
+                    offset_to=current_offset,
+                    name_from=previous_name,
+                    name_to=current_name,
+                )
+            )
+            previous_offset = current_offset
+            previous_name = current_name
+    return transitions
+
+
+def _bisect_transition(tz: ZoneInfo, lower: datetime, upper: datetime) -> datetime:
+    while (upper - lower) > timedelta(minutes=1):
+        midpoint = lower + (upper - lower) / 2
+        if tz.utcoffset(midpoint) == tz.utcoffset(lower):
+            lower = midpoint
+        else:
+            upper = midpoint
+    return upper
+
+
+def _format_offset(delta: timedelta) -> str:
+    total_seconds = int(delta.total_seconds())
+    sign = "+" if total_seconds >= 0 else "-"
+    total_seconds = abs(total_seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes = remainder // 60
+    return f"{sign}{hours:02d}{minutes:02d}"

--- a/tests/export/test_ics_exports.py
+++ b/tests/export/test_ics_exports.py
@@ -1,0 +1,68 @@
+from datetime import UTC, datetime
+
+from astroengine.export import Alarm, CalendarEvent, to_csv, to_ics
+
+
+def _sample_event():
+    return CalendarEvent(
+        uid="evt-123",
+        kind="transit",
+        summary="Venus trine Jupiter",
+        description="Facet breakdown",
+        start="2025-05-02T14:20:00Z",
+        end="2025-05-02T16:20:00Z",
+        location="New York, NY",
+        categories=("Astro", "Trine"),
+        alarms=(Alarm(trigger="-PT30M"),),
+        meta={"severity": 0.86, "dataset": "sf9://election/123"},
+    )
+
+
+def test_to_ics_emits_categories_and_alarm(tmp_path):
+    events = [_sample_event()]
+    stamp = datetime(2024, 1, 1, tzinfo=UTC)
+
+    payload = to_ics(events, tz="America/New_York", calendar_name="Astro Planner", generated_ts=stamp)
+    text = payload.decode("utf-8")
+
+    assert "BEGIN:VCALENDAR" in text
+    assert "X-WR-CALNAME:Astro Planner" in text
+    assert "BEGIN:VTIMEZONE" in text and "TZID:America/New_York" in text
+    assert "SUMMARY:Venus trine Jupiter" in text
+    assert "CATEGORIES:Astro,Trine" in text
+    assert "BEGIN:VALARM" in text and "TRIGGER:-PT30M" in text
+    assert "X-ASTROENGINE-META:" in text
+    # DTSTART should reference the requested timezone without a Z suffix
+    assert "DTSTART;TZID=America/New_York:20250502T102000" in text
+
+
+def test_to_csv_preserves_payload_round_trip():
+    events = [_sample_event()]
+    csv_bytes = to_csv(events)
+    text = csv_bytes.decode("utf-8")
+    lines = text.splitlines()
+    assert lines[0].startswith("uid,kind,summary")
+    assert "evt-123" in lines[1]
+    assert "sf9://election/123" in lines[1]
+
+
+def test_multiple_events_fold_long_lines():
+    long_description = "This description is extremely long " * 4
+    events = [
+        CalendarEvent(
+            uid="evt-456",
+            kind="return",
+            summary="Mars return",
+            description=long_description,
+            start="2025-07-01T05:00:00Z",
+            all_day=False,
+            alarms=(Alarm(trigger="-P1D", description="Reminder"),),
+            meta={"note": "Check Solar Fire"},
+        )
+    ]
+    stamp = datetime(2024, 1, 1, tzinfo=UTC)
+    payload = to_ics(events, generated_ts=stamp)
+    text = payload.decode("utf-8")
+    folded = [line for line in text.split("\r\n") if line.startswith(" ")]  # continuation lines
+    assert folded, "Expected folded lines for long description"
+    assert "DESCRIPTION:This description" in text


### PR DESCRIPTION
## Summary
- add a dedicated `astroengine.export` package that normalizes calendar events and serializes them to ICS and CSV
- provide RFC-5545 timezone block generation helpers so local exports include `VTIMEZONE`
- cover the exporter with unit tests exercising categories, alarms, and line folding behaviour

## Testing
- pytest tests/export/test_ics_exports.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d88f472eec832491b2912ef34bd6c5