### PR TITLE
fix(minorplanets): reconstruct MPC elements and expand presets

### DIFF
--- a/astroengine/engine/minorplanets/__init__.py
+++ b/astroengine/engine/minorplanets/__init__.py
@@ -1,0 +1,39 @@
+"""Minor planet ingestion, registries, and indexing utilities."""
+
+from .mpc_ingest import (
+    Counts,
+    MinorPlanet,
+    MinorPlanetBase,
+    MpcRow,
+    download_mpcorb,
+    export_parquet,
+    export_zarr_angles,
+    filter_rows,
+    parse_mpcorb,
+    upsert_rows,
+)
+from .builtins import (
+    CuratedMinorPlanet,
+    CURATED_MINOR_PLANETS,
+    DEFAULT_MINOR_BODY_ORBS,
+    lilith_mean,
+    lilith_true,
+)
+
+__all__ = [
+    "Counts",
+    "MinorPlanet",
+    "MinorPlanetBase",
+    "MpcRow",
+    "download_mpcorb",
+    "export_parquet",
+    "export_zarr_angles",
+    "filter_rows",
+    "parse_mpcorb",
+    "upsert_rows",
+    "CuratedMinorPlanet",
+    "CURATED_MINOR_PLANETS",
+    "DEFAULT_MINOR_BODY_ORBS",
+    "lilith_mean",
+    "lilith_true",
+]

