### PR TITLE
Include Vedic dasha routes in API

### DIFF
--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -13,8 +13,8 @@ def create_app() -> FastAPI:
     from .routers import plus as plus_router
     from .routers import scan as scan_router
     from .routers import synastry as synastry_router
-
     from .routers import topocentric as topocentric_router
+    from .routers import vedic as vedic_router
 
 
     app = FastAPI(title="AstroEngine API")
@@ -24,6 +24,7 @@ def create_app() -> FastAPI:
     app.include_router(synastry_router.router, prefix="/v1/synastry", tags=["synastry"])
 
     app.include_router(topocentric_router.router, prefix="/v1", tags=["topocentric"])
+    app.include_router(vedic_router.router)
 
     return app
 

--- a/astroengine/api/routers/__init__.py
+++ b/astroengine/api/routers/__init__.py
@@ -3,5 +3,5 @@
 from __future__ import annotations
 
 
-__all__ = ["plus", "scan", "synastry", "topocentric"]
+__all__ = ["plus", "scan", "synastry", "topocentric", "vedic"]
 

--- a/astroengine/engine/lots/__init__.py
+++ b/astroengine/engine/lots/__init__.py
@@ -1,6 +1,12 @@
 """Arabic Lots engine with DSL compilation, evaluation, and event scanning."""
 
-from .builtins import LotsProfile, builtin_profile, list_builtin_profiles
+from .builtins import (
+    LotsProfile,
+    builtin_profile,
+    list_builtin_profiles,
+    load_custom_profiles,
+    save_custom_profile,
+)
 from .dsl import (
     Add,
     Arc,
@@ -44,6 +50,8 @@ __all__ = [
     "evaluate",
     "is_day",
     "list_builtin_profiles",
+    "load_custom_profiles",
     "parse_lot_defs",
+    "save_custom_profile",
     "scan_lot_events",
 ]


### PR DESCRIPTION
## Summary
- register the Vedic router with the FastAPI factory so Vimśottarī dashas are available through the service
- expose the lots module helpers required by the API router when loading custom profiles

## Testing
- pytest tests/vedic/test_api.py


------
https://chatgpt.com/codex/tasks/task_e_68dbf4ce1920832483c38cf59ccdd14b