### PR TITLE
Add lunar month and paksha calculations for sidereal and tropical charts

### DIFF
--- a/astroengine/engine/lunar/__init__.py
+++ b/astroengine/engine/lunar/__init__.py
@@ -1,0 +1,17 @@
+"""Lunar calendar helpers shared across traditions."""
+
+from .calendar import (
+    MASA_SEQUENCE,
+    MasaInfo,
+    PakshaInfo,
+    masa_for_longitude,
+    paksha_from_longitudes,
+)
+
+__all__ = [
+    "MASA_SEQUENCE",
+    "MasaInfo",
+    "PakshaInfo",
+    "masa_for_longitude",
+    "paksha_from_longitudes",
+]

--- a/astroengine/engine/lunar/calendar.py
+++ b/astroengine/engine/lunar/calendar.py
@@ -1,0 +1,143 @@
+"""Shared lunar calendar helpers for Vedic and tropical systems."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+from astroengine.detectors.ingresses import ZODIAC_SIGNS, sign_index
+from astroengine.utils.angles import norm360
+
+__all__ = [
+    "MASA_SEQUENCE",
+    "PakshaInfo",
+    "MasaInfo",
+    "masa_for_longitude",
+    "paksha_from_longitudes",
+]
+
+# Month names follow the classical sequence that ties the lunar month to the
+# solar sign of the Sun at the start of the Shukla paksha.  We intentionally
+# keep the data minimal to avoid duplicating narratives that can drift by
+# locale.
+MASA_SEQUENCE: Sequence[str] = (
+    "Chaitra",
+    "Vaisakha",
+    "Jyeshtha",
+    "Ashadha",
+    "Shravana",
+    "Bhadrapada",
+    "Ashvina",
+    "Kartika",
+    "Margashirsha",
+    "Pausha",
+    "Magha",
+    "Phalguna",
+)
+
+_SHUKLA_TITHI_NAMES: Sequence[str] = (
+    "Pratipada",
+    "Dvitiya",
+    "Tritiya",
+    "Chaturthi",
+    "Panchami",
+    "Shashthi",
+    "Saptami",
+    "Ashtami",
+    "Navami",
+    "Dashami",
+    "Ekadashi",
+    "Dvadashi",
+    "Trayodashi",
+    "Chaturdashi",
+    "Purnima",
+)
+
+_KRISHNA_TITHI_NAMES: Sequence[str] = (
+    "Pratipada",
+    "Dvitiya",
+    "Tritiya",
+    "Chaturthi",
+    "Panchami",
+    "Shashthi",
+    "Saptami",
+    "Ashtami",
+    "Navami",
+    "Dashami",
+    "Ekadashi",
+    "Dvadashi",
+    "Trayodashi",
+    "Chaturdashi",
+    "Amavasya",
+)
+
+
+@dataclass(frozen=True)
+class PakshaInfo:
+    """Summary of the waxing/waning half of the synodic month."""
+
+    name: Literal["Shukla", "Krishna"]
+    waxing: bool
+    tithi_index: int
+    tithi_name: str
+    day_in_paksha: int
+    elongation_deg: float
+
+
+@dataclass(frozen=True)
+class MasaInfo:
+    """Metadata describing the running lunar month."""
+
+    index: int
+    name: str
+    sign_index: int
+    sign_name: str
+    zodiac: Literal["sidereal", "tropical"]
+    longitude: float
+
+
+def masa_for_longitude(sun_longitude: float, *, zodiac: Literal["sidereal", "tropical"]) -> MasaInfo:
+    """Return the lunar month inferred from the Sun's longitude."""
+
+    lon = norm360(float(sun_longitude))
+    sign_idx = sign_index(lon)
+    month_name = MASA_SEQUENCE[sign_idx]
+    return MasaInfo(
+        index=sign_idx + 1,
+        name=month_name,
+        sign_index=sign_idx,
+        sign_name=ZODIAC_SIGNS[sign_idx],
+        zodiac=zodiac,
+        longitude=lon,
+    )
+
+
+def _tithi_name(index: int) -> str:
+    if index < 15:
+        return _SHUKLA_TITHI_NAMES[index]
+    return _KRISHNA_TITHI_NAMES[index - 15]
+
+
+def paksha_from_longitudes(moon_longitude: float, sun_longitude: float) -> PakshaInfo:
+    """Return the waxing/waning state derived from Moon and Sun."""
+
+    moon = norm360(float(moon_longitude))
+    sun = norm360(float(sun_longitude))
+    elongation = norm360(moon - sun)
+    # Guard against floating point roundoff when elongation lands exactly on 360.
+    if elongation >= 360.0:
+        elongation = 0.0
+    # Each tithi spans 12 degrees of elongation.
+    tithi = int(elongation // 12.0)
+    if tithi >= 30:
+        tithi = 29
+    paksha_name: Literal["Shukla", "Krishna"]
+    paksha_name = "Shukla" if tithi < 15 else "Krishna"
+    return PakshaInfo(
+        name=paksha_name,
+        waxing=paksha_name == "Shukla",
+        tithi_index=tithi + 1,
+        tithi_name=_tithi_name(tithi),
+        day_in_paksha=(tithi % 15) + 1,
+        elongation_deg=elongation,
+    )

--- a/astroengine/engine/traditional/__init__.py
+++ b/astroengine/engine/traditional/__init__.py
@@ -19,6 +19,8 @@ from .zr import apply_loosing_of_bond, flag_peaks_fortune, zr_periods
 from .sect import sect_info
 from .life_lengths import find_alcocoden, find_hyleg
 from .profiles import load_traditional_profiles
+from .lunar_calendar import masa_for_chart as masa_for_tropical_chart
+from .lunar_calendar import paksha_for_chart as paksha_for_tropical_chart
 
 __all__ = [
     "AlcocodenResult",
@@ -39,6 +41,8 @@ __all__ = [
     "find_hyleg",
     "flag_peaks_fortune",
     "load_traditional_profiles",
+    "masa_for_tropical_chart",
+    "paksha_for_tropical_chart",
     "profection_year_segments",
     "sect_info",
     "zr_periods",

--- a/astroengine/engine/traditional/lunar_calendar.py
+++ b/astroengine/engine/traditional/lunar_calendar.py
@@ -1,0 +1,34 @@
+"""Tropical lunar calendar helpers (masa and paksha equivalents)."""
+
+from __future__ import annotations
+
+from astroengine.chart import NatalChart
+
+from ..lunar import MasaInfo, PakshaInfo, masa_for_longitude, paksha_from_longitudes
+
+__all__ = [
+    "masa_for_chart",
+    "paksha_for_chart",
+]
+
+
+def _require_body(chart: NatalChart, body: str) -> float:
+    position = chart.positions.get(body)
+    if position is None:
+        raise ValueError(f"{body} position unavailable in chart")
+    return position.longitude
+
+
+def masa_for_chart(chart: NatalChart) -> MasaInfo:
+    """Return the tropical lunar month for ``chart``."""
+
+    sun_lon = _require_body(chart, "Sun")
+    return masa_for_longitude(sun_lon, zodiac="tropical")
+
+
+def paksha_for_chart(chart: NatalChart) -> PakshaInfo:
+    """Return the tropical paksha state for ``chart``."""
+
+    moon_lon = _require_body(chart, "Moon")
+    sun_lon = _require_body(chart, "Sun")
+    return paksha_from_longitudes(moon_lon, sun_lon)

--- a/astroengine/engine/vedic/__init__.py
+++ b/astroengine/engine/vedic/__init__.py
@@ -21,6 +21,8 @@ from .dasha_vimshottari import (
     vimshottari_sequence,
 )
 from .dasha_yogini import build_yogini, yogini_sequence
+from .lunar_calendar import masa_for_chart as masa_for_sidereal_chart
+from .lunar_calendar import paksha_for_chart as paksha_for_sidereal_chart
 from .nakshatra import (
     NAKSHATRA_ARC_DEGREES,
     PADA_ARC_DEGREES,
@@ -53,6 +55,8 @@ __all__ = [
     "vimshottari_sequence",
     "build_yogini",
     "yogini_sequence",
+    "masa_for_sidereal_chart",
+    "paksha_for_sidereal_chart",
     "NAKSHATRA_ARC_DEGREES",
     "PADA_ARC_DEGREES",
     "Nakshatra",

--- a/astroengine/engine/vedic/lunar_calendar.py
+++ b/astroengine/engine/vedic/lunar_calendar.py
@@ -1,0 +1,34 @@
+"""Sidereal lunar calendar helpers (masa and paksha)."""
+
+from __future__ import annotations
+
+from astroengine.chart import NatalChart
+
+from ..lunar import MasaInfo, PakshaInfo, masa_for_longitude, paksha_from_longitudes
+
+__all__ = [
+    "masa_for_chart",
+    "paksha_for_chart",
+]
+
+
+def _require_body(chart: NatalChart, body: str) -> float:
+    position = chart.positions.get(body)
+    if position is None:
+        raise ValueError(f"{body} position unavailable in chart")
+    return position.longitude
+
+
+def masa_for_chart(chart: NatalChart) -> MasaInfo:
+    """Return the sidereal lunar month for ``chart``."""
+
+    sun_lon = _require_body(chart, "Sun")
+    return masa_for_longitude(sun_lon, zodiac="sidereal")
+
+
+def paksha_for_chart(chart: NatalChart) -> PakshaInfo:
+    """Return the sidereal paksha state for ``chart``."""
+
+    moon_lon = _require_body(chart, "Moon")
+    sun_lon = _require_body(chart, "Sun")
+    return paksha_from_longitudes(moon_lon, sun_lon)

--- a/tests/engine/test_lunar_calendar.py
+++ b/tests/engine/test_lunar_calendar.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from astroengine.engine.lunar import MASA_SEQUENCE, masa_for_longitude, paksha_from_longitudes
+
+
+@pytest.mark.parametrize(
+    "sun, expected_name",
+    [
+        (0.0, MASA_SEQUENCE[0]),
+        (45.0, MASA_SEQUENCE[1]),
+        (215.0, MASA_SEQUENCE[7]),
+        (359.9, MASA_SEQUENCE[11]),
+    ],
+)
+def test_masa_matches_solar_sign(sun: float, expected_name: str) -> None:
+    info = masa_for_longitude(sun, zodiac="sidereal")
+    assert info.name == expected_name
+    assert math.isclose(info.longitude, sun % 360.0)
+
+
+def test_masa_marks_requested_zodiac() -> None:
+    tropical = masa_for_longitude(75.0, zodiac="tropical")
+    sidereal = masa_for_longitude(75.0, zodiac="sidereal")
+    assert tropical.zodiac == "tropical"
+    assert sidereal.zodiac == "sidereal"
+    assert tropical.name == sidereal.name == MASA_SEQUENCE[2]
+
+
+def test_paksha_shukla_sequence() -> None:
+    info = paksha_from_longitudes(moon_longitude=5.0, sun_longitude=0.0)
+    assert info.name == "Shukla"
+    assert info.waxing is True
+    assert info.tithi_index == 1
+    assert info.tithi_name == "Pratipada"
+    assert info.day_in_paksha == 1
+
+
+def test_paksha_krishna_sequence() -> None:
+    info = paksha_from_longitudes(moon_longitude=350.0, sun_longitude=10.0)
+    assert info.name == "Krishna"
+    assert info.waxing is False
+    assert info.tithi_index == 29
+    assert info.tithi_name == "Chaturdashi"
+    assert info.day_in_paksha == 14
+
+
+def test_paksha_handles_amavasya_boundary() -> None:
+    info = paksha_from_longitudes(moon_longitude=359.99, sun_longitude=0.0)
+    assert info.tithi_index == 30
+    assert info.tithi_name == "Amavasya"
+    assert info.day_in_paksha == 15


### PR DESCRIPTION
## Summary
- add shared lunar calendar helpers that compute masa (lunar month) and paksha from solar and lunar longitudes
- expose sidereal (Vedic) and tropical wrappers that integrate the helpers with natal chart data
- cover the new helpers with unit tests across both waxing and waning phases

## Testing
- pytest tests/engine/test_lunar_calendar.py


------
https://chatgpt.com/codex/tasks/task_e_68dbf6eff98483248478375284cfb3b5