--- a/astroengine/engine/minorplanets/builtins.py
+++ b/astroengine/engine/minorplanets/builtins.py
@@ -1,0 +1,102 @@
+"""Curated minor planet definitions and Lilith longitude helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Final
+
+import swisseph as swe
+
+from astroengine.core.time import ensure_utc, julian_day
+
+__all__ = [
+    "CuratedMinorPlanet",
+    "DEFAULT_MINOR_BODY_ORBS",
+    "CURATED_MINOR_PLANETS",
+    "lilith_mean",
+    "lilith_true",
+]
+
+
+_SWE_INITIALISED: bool = False
+
+
+def _ensure_swisseph_path() -> None:
+    """Initialise Swiss Ephemeris with the bundled stub data."""
+
+    global _SWE_INITIALISED
+    if _SWE_INITIALISED:
+        return
+    from pathlib import Path
+
+    ephe_dir = Path(__file__).resolve().parents[3] / "datasets" / "swisseph_stub"
+    swe.set_ephe_path(str(ephe_dir))
+    _SWE_INITIALISED = True
+
+
+def _calc_apogee_longitude(moment: datetime, body: int) -> float:
+    """Return the ecliptic longitude for the requested apogee variant."""
+
+    _ensure_swisseph_path()
+    utc_moment = ensure_utc(moment)
+    jd_ut = julian_day(utc_moment)
+    position, _ = swe.calc_ut(jd_ut, body)
+    longitude = position[0] % 360.0
+    if longitude < 0.0:
+        longitude += 360.0
+    return float(longitude)
+
+
+def lilith_mean(moment: datetime) -> float:
+    """Return the mean Black Moon Lilith longitude in degrees."""
+
+    return _calc_apogee_longitude(moment, swe.MEAN_APOG)
+
+
+def lilith_true(moment: datetime) -> float:
+    """Return the oscillating Black Moon Lilith longitude in degrees."""
+
+    return _calc_apogee_longitude(moment, swe.OSCU_APOG)
+
+
+@dataclass(frozen=True, slots=True)
+class CuratedMinorPlanet:
+    """Metadata describing curated non-MPC bodies."""
+
+    name: str
+    designation: str
+    kind: str
+    default_orb: float
+
+
+DEFAULT_MINOR_BODY_ORBS: Final[dict[str, float]] = {
+    "chiron": 2.0,
+    "eris": 1.0,
+    "sedna": 1.0,
+    "haumea": 1.0,
+    "makemake": 1.0,
+    "ceres": 2.0,
+    "pallas": 2.0,
+    "juno": 2.0,
+    "vesta": 2.0,
+    "mean_lilith": 2.0,
+    "true_lilith": 2.0,
+    "large_numbered": 1.5,
+    "default": 1.0,
+}
+
+
+CURATED_MINOR_PLANETS: Final[tuple[CuratedMinorPlanet, ...]] = (
+    CuratedMinorPlanet("Chiron", "2060 Chiron", "centaur", DEFAULT_MINOR_BODY_ORBS["chiron"]),
+    CuratedMinorPlanet("Eris", "136199 Eris", "tno", DEFAULT_MINOR_BODY_ORBS["eris"]),
+    CuratedMinorPlanet("Sedna", "90377 Sedna", "tno", DEFAULT_MINOR_BODY_ORBS["sedna"]),
+    CuratedMinorPlanet("Haumea", "136108 Haumea", "tno", DEFAULT_MINOR_BODY_ORBS["haumea"]),
+    CuratedMinorPlanet("Makemake", "136472 Makemake", "tno", DEFAULT_MINOR_BODY_ORBS["makemake"]),
+    CuratedMinorPlanet("Ceres", "1 Ceres", "dwarf", DEFAULT_MINOR_BODY_ORBS["ceres"]),
+    CuratedMinorPlanet("Pallas", "2 Pallas", "asteroid", DEFAULT_MINOR_BODY_ORBS["pallas"]),
+    CuratedMinorPlanet("Juno", "3 Juno", "asteroid", DEFAULT_MINOR_BODY_ORBS["juno"]),
+    CuratedMinorPlanet("Vesta", "4 Vesta", "asteroid", DEFAULT_MINOR_BODY_ORBS["vesta"]),
+    CuratedMinorPlanet("Black Moon Lilith (Mean)", "mean_lilith", "point", DEFAULT_MINOR_BODY_ORBS["mean_lilith"]),
+    CuratedMinorPlanet("Black Moon Lilith (True)", "true_lilith", "point", DEFAULT_MINOR_BODY_ORBS["true_lilith"]),
+)

--- a/astroengine/engine/minorplanets/mpc_ingest.py
+++ b/astroengine/engine/minorplanets/mpc_ingest.py
@@ -1,0 +1,443 @@
+"""Utilities for downloading, parsing, and storing MPCORB elements."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import gzip
+import hashlib
+import math
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+from sqlalchemy import JSON, Column, DateTime, Float, Integer, String, func, select
+from sqlalchemy.orm import DeclarativeBase, Session
+
+from astroengine.core.time import julian_day
+
+__all__ = [
+    "Counts",
+    "MinorPlanet",
+    "MinorPlanetBase",
+    "MpcRow",
+    "download_mpcorb",
+    "export_parquet",
+    "export_zarr_angles",
+    "filter_rows",
+    "parse_mpcorb",
+    "upsert_rows",
+]
+
+
+_DEFAULT_MPC_URL = "https://minorplanetcenter.net/Extended_Files/MPCORB.DAT.gz"
+
+# See https://en.wikipedia.org/wiki/Gaussian_gravitational_constant. The MPCORB
+# catalogue expresses mean motion in degrees per day; the Gaussian constant is
+# defined in astronomical units^(3/2) per day, so we convert to and from
+# radians/degrees as needed.
+_GAUSSIAN_GRAVITATIONAL_CONSTANT = 0.01720209895
+
+
+class MinorPlanetBase(DeclarativeBase):
+    """Dedicated SQLAlchemy base for minor planet tables."""
+
+    pass
+
+
+class MinorPlanet(MinorPlanetBase):
+    """ORM model storing MPC-derived orbital elements."""
+
+    __tablename__ = "mpc_bodies"
+
+    body_id = Column(Integer, primary_key=True, autoincrement=True)
+    mpc_number = Column(Integer, nullable=True, index=True)
+    provisional_designation = Column(String(32), nullable=True, index=True)
+    name = Column(String(128), nullable=True, index=True)
+    kind = Column(String(16), nullable=False, default="asteroid")
+    family = Column(String(64), nullable=True)
+    absolute_magnitude = Column(Float, nullable=True)
+    slope = Column(Float, nullable=True)
+    uncertainty = Column(Integer, nullable=True)
+    epoch_jd = Column(Float, nullable=False)
+    mean_anomaly_deg = Column(Float, nullable=False)
+    argument_perihelion_deg = Column(Float, nullable=False)
+    ascending_node_deg = Column(Float, nullable=False)
+    inclination_deg = Column(Float, nullable=False)
+    eccentricity = Column(Float, nullable=False)
+    mean_motion_deg_per_day = Column(Float, nullable=False)
+    semi_major_axis_au = Column(Float, nullable=False)
+    perihelion_distance_au = Column(Float, nullable=False)
+    data_source = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    def update_from_row(self, row: "MpcRow") -> None:
+        """Update the ORM instance with the latest parsed values."""
+
+        self.mpc_number = row.mpc_number
+        self.provisional_designation = row.provisional_designation
+        self.name = row.name or self.name
+        self.kind = row.kind
+        self.family = row.family
+        self.absolute_magnitude = row.absolute_magnitude
+        self.slope = row.slope
+        self.uncertainty = row.uncertainty
+        self.epoch_jd = row.epoch_jd
+        self.mean_anomaly_deg = row.mean_anomaly_deg
+        self.argument_perihelion_deg = row.argument_perihelion_deg
+        self.ascending_node_deg = row.ascending_node_deg
+        self.inclination_deg = row.inclination_deg
+        self.eccentricity = row.eccentricity
+        self.mean_motion_deg_per_day = row.mean_motion_deg_per_day
+        self.semi_major_axis_au = row.semi_major_axis_au
+        self.perihelion_distance_au = row.perihelion_distance_au
+        self.data_source = row.source
+
+    @classmethod
+    def from_row(cls, row: "MpcRow") -> "MinorPlanet":
+        instance = cls()
+        instance.update_from_row(row)
+        return instance
+
+
+@dataclass(slots=True)
+class MpcRow:
+    """Parsed Minor Planet Center row."""
+
+    mpc_number: int | None
+    provisional_designation: str | None
+    name: str | None
+    kind: str
+    family: str | None
+    absolute_magnitude: float | None
+    slope: float | None
+    uncertainty: int | None
+    epoch_jd: float
+    mean_anomaly_deg: float
+    argument_perihelion_deg: float
+    ascending_node_deg: float
+    inclination_deg: float
+    eccentricity: float
+    mean_motion_deg_per_day: float
+    semi_major_axis_au: float
+    perihelion_distance_au: float
+    source: dict[str, str] = field(default_factory=dict)
+
+    def as_dict(self) -> dict[str, object]:
+        return {
+            "mpc_number": self.mpc_number,
+            "provisional_designation": self.provisional_designation,
+            "name": self.name,
+            "kind": self.kind,
+            "family": self.family,
+            "absolute_magnitude": self.absolute_magnitude,
+            "slope": self.slope,
+            "uncertainty": self.uncertainty,
+            "epoch_jd": self.epoch_jd,
+            "mean_anomaly_deg": self.mean_anomaly_deg,
+            "argument_perihelion_deg": self.argument_perihelion_deg,
+            "ascending_node_deg": self.ascending_node_deg,
+            "inclination_deg": self.inclination_deg,
+            "eccentricity": self.eccentricity,
+            "mean_motion_deg_per_day": self.mean_motion_deg_per_day,
+            "semi_major_axis_au": self.semi_major_axis_au,
+            "perihelion_distance_au": self.perihelion_distance_au,
+            "source": self.source,
+        }
+
+
+@dataclass(slots=True)
+class Counts:
+    """Summary of insert and update activity."""
+
+    inserted: int = 0
+    updated: int = 0
+
+
+def download_mpcorb(cache_dir: str | os.PathLike[str]) -> Path:
+    """Download the MPCORB catalogue into ``cache_dir`` with checksums."""
+
+    cache_path = Path(cache_dir)
+    cache_path.mkdir(parents=True, exist_ok=True)
+    url = os.environ.get("ASTROENGINE_MPCORB_URL", _DEFAULT_MPC_URL)
+    target = cache_path / "MPCORB.dat.gz"
+    checksum_path = target.with_suffix(".sha256")
+
+    response = requests.get(url, stream=True, timeout=120)
+    response.raise_for_status()
+
+    sha256 = hashlib.sha256()
+    with tempfile_path(target) as tmp_path:
+        with open(tmp_path, "wb") as handle:
+            for chunk in response.iter_content(chunk_size=1 << 20):
+                if not chunk:
+                    continue
+                handle.write(chunk)
+                sha256.update(chunk)
+    checksum = sha256.hexdigest()
+    checksum_path.write_text(checksum)
+    return target
+
+
+class tempfile_path:
+    """Context manager ensuring atomic downloads."""
+
+    def __init__(self, target: Path) -> None:
+        self.target = target
+        self.tmp = target.with_suffix(target.suffix + ".tmp")
+
+    def __enter__(self) -> Path:
+        if self.tmp.exists():
+            self.tmp.unlink()
+        return self.tmp
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        if exc_type is None:
+            self.tmp.replace(self.target)
+        elif self.tmp.exists():
+            self.tmp.unlink()
+
+
+def parse_mpcorb(path: str | os.PathLike[str]) -> list[MpcRow]:
+    """Parse MPCORB data into :class:`MpcRow` structures."""
+
+    path = Path(path)
+    opener = gzip.open if path.suffix == ".gz" else open
+    rows: list[MpcRow] = []
+    with opener(path, "rt", encoding="utf8", errors="ignore") as handle:
+        for raw_line in handle:
+            if not raw_line or raw_line.startswith("#"):
+                continue
+            line = raw_line.rstrip("\n")
+            if not line.strip():
+                continue
+            try:
+                row = _parse_line(line)
+            except ValueError:
+                continue
+            rows.append(row)
+    return rows
+
+
+def _parse_line(line: str) -> MpcRow:
+    number = _parse_int(line[0:7])
+    absolute_magnitude = _parse_float(line[8:14])
+    slope = _parse_float(line[14:20])
+    epoch_field = line[20:32].strip() or line[19:32].strip()
+    epoch_jd = _parse_epoch(epoch_field)
+    mean_anomaly = _parse_float(line[32:44])
+    arg_peri = _parse_float(line[44:56])
+    ascending_node = _parse_float(line[56:68])
+    inclination = _parse_float(line[68:80])
+    eccentricity = _parse_float(line[80:92])
+    mean_motion = _parse_float(line[92:105])
+    semi_major = _parse_float(line[105:118])
+    uncertainty = _parse_int(line[118:120])
+    provisional = line[120:136].strip() or None
+    name = line[166:].strip() or None
+    if semi_major is None and mean_motion is not None:
+        semi_major = _semi_major_from_mean_motion(mean_motion)
+    if mean_motion is None and semi_major is not None:
+        mean_motion = _mean_motion_from_semi_major(semi_major)
+
+    perihelion = semi_major * (1.0 - eccentricity) if semi_major is not None else None
+
+    if None in (
+        epoch_jd,
+        mean_anomaly,
+        arg_peri,
+        ascending_node,
+        inclination,
+        eccentricity,
+        mean_motion,
+        semi_major,
+        perihelion,
+    ):
+        raise ValueError("Incomplete MPC row")
+
+    kind = _classify_minor_planet(semi_major)
+    source = {"line": line.strip()}
+    return MpcRow(
+        mpc_number=number,
+        provisional_designation=provisional,
+        name=name,
+        kind=kind,
+        family=None,
+        absolute_magnitude=absolute_magnitude,
+        slope=slope,
+        uncertainty=uncertainty,
+        epoch_jd=epoch_jd,
+        mean_anomaly_deg=mean_anomaly,
+        argument_perihelion_deg=arg_peri,
+        ascending_node_deg=ascending_node,
+        inclination_deg=inclination,
+        eccentricity=eccentricity,
+        mean_motion_deg_per_day=mean_motion,
+        semi_major_axis_au=semi_major,
+        perihelion_distance_au=perihelion,
+        source=source,
+    )
+
+
+def _classify_minor_planet(semi_major_axis: float) -> str:
+    if semi_major_axis >= 30.0:
+        return "tno"
+    if semi_major_axis >= 5.5:
+        return "centaur"
+    return "asteroid"
+
+
+def _parse_int(value: str) -> int | None:
+    value = value.strip()
+    if not value:
+        return None
+    return int(value)
+
+
+def _parse_float(value: str) -> float | None:
+    value = value.strip()
+    if not value:
+        return None
+    return float(value)
+
+
+def _mean_motion_from_semi_major(semi_major: float) -> float:
+    if semi_major <= 0.0:
+        raise ValueError("semi-major axis must be positive")
+    n_rad = _GAUSSIAN_GRAVITATIONAL_CONSTANT / math.pow(semi_major, 1.5)
+    return math.degrees(n_rad)
+
+
+def _semi_major_from_mean_motion(mean_motion: float) -> float:
+    if mean_motion <= 0.0:
+        raise ValueError("mean motion must be positive")
+    n_rad = math.radians(mean_motion)
+    return math.pow(_GAUSSIAN_GRAVITATIONAL_CONSTANT / n_rad, 2.0 / 3.0)
+
+
+def _parse_epoch(token: str) -> float:
+    if not token:
+        raise ValueError("missing epoch")
+    token = token.strip()
+    if token.replace(".", "", 1).isdigit():
+        return float(token)
+    return _julian_day_from_packed(token)
+
+
+_PACKED_YEAR_OFFSET = {
+    **{str(d): d for d in range(10)},
+    **{chr(ord("A") + i): 10 + i for i in range(26)},
+}
+_PACKED_DAY_OFFSET = {**_PACKED_YEAR_OFFSET, **{chr(ord("a") + i): 36 + i for i in range(26)}}
+
+
+def _julian_day_from_packed(token: str) -> float:
+    if len(token) != 5:
+        raise ValueError(f"Unexpected packed epoch '{token}'")
+    century = _PACKED_YEAR_OFFSET[token[0]]
+    year_suffix = int(token[1:3])
+    year = century * 100 + year_suffix
+    month = _PACKED_YEAR_OFFSET[token[3]]
+    day = _PACKED_DAY_OFFSET[token[4]]
+    moment = _dt.datetime(year, month, day, tzinfo=_dt.UTC)
+    return julian_day(moment)
+
+
+def filter_rows(rows: Sequence[MpcRow], H_max: float = 12.0, U_max: int = 5) -> list[MpcRow]:
+    """Filter rows based on absolute magnitude and uncertainty."""
+
+    filtered: list[MpcRow] = []
+    for row in rows:
+        if row.absolute_magnitude is not None and row.absolute_magnitude > H_max:
+            continue
+        if row.uncertainty is not None and row.uncertainty > U_max:
+            continue
+        filtered.append(row)
+    return filtered
+
+
+def upsert_rows(session: Session, rows: Sequence[MpcRow]) -> Counts:
+    """Insert or update :class:`MpcRow` entries into the database."""
+
+    counts = Counts()
+    for row in rows:
+        statement = None
+        if row.mpc_number is not None:
+            statement = select(MinorPlanet).where(MinorPlanet.mpc_number == row.mpc_number)
+        elif row.provisional_designation:
+            statement = select(MinorPlanet).where(
+                MinorPlanet.provisional_designation == row.provisional_designation
+            )
+        elif row.name:
+            statement = select(MinorPlanet).where(MinorPlanet.name == row.name)
+
+        existing = session.scalar(statement) if statement is not None else None
+        if existing is None:
+            session.add(MinorPlanet.from_row(row))
+            counts.inserted += 1
+        else:
+            existing.update_from_row(row)
+            counts.updated += 1
+    return counts
+
+
+def export_parquet(rows: Sequence[MpcRow], path: str | os.PathLike[str]) -> Path:
+    """Export rows to a Parquet file for analytics workflows."""
+
+    path = Path(path)
+    data = [row.as_dict() for row in rows]
+    table = pa.Table.from_pylist(data)
+    pq.write_table(table, path)
+    return path
+
+
+def export_zarr_angles(
+    ephem,
+    rows: Sequence[MpcRow],
+    start: _dt.datetime,
+    end: _dt.datetime,
+    step: _dt.timedelta,
+    out_dir: str | os.PathLike[str],
+    *,
+    scale: int = 100,
+) -> Path:
+    """Export quantised longitudes to a Zarr array on disk."""
+
+    try:
+        import zarr
+    except ModuleNotFoundError as exc:  # pragma: no cover - optional dependency
+        raise ModuleNotFoundError(
+            "The 'zarr' package is required for export_zarr_angles"  # noqa: TRY003
+        ) from exc
+
+    out_path = Path(out_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+    timestamps = _build_time_grid(start, end, step)
+    data = np.empty((len(rows), len(timestamps)), dtype=np.uint16)
+
+    for i, row in enumerate(rows):
+        for j, moment in enumerate(timestamps):
+            lon = float(ephem.longitude(row, moment)) % 360.0
+            if lon < 0.0:
+                lon += 360.0
+            data[i, j] = int(round(lon * scale)) % (360 * scale)
+
+    store_path = out_path / "angles.zarr"
+    zarr.save_array(store_path, data, compressor=zarr.Blosc())
+    return store_path
+
+
+def _build_time_grid(start: _dt.datetime, end: _dt.datetime, step: _dt.timedelta) -> list[_dt.datetime]:
+    moments: list[_dt.datetime] = []
+    current = start
+    while current <= end:
+        moments.append(current)
+        current = current + step
+    return moments

--- a/tests/minorplanets/test_builtins_lilith.py
+++ b/tests/minorplanets/test_builtins_lilith.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from astroengine.engine.minorplanets import builtins
+
+
+def test_lilith_variants_diverge() -> None:
+    moment = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    mean = builtins.lilith_mean(moment)
+    true = builtins.lilith_true(moment)
+    assert 0.0 <= mean < 360.0
+    assert 0.0 <= true < 360.0
+    assert abs(mean - true) > 0.1
+
+
+def test_lilith_progression_monotonic() -> None:
+    base = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    first = builtins.lilith_mean(base)
+    second = builtins.lilith_mean(base.replace(day=2))
+    assert first != second
+
+
+def test_curated_minor_planets_cover_core_set() -> None:
+    designations = {body.designation for body in builtins.CURATED_MINOR_PLANETS}
+    expected = {
+        "2060 Chiron",
+        "136199 Eris",
+        "90377 Sedna",
+        "136108 Haumea",
+        "136472 Makemake",
+        "1 Ceres",
+        "2 Pallas",
+        "3 Juno",
+        "4 Vesta",
+        "mean_lilith",
+        "true_lilith",
+    }
+    assert expected.issubset(designations)
+
+
+def test_default_minor_body_orbs_include_overrides() -> None:
+    assert pytest.approx(builtins.DEFAULT_MINOR_BODY_ORBS["large_numbered"]) == 1.5
+    assert pytest.approx(builtins.DEFAULT_MINOR_BODY_ORBS["default"]) == 1.0

--- a/tests/minorplanets/test_minorplanet_exports.py
+++ b/tests/minorplanets/test_minorplanet_exports.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+
+from astroengine.engine.minorplanets import mpc_ingest
+
+
+class DummyEphem:
+    def longitude(self, row: mpc_ingest.MpcRow, moment: dt.datetime) -> float:
+        base = (row.mpc_number or 0) * 1.0
+        return (base + moment.timetuple().tm_yday) % 360.0
+
+
+def _row(number: int) -> mpc_ingest.MpcRow:
+    return mpc_ingest.MpcRow(
+        mpc_number=number,
+        provisional_designation=f"X{number:04d}",
+        name=f"Asteroid {number}",
+        kind="asteroid",
+        family=None,
+        absolute_magnitude=10.0,
+        slope=0.15,
+        uncertainty=1,
+        epoch_jd=2459200.5,
+        mean_anomaly_deg=0.0,
+        argument_perihelion_deg=0.0,
+        ascending_node_deg=0.0,
+        inclination_deg=0.0,
+        eccentricity=0.1,
+        mean_motion_deg_per_day=0.1,
+        semi_major_axis_au=2.7,
+        perihelion_distance_au=2.4,
+        source={"line": ""},
+    )
+
+
+def test_export_parquet_round_trip(tmp_path: Path) -> None:
+    rows = [_row(1), _row(2)]
+    path = tmp_path / "rows.parquet"
+    mpc_ingest.export_parquet(rows, path)
+    table = pq.read_table(path)
+    assert table.num_rows == 2
+    assert table.column("mpc_number")[0].as_py() == 1
+
+
+def test_export_zarr_angles(tmp_path: Path) -> None:
+    zarr = pytest.importorskip("zarr")
+    rows = [_row(1), _row(2)]
+    start = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+    end = dt.datetime(2024, 1, 2, tzinfo=dt.timezone.utc)
+    step = dt.timedelta(days=1)
+    ephem = DummyEphem()
+    store_path = mpc_ingest.export_zarr_angles(ephem, rows, start, end, step, tmp_path)
+    arr = zarr.open(store_path, mode="r")
+    assert arr.shape == (2, 2)
+    assert arr[0, 0] != arr[0, 1]

--- a/tests/minorplanets/test_mpc_parse.py
+++ b/tests/minorplanets/test_mpc_parse.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from astroengine.engine.minorplanets import mpc_ingest
+
+
+def _format_field(value: str, width: int) -> str:
+    text = f"{value:>{width}}"
+    if len(text) > width:
+        return text[:width]
+    return text
+
+
+def _format_float(value: float, width: int, precision: int) -> str:
+    text = f"{value:{width}.{precision}f}"
+    if len(text) > width:
+        text = text[:width]
+    return text
+
+
+def _mpc_line(
+    number: int,
+    H: float,
+    G: float,
+    epoch_jd: float,
+    mean_anomaly: float,
+    arg_peri: float,
+    ascending_node: float,
+    inclination: float,
+    eccentricity: float,
+    mean_motion: float,
+    semi_major: float,
+    uncertainty: int,
+    provisional: str,
+    name: str,
+) -> str:
+    line = [" "] * 194
+    line[0:7] = _format_field(f"{number:d}", 7)
+    line[8:14] = _format_float(H, 6, 2)
+    line[14:20] = _format_float(G, 6, 2)
+    line[20:32] = _format_float(epoch_jd, 12, 1)
+    line[32:44] = _format_float(mean_anomaly, 12, 5)
+    line[44:56] = _format_float(arg_peri, 12, 5)
+    line[56:68] = _format_float(ascending_node, 12, 5)
+    line[68:80] = _format_float(inclination, 12, 5)
+    line[80:92] = _format_float(eccentricity, 12, 7)
+    line[92:105] = _format_float(mean_motion, 13, 8)
+    line[105:118] = _format_float(semi_major, 13, 7)
+    line[118:120] = _format_field(str(uncertainty), 2)
+    line[120:136] = _format_field(provisional, 16)
+    line[166:166 + len(name)] = list(name)
+    return "".join(line)
+
+
+def test_parse_mpc_rows(tmp_path: Path) -> None:
+    content = "\n".join(
+        [
+            _mpc_line(
+                1,
+                3.34,
+                0.12,
+                2459200.5,
+                80.30420,
+                73.59748,
+                80.30563,
+                10.58764,
+                0.0785020,
+                0.21456678,
+                2.7678531,
+                0,
+                "A1234",
+                "(1) Ceres",
+            ),
+            _mpc_line(
+                2060,
+                6.54,
+                0.15,
+                2459200.5,
+                138.74120,
+                311.12345,
+                209.12345,
+                6.93725,
+                0.3829402,
+                0.09956789,
+                13.6901234,
+                2,
+                "1977UB",
+                "(2060) Chiron",
+            ),
+        ]
+    )
+    catalog_path = tmp_path / "sample.dat"
+    catalog_path.write_text(content)
+
+    rows = mpc_ingest.parse_mpcorb(catalog_path)
+    assert len(rows) == 2
+
+    ceres, chiron = rows
+    assert ceres.mpc_number == 1
+    assert pytest.approx(ceres.semi_major_axis_au, rel=1e-7) == 2.7678531
+    assert ceres.kind == "asteroid"
+    assert ceres.name == "(1) Ceres"
+    assert pytest.approx(chiron.perihelion_distance_au, rel=1e-7) == pytest.approx(
+        13.6901234 * (1.0 - 0.3829402), rel=1e-7
+    )
+    assert chiron.kind == "centaur"
+
+
+def test_filtering_limits() -> None:
+    rows = [
+        mpc_ingest.MpcRow(
+            mpc_number=1,
+            provisional_designation=None,
+            name="Ceres",
+            kind="asteroid",
+            family=None,
+            absolute_magnitude=3.3,
+            slope=0.15,
+            uncertainty=1,
+            epoch_jd=2459200.5,
+            mean_anomaly_deg=0.0,
+            argument_perihelion_deg=0.0,
+            ascending_node_deg=0.0,
+            inclination_deg=0.0,
+            eccentricity=0.1,
+            mean_motion_deg_per_day=0.1,
+            semi_major_axis_au=2.7,
+            perihelion_distance_au=2.4,
+            source={"line": ""},
+        ),
+        mpc_ingest.MpcRow(
+            mpc_number=2,
+            provisional_designation=None,
+            name="Dim",
+            kind="asteroid",
+            family=None,
+            absolute_magnitude=15.0,
+            slope=0.15,
+            uncertainty=1,
+            epoch_jd=2459200.5,
+            mean_anomaly_deg=0.0,
+            argument_perihelion_deg=0.0,
+            ascending_node_deg=0.0,
+            inclination_deg=0.0,
+            eccentricity=0.1,
+            mean_motion_deg_per_day=0.1,
+            semi_major_axis_au=2.7,
+            perihelion_distance_au=2.4,
+            source={"line": ""},
+        ),
+        mpc_ingest.MpcRow(
+            mpc_number=3,
+            provisional_designation=None,
+            name="Fuzzy",
+            kind="asteroid",
+            family=None,
+            absolute_magnitude=10.0,
+            slope=0.15,
+            uncertainty=9,
+            epoch_jd=2459200.5,
+            mean_anomaly_deg=0.0,
+            argument_perihelion_deg=0.0,
+            ascending_node_deg=0.0,
+            inclination_deg=0.0,
+            eccentricity=0.1,
+            mean_motion_deg_per_day=0.1,
+            semi_major_axis_au=2.7,
+            perihelion_distance_au=2.4,
+            source={"line": ""},
+        ),
+    ]
+
+    filtered = mpc_ingest.filter_rows(rows, H_max=12.0, U_max=5)
+    assert [row.mpc_number for row in filtered] == [1]
+
+
+def test_missing_mean_motion_reconstructed(tmp_path: Path) -> None:
+    line = _mpc_line(
+        1,
+        3.34,
+        0.12,
+        2459200.5,
+        80.30420,
+        73.59748,
+        80.30563,
+        10.58764,
+        0.0785020,
+        0.21456678,
+        2.7678531,
+        0,
+        "A1234",
+        "(1) Ceres",
+    )
+    line = f"{line[:92]}{' ' * 13}{line[105:]}"
+    path = tmp_path / "missing_n.dat"
+    path.write_text(line)
+
+    rows = mpc_ingest.parse_mpcorb(path)
+    assert len(rows) == 1
+    row = rows[0]
+    expected = mpc_ingest._mean_motion_from_semi_major(row.semi_major_axis_au)
+    assert pytest.approx(row.mean_motion_deg_per_day, rel=1e-9) == expected
+
+
+def test_missing_semi_major_reconstructed(tmp_path: Path) -> None:
+    semi_major = 2.7678531
+    mean_motion = mpc_ingest._mean_motion_from_semi_major(semi_major)
+    line = _mpc_line(
+        1,
+        3.34,
+        0.12,
+        2459200.5,
+        80.30420,
+        73.59748,
+        80.30563,
+        10.58764,
+        0.0785020,
+        mean_motion,
+        semi_major,
+        0,
+        "A1234",
+        "(1) Ceres",
+    )
+    line = f"{line[:105]}{' ' * 13}{line[118:]}"
+    path = tmp_path / "missing_a.dat"
+    path.write_text(line)
+
+    rows = mpc_ingest.parse_mpcorb(path)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.semi_major_axis_au == pytest.approx(semi_major, rel=1e-7)

--- a/tests/minorplanets/test_mpc_upsert.py
+++ b/tests/minorplanets/test_mpc_upsert.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from astroengine.engine.minorplanets import mpc_ingest
+
+
+def _row(number: int, name: str, semi_major: float) -> mpc_ingest.MpcRow:
+    return mpc_ingest.MpcRow(
+        mpc_number=number,
+        provisional_designation=None,
+        name=name,
+        kind="asteroid",
+        family=None,
+        absolute_magnitude=3.0,
+        slope=0.15,
+        uncertainty=1,
+        epoch_jd=2459200.5,
+        mean_anomaly_deg=0.0,
+        argument_perihelion_deg=0.0,
+        ascending_node_deg=0.0,
+        inclination_deg=0.0,
+        eccentricity=0.1,
+        mean_motion_deg_per_day=0.1,
+        semi_major_axis_au=semi_major,
+        perihelion_distance_au=semi_major * (1.0 - 0.1),
+        source={"line": ""},
+    )
+
+
+def test_upsert_inserts_and_updates(tmp_path) -> None:
+    engine = create_engine("sqlite:///:memory:")
+    mpc_ingest.MinorPlanetBase.metadata.create_all(engine)
+
+    rows = [_row(1, "Ceres", 2.77), _row(2, "Pallas", 2.72)]
+    with Session(engine) as session:
+        counts = mpc_ingest.upsert_rows(session, rows)
+        session.commit()
+        assert counts.inserted == 2
+        assert counts.updated == 0
+
+        updated = [_row(1, "Ceres", 2.80)]
+        counts = mpc_ingest.upsert_rows(session, updated)
+        session.commit()
+        assert counts.inserted == 0
+        assert counts.updated == 1
+
+        stored = session.query(mpc_ingest.MinorPlanet).filter_by(mpc_number=1).one()
+        assert stored.semi_major_axis_au == 2.80


### PR DESCRIPTION
## Summary
- add a dedicated minor planet ingestion module with MPC row parsing, SQLAlchemy storage helpers, and columnar export utilities
- expose curated Lilith adapters backed by Swiss Ephemeris along with default orb presets for common centaurs and TNOs
- cover the new functionality with parsing, export, Lilith, and database upsert tests
- reconstruct missing MPCORB mean-motion/semi-major pairs during parsing and broaden curated presets for dwarf planets and numbered asteroids

## Testing
- pytest tests/minorplanets -q
- pytest -q *(fails: missing optional dependencies such as prometheus_client and application routers outside the test matrix)*

------
https://chatgpt.com/codex/tasks/task_e_68d88b79cfcc8324b0e6cb31dd1044e6