### PR TITLE
Annotate station events with retrograde turns

### DIFF
--- a/astroengine/detectors/stations.py
+++ b/astroengine/detectors/stations.py
@@ -89,6 +89,9 @@ def find_stations(
                 key = (name, int(round(root * 86400)))
                 if key not in seen:
                     longitude = _longitude(root, code)
+                    station_type = _classify_station(root, code)
+                    if station_type not in {"retrograde", "direct"}:
+                        station_type = None
                     events.append(
                         StationEvent(
                             ts=jd_to_iso(root),
@@ -97,6 +100,7 @@ def find_stations(
                             motion="stationary",
                             longitude=longitude,
                             speed_longitude=0.0,
+                            station_type=station_type,
                         )
                     )
                     seen.add(key)
@@ -218,7 +222,7 @@ def find_shadow_periods(
 
         typed: list[tuple[StationEvent, str]] = []
         for event in stations:
-            kind = _classify_station(event.jd, code)
+            kind = event.station_type or _classify_station(event.jd, code)
             if kind in {"retrograde", "direct"}:
                 typed.append((event, kind))
 

--- a/astroengine/events.py
+++ b/astroengine/events.py
@@ -55,12 +55,19 @@ class EclipseEvent(BaseEvent):
 
 @dataclass(frozen=True)
 class StationEvent(BaseEvent):
-    """Represents a planetary station (speed crossing zero)."""
+    """Represents a planetary station (speed crossing zero).
+
+    The ``station_type`` field distinguishes whether the station marks the
+    onset of retrograde motion (``"retrograde"``) or the return to direct
+    motion (``"direct"``). For rare cases where the direction cannot be
+    established the value remains ``None``.
+    """
 
     body: str
     motion: str
     longitude: float
     speed_longitude: float
+    station_type: str | None = None
 
 
 @dataclass(frozen=True)

--- a/docs/module/event-detectors/overview.md
+++ b/docs/module/event-detectors/overview.md
@@ -14,7 +14,7 @@ All detector families described below are wired into the shared registry and exe
 
 | Detector | Inputs & thresholds | Runtime implementation | Tests |
 | --- | --- | --- | --- |
-| Stations (retrograde/direct + shadows) | Longitudinal speed sign changes refined with Swiss Ephemeris. Shadow windows reuse the paired station longitudes. | `astroengine.detectors.stations.find_stations`, `astroengine.detectors.stations.find_shadow_periods`. | `tests/test_stations_impl.py` |
+| Stations (retrograde/direct + shadows) | Longitudinal speed sign changes refined with Swiss Ephemeris. Shadow windows reuse the paired station longitudes. Station payloads expose `station_type` to distinguish retrograde vs. direct turns. | `astroengine.detectors.stations.find_stations`, `astroengine.detectors.stations.find_shadow_periods`. | `tests/test_stations_impl.py` |
 | Sign ingresses | Ephemeris sampling with adaptive zero-crossing for sign boundaries. | `astroengine.detectors.ingresses.find_sign_ingresses`. | `tests/test_ingress_features.py` |
 | House ingresses | Sampling engine applied to natal house cusps supplied by providers. | `astroengine.detectors.ingresses.find_house_ingresses`. | `tests/test_ingresses_mundane.py` |
 | Lunations & eclipses | Sun/Moon phase tracking with eclipse visibility checks. | `astroengine.detectors.lunations.find_lunations`, `astroengine.detectors.eclipses.find_eclipses`. | `tests/test_lunations_impl.py`, `tests/test_eclipses_impl.py` |

--- a/tests/test_stations_impl.py
+++ b/tests/test_stations_impl.py
@@ -42,6 +42,26 @@ def test_station_refines_speed():
     values, _ = swe.calc_ut(mercury.jd, swe.MERCURY, swe.FLG_SWIEPH | swe.FLG_SPEED)
     assert abs(values[3]) < 5e-6
 
+    offsets = (0.5 / 24.0, 1.0 / 24.0, 2.0 / 24.0)
+    expected_station = None
+    for delta in offsets:
+        before_values, _ = swe.calc_ut(
+            mercury.jd - delta, swe.MERCURY, swe.FLG_SWIEPH | swe.FLG_SPEED
+        )
+        after_values, _ = swe.calc_ut(
+            mercury.jd + delta, swe.MERCURY, swe.FLG_SWIEPH | swe.FLG_SPEED
+        )
+        before = before_values[3]
+        after = after_values[3]
+        if before > 0 and after < 0:
+            expected_station = "retrograde"
+            break
+        if before < 0 and after > 0:
+            expected_station = "direct"
+            break
+
+    assert mercury.station_type == expected_station
+
     jds = [event.jd for event in events]
     assert jds == sorted(jds)
 


### PR DESCRIPTION
## Summary
- add a `station_type` marker to station events so callers can distinguish retrograde vs. direct turns
- tag station detections with the computed station type and reuse it when assembling shadow periods
- document the extra payload field and extend the regression test to assert the Swiss Ephemeris direction change

## Testing
- pytest tests/test_stations_impl.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf64c31248324825741b466d8095a