### PR TITLE
Add Swiss ayanamsa helper and primary preset support

### DIFF
--- a/astroengine/engine/vedic/__init__.py
+++ b/astroengine/engine/vedic/__init__.py
@@ -6,9 +6,12 @@ from .ayanamsa import (
     AyanamsaInfo,
     AyanamsaPreset,
     SIDEREAL_PRESETS,
+    PRIMARY_AYANAMSAS,
+    available_ayanamsas,
     ayanamsa_metadata,
     ayanamsa_value,
     normalize_ayanamsa,
+    swe_ayanamsa,
 )
 from .chart import VedicChartContext, compute_sidereal_chart, build_context
 from .dasha_vimshottari import (
@@ -35,9 +38,12 @@ __all__ = [
     "AyanamsaInfo",
     "AyanamsaPreset",
     "SIDEREAL_PRESETS",
+    "PRIMARY_AYANAMSAS",
+    "available_ayanamsas",
     "ayanamsa_metadata",
     "ayanamsa_value",
     "normalize_ayanamsa",
+    "swe_ayanamsa",
     "VedicChartContext",
     "compute_sidereal_chart",
     "build_context",

--- a/astroengine/engine/vedic/ayanamsa.py
+++ b/astroengine/engine/vedic/ayanamsa.py
@@ -16,9 +16,12 @@ __all__ = [
     "AyanamsaInfo",
     "AyanamsaPreset",
     "SIDEREAL_PRESETS",
+    "PRIMARY_AYANAMSAS",
+    "available_ayanamsas",
     "ayanamsa_metadata",
     "ayanamsa_value",
     "normalize_ayanamsa",
+    "swe_ayanamsa",
 ]
 
 
@@ -88,6 +91,14 @@ SIDEREAL_PRESETS: Final[Mapping[AyanamsaPreset, AyanamsaInfo]] = {
 }
 
 
+PRIMARY_AYANAMSAS: Final[tuple[AyanamsaPreset, ...]] = (
+    AyanamsaPreset.LAHIRI,
+    AyanamsaPreset.RAMAN,
+    AyanamsaPreset.KRISHNAMURTI,
+    AyanamsaPreset.FAGAN_BRADLEY,
+)
+
+
 def normalize_ayanamsa(value: str | AyanamsaPreset) -> AyanamsaPreset:
     """Return the canonical :class:`AyanamsaPreset` for ``value``."""
 
@@ -147,3 +158,25 @@ def available_ayanamsas() -> Iterable[AyanamsaPreset]:
     """Return all presets recognised by the engine."""
 
     return tuple(SIDEREAL_PRESETS.keys())
+
+
+def swe_ayanamsa(
+    moment: datetime,
+    preset: AyanamsaPreset | str = AyanamsaPreset.LAHIRI,
+) -> dict[str, object]:
+    """Return Swiss Ephemeris ayanamsa data for ``moment``.
+
+    The helper exposes the canonical presets backed by the Swiss Ephemeris
+    constants, ensuring the common Lahiri, Raman, Krishnamurti, and
+    Fagan/Bradley modes are easily accessible alongside the wider preset
+    catalogue.
+    """
+
+    normalized = normalize_ayanamsa(preset)
+    info = SIDEREAL_PRESETS[normalized]
+    metadata = ayanamsa_metadata(normalized, moment)
+    return {
+        **metadata,
+        "preset": normalized,
+        "swe_mode": info.swe_mode,
+    }

--- a/tests/vedic/test_ayanamsa.py
+++ b/tests/vedic/test_ayanamsa.py
@@ -2,7 +2,13 @@ from datetime import UTC, datetime
 
 import swisseph as swe
 
-from astroengine.engine.vedic import SIDEREAL_PRESETS, ayanamsa_value
+from astroengine.engine.vedic import (
+    PRIMARY_AYANAMSAS,
+    SIDEREAL_PRESETS,
+    ayanamsa_value,
+    available_ayanamsas,
+    swe_ayanamsa,
+)
 
 
 def _jd(moment: datetime) -> float:
@@ -21,3 +27,18 @@ def test_ayanamsa_matches_swisseph():
             _flags, expected = swe.get_ayanamsa_ex_ut(jd, info.swe_mode)
             result = ayanamsa_value(preset, moment)
             assert abs(result - expected) < 1e-4
+
+
+def test_primary_presets_and_helper_metadata():
+    presets = set(available_ayanamsas())
+    for preset in PRIMARY_AYANAMSAS:
+        assert preset in presets
+
+    moment = datetime(2024, 1, 15, 6, 45, tzinfo=UTC)
+    for preset in PRIMARY_AYANAMSAS:
+        payload = swe_ayanamsa(moment, preset)
+        assert payload["ayanamsa"] == preset.value
+        assert payload["preset"] == preset
+        assert payload["swe_mode"] == SIDEREAL_PRESETS[preset].swe_mode
+        expected = ayanamsa_value(preset, moment)
+        assert abs(payload["ayanamsa_degrees"] - expected) < 1e-6


### PR DESCRIPTION
## Summary
- expose the primary Swiss Ephemeris ayanamsa presets and a swe_ayanamsa helper for metadata retrieval
- re-export the new helpers from the Vedic package so downstream code can consume them easily
- extend ayanamsa tests to cover the helper output and verify availability of Lahiri, Raman, Krishnamurti, and Fagan/Bradley presets

## Testing
- pytest tests/vedic/test_ayanamsa.py


------
https://chatgpt.com/codex/tasks/task_e_68dbf3df211c832495ab5bfc4da3be1d