### PR TITLE
Add deep Vimshottari levels and annotate dasha lord transits

### DIFF
--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -2010,7 +2010,10 @@ def _add_timelord_compute_args(
     parser.add_argument(
         "--timelord-levels",
         default="maha,antar",
-        help="Comma-separated Vimśottarī levels to include",
+        help=(
+            "Comma-separated Vimśottarī levels to include (maha, antar, pratyantar, "
+            "sookshma, praan)"
+        ),
     )
     parser.add_argument(
         "--zr", action="store_true", help="Emit zodiacal releasing periods"

--- a/astroengine/engine/scanning.py
+++ b/astroengine/engine/scanning.py
@@ -106,6 +106,18 @@ _BODY_CODE_TO_NAME = {
     9: "pluto",
 }
 
+_VIMSHOTTARI_LORDS = {
+    "ketu",
+    "venus",
+    "sun",
+    "moon",
+    "mars",
+    "rahu",
+    "jupiter",
+    "saturn",
+    "mercury",
+}
+
 
 class _TickCachingProvider:
     """Memoize ``positions_ecliptic`` calls for a single scan session."""
@@ -198,6 +210,37 @@ def _attach_timelords(
         return
     stack = calculator.active_stack(_parse_iso_datetime(event.timestamp))
     event.metadata.setdefault("timelord_rulers", stack.rulers())
+    vimshottari_periods = [
+        period
+        for period in stack.iter_periods()
+        if period.system == "vimshottari"
+        and period.ruler.lower() in _VIMSHOTTARI_LORDS
+    ]
+    matches: list[dict[str, object]] = []
+    moving = event.moving.lower()
+    target = event.target.lower()
+    for period in vimshottari_periods:
+        ruler = period.ruler.lower()
+        if moving == ruler:
+            matches.append(
+                {
+                    "role": "moving",
+                    "ruler": period.ruler,
+                    "level": period.level,
+                    "system": period.system,
+                }
+            )
+        if target == ruler:
+            matches.append(
+                {
+                    "role": "target",
+                    "ruler": period.ruler,
+                    "level": period.level,
+                    "system": period.system,
+                }
+            )
+    if matches:
+        event.metadata.setdefault("transit_over_dasha_lords", matches)
     event.metadata.setdefault("timelords", stack.to_dict())
 
 

--- a/astroengine/engine/vedic/dasha_vimshottari.py
+++ b/astroengine/engine/vedic/dasha_vimshottari.py
@@ -35,6 +35,14 @@ ORDER: Sequence[tuple[str, float]] = (
 )
 TOTAL_YEARS = sum(duration for _, duration in ORDER)
 
+_LEVEL_BY_DEPTH = {
+    1: "maha",
+    2: "antar",
+    3: "pratyantar",
+    4: "sookshma",
+    5: "praan",
+}
+
 
 @dataclass(frozen=True)
 class DashaPeriod:
@@ -106,8 +114,11 @@ def _subdivide(
             fraction = accumulator / TOTAL_YEARS
             sub_end = start + timedelta(days=total_days * fraction)
         parent_years = total_days / options.year_basis
-        metadata = {"parent": parent_ruler, "span_years": parent_years * (years / TOTAL_YEARS)}
-        level_name = "antar" if level == 2 else "pratyantar"
+        metadata = {
+            "parent": parent_ruler,
+            "span_years": parent_years * (years / TOTAL_YEARS),
+        }
+        level_name = _LEVEL_BY_DEPTH.get(level, f"level{level}")
         periods.append(
             DashaPeriod(
                 system="vimshottari",
@@ -160,8 +171,10 @@ def build_vimshottari(
 ) -> list[DashaPeriod]:
     """Return Vimśottarī dashas covering 120 years from the birth moment."""
 
-    if levels < 1 or levels > 3:
-        raise ValueError("levels must be between 1 and 3")
+    if levels < 1 or levels > len(_LEVEL_BY_DEPTH):
+        raise ValueError(
+            f"levels must be between 1 and {len(_LEVEL_BY_DEPTH)}"
+        )
     opts = options or VimshottariOptions()
     natal = _chart_from_context(chart)
     anchor_start = _apply_anchor(natal.moment, opts)

--- a/astroengine/timelords/vimshottari.py
+++ b/astroengine/timelords/vimshottari.py
@@ -1,4 +1,4 @@
-"""Vimśottarī Daśā calculator (maha/antar/pratyantar levels)."""
+"""Vimśottarī Daśā calculator supporting maha → praan levels."""
 
 from __future__ import annotations
 
@@ -18,6 +18,14 @@ __all__ = [
     "VIMSHOTTARI_SEQUENCE",
     "generate_vimshottari_periods",
 ]
+
+_LEVEL_BY_DEPTH = {
+    1: "maha",
+    2: "antar",
+    3: "pratyantar",
+    4: "sookshma",
+    5: "praan",
+}
 
 NAKSHATRA_DEGREES = 360.0 / 27.0
 
@@ -162,14 +170,16 @@ def _subdivide(
         else:
             fraction = accumulator / TOTAL_YEARS
             sub_end = start + timedelta(days=total_days * fraction)
+        level_name = _LEVEL_BY_DEPTH.get(level, f"level{level}")
+        metadata = {"parent": ruler}
         periods.append(
             TimelordPeriod(
                 system="vimshottari",
-                level="antar" if level == 2 else "pratyantar",
+                level=level_name,
                 ruler=seed.ruler,
                 start=cursor,
                 end=sub_end,
-                metadata={"parent": ruler},
+                metadata=metadata,
             )
         )
         if level < max_level:
@@ -181,10 +191,14 @@ def generate_vimshottari_periods(
     context: TimelordContext,
     until: datetime,
     *,
-    levels: int = 3,
+    levels: int = 5,
 ) -> list[TimelordPeriod]:
     """Return Vimśottarī periods covering ``context.moment`` → ``until``."""
 
     if levels < 1:
         raise ValueError("levels must be >= 1")
+    if levels > len(_LEVEL_BY_DEPTH):
+        raise ValueError(
+            f"levels must be <= {len(_LEVEL_BY_DEPTH)} for Vimśottarī calculations"
+        )
     return _maha_periods(context, until, levels=levels)

--- a/tests/test_timelords.py
+++ b/tests/test_timelords.py
@@ -38,6 +38,21 @@ def test_vimshottari_includes_antar_periods() -> None:
     assert abs(ketu_antar[-1].end_jd - first_maha.end_jd) < 1e-4
 
 
+def test_vimshottari_supports_deep_levels() -> None:
+    start = datetime(2024, 3, 20, tzinfo=UTC)
+    events = compute_vimshottari_dasha(
+        5.0,
+        start,
+        cycles=1,
+        levels=("maha", "antar", "pratyantar", "sookshma", "praan"),
+    )
+    levels = {event.level for event in events}
+    assert {"antar", "pratyantar", "sookshma", "praan"}.issubset(levels)
+    praan = [event for event in events if event.level == "praan"]
+    assert praan, "expected praan level periods"
+    assert all(period.parent for period in praan)
+
+
 def test_zodiacal_releasing_levels() -> None:
     start = datetime(2024, 3, 20, tzinfo=UTC)
     events = compute_zodiacal_releasing(5.0, start, periods=4, levels=("l1", "l2"))

--- a/tests/test_timelords_systems.py
+++ b/tests/test_timelords_systems.py
@@ -6,6 +6,9 @@ import pytest
 from astroengine import cli
 from astroengine import engine as engine_module
 from astroengine.engine import scan_contacts
+from astroengine.engine import scanning as scanning_module
+from astroengine.engine.scanning import _attach_timelords
+from astroengine.exporters import LegacyTransitEvent
 from astroengine.timelords import (
     TimelordCalculator,
     active_timelords,
@@ -41,6 +44,12 @@ def test_vimshottari_known_dates(natal_context):
     praty = [period for period in periods if period.level == "pratyantar"]
     assert praty[0].end.date() == date(1985, 1, 22)
     assert praty[1].end.date() == date(1985, 5, 17)
+    sookshma = [period for period in periods if period.level == "sookshma"]
+    assert sookshma, "expected sookshma periods to be generated"
+    assert sookshma[0].metadata["parent"] == praty[0].ruler
+    praan = [period for period in periods if period.level == "praan"]
+    assert praan, "expected praan periods to be generated"
+    assert praan[0].metadata["parent"] == sookshma[0].ruler
 
 
 def test_zodiacal_releasing_spirit_first_periods(natal_context):
@@ -82,6 +91,8 @@ def test_active_timelord_stack(natal_context):
         "jupiter",
         "jupiter",
         "saturn",
+        "rahu",
+        "mars",
         "scorpio",
         "scorpio",
         "aries",
@@ -131,3 +142,40 @@ def test_scan_contacts_injects_timelord_metadata(natal_context):
     assert "timelords" in payload
     # ensure metadata round-trips through JSON serialization
     json.dumps(payload)
+
+
+def test_timelord_calculator_system_filter(natal_context):
+    until = parse_iso("1984-12-31T00:00:00Z")
+    calculator = TimelordCalculator(
+        context=natal_context,
+        until=until,
+        systems=("vimshottari",),
+    )
+    assert calculator.profections == []
+    assert calculator.zr_spirit == []
+    assert calculator.vimshottari
+    systems = {period.system for period in calculator.iter_periods()}
+    assert systems == {"vimshottari"}
+
+
+def test_attach_timelords_marks_dasha_transits(natal_context):
+    until = parse_iso("1985-01-15T00:00:00Z")
+    calculator = TimelordCalculator(context=natal_context, until=until)
+    event = LegacyTransitEvent(
+        kind="aspect",
+        timestamp="1984-11-01T00:00:00Z",
+        moving="Jupiter",
+        target="Moon",
+        orb_abs=0.0,
+        orb_allow=1.0,
+        applying_or_separating="applying",
+        score=0.0,
+    )
+    try:
+        scanning_module.FEATURE_TIMELORDS = True
+        _attach_timelords(event, calculator)
+    finally:
+        scanning_module.FEATURE_TIMELORDS = False
+    assert "transit_over_dasha_lords" in event.metadata
+    roles = {entry["role"] for entry in event.metadata["transit_over_dasha_lords"]}
+    assert "moving" in roles


### PR DESCRIPTION
## Summary
- extend Vimshottari generators to cover sookshma and praan levels and expose them through the CLI
- add conditional timelord system selection plus dasha lord transit metadata in the scanning engine
- expand the test suite to exercise deeper levels and the new transit annotations

## Testing
- pytest tests/test_timelords.py tests/test_timelords_systems.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf7a99acc83249387f03e4248882e