### PR TITLE
Add Jyotish house rulership scoring module

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -191,6 +191,22 @@ from .ritual import (
     VoidOfCourseRule,
 )
 from .rulesets import VCA_RULESET, get_vca_aspect, vca_orb_for
+from .jyotish import (
+    GrahaYuddhaOutcome,
+    HouseClaim,
+    HouseWinner,
+    SrishtiAspect,
+    StrengthScore,
+    determine_house_lords,
+    evaluate_house_claims,
+    evaluate_house_claims_from_chart,
+    house_occupants,
+    karakas_for_house,
+    match_karakas,
+    score_planet_strength,
+    compute_srishti_aspects,
+    detect_graha_yuddha,
+)
 from .scoring import (
     DEFAULT_ASPECTS,
     OrbCalculator,
@@ -376,6 +392,20 @@ __all__ = [
     "DirectionEvent",
     "ProfectionEvent",
     "OutOfBoundsEvent",
+    "determine_house_lords",
+    "house_occupants",
+    "karakas_for_house",
+    "match_karakas",
+    "StrengthScore",
+    "score_planet_strength",
+    "SrishtiAspect",
+    "GrahaYuddhaOutcome",
+    "compute_srishti_aspects",
+    "detect_graha_yuddha",
+    "HouseClaim",
+    "HouseWinner",
+    "evaluate_house_claims",
+    "evaluate_house_claims_from_chart",
 ]
 
 # Hypothesis 6.112+ disallows timezone-aware bounds for datetimes; provide a

--- a/astroengine/interpret/models.py
+++ b/astroengine/interpret/models.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable, Literal, Mapping, Sequence
 
 
 from pydantic import (
+    AliasChoices,
     AwareDatetime,
     BaseModel,
     ConfigDict,

--- a/astroengine/jyotish/__init__.py
+++ b/astroengine/jyotish/__init__.py
@@ -1,0 +1,36 @@
+"""Public Jyotish helpers for house rulership and strength scoring."""
+
+from __future__ import annotations
+
+from .aspects import (
+    GrahaYuddhaOutcome,
+    SrishtiAspect,
+    compute_srishti_aspects,
+    detect_graha_yuddha,
+)
+from .karaka import match_karakas
+from .lords import determine_house_lords, house_occupants, karakas_for_house
+from .rules import (
+    HouseClaim,
+    HouseWinner,
+    evaluate_house_claims,
+    evaluate_house_claims_from_chart,
+)
+from .strength import StrengthScore, score_planet_strength
+
+__all__ = [
+    "determine_house_lords",
+    "house_occupants",
+    "karakas_for_house",
+    "match_karakas",
+    "StrengthScore",
+    "score_planet_strength",
+    "SrishtiAspect",
+    "GrahaYuddhaOutcome",
+    "compute_srishti_aspects",
+    "detect_graha_yuddha",
+    "HouseClaim",
+    "HouseWinner",
+    "evaluate_house_claims",
+    "evaluate_house_claims_from_chart",
+]

--- a/astroengine/jyotish/aspects.py
+++ b/astroengine/jyotish/aspects.py
@@ -1,0 +1,119 @@
+"""Aspect utilities covering whole-sign drishti and graha yuddha."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from collections.abc import Mapping
+
+from ..ephemeris import BodyPosition, HousePositions
+from ..detectors.ingresses import sign_index, sign_name
+from .data import (
+    PLANETARY_WAR_BRIGHTNESS,
+    PLANETARY_WAR_PARTICIPANTS,
+    SRISHTI_ASPECT_OFFSETS,
+)
+from .utils import circular_separation, planet_house_map
+
+__all__ = [
+    "SrishtiAspect",
+    "GrahaYuddhaOutcome",
+    "compute_srishti_aspects",
+    "detect_graha_yuddha",
+]
+
+
+@dataclass(frozen=True)
+class SrishtiAspect:
+    planet: str
+    source_house: int
+    target_house: int
+    offset: int
+    aspect_type: str
+    weight: float
+
+
+@dataclass(frozen=True)
+class GrahaYuddhaOutcome:
+    planets: tuple[str, str]
+    sign: str
+    orb: float
+    winner: str
+    loser: str
+    rationale: str
+
+
+def compute_srishti_aspects(
+    positions: Mapping[str, BodyPosition], houses: HousePositions
+) -> list[SrishtiAspect]:
+    """Return the whole-sign (Parasara) aspects present in the chart."""
+
+    house_map = planet_house_map(positions, houses)
+    aspects: list[SrishtiAspect] = []
+    for planet, house_idx in house_map.items():
+        offsets = SRISHTI_ASPECT_OFFSETS.get(planet, (7,))
+        for offset in offsets:
+            target = ((house_idx + offset - 1) % 12) + 1
+            aspect_type = "full" if offset == 7 else "special"
+            weight = 1.0 if aspect_type == "full" else 0.75
+            aspects.append(
+                SrishtiAspect(
+                    planet=planet,
+                    source_house=house_idx,
+                    target_house=target,
+                    offset=offset,
+                    aspect_type=aspect_type,
+                    weight=weight,
+                )
+            )
+    return aspects
+
+
+def _brightness_rank(planet: str) -> int:
+    return PLANETARY_WAR_BRIGHTNESS.get(planet, 0)
+
+
+def detect_graha_yuddha(
+    positions: Mapping[str, BodyPosition], *, orb_limit: float = 1.0
+) -> list[GrahaYuddhaOutcome]:
+    """Return graha yuddha encounters using the classical Parasara rule."""
+
+    outcomes: list[GrahaYuddhaOutcome] = []
+    bodies = [p for p in PLANETARY_WAR_PARTICIPANTS if p in positions]
+    for idx, planet_a in enumerate(bodies):
+        pos_a = positions[planet_a]
+        sign_a = sign_index(pos_a.longitude)
+        for planet_b in bodies[idx + 1 :]:
+            pos_b = positions[planet_b]
+            if sign_index(pos_b.longitude) != sign_a:
+                continue
+            orb = circular_separation(pos_a.longitude, pos_b.longitude)
+            if orb > orb_limit:
+                continue
+            lat_a = pos_a.latitude
+            lat_b = pos_b.latitude
+            if abs(lat_a - lat_b) > 1e-6:
+                winner = planet_a if lat_a > lat_b else planet_b
+                rationale = "higher_latitude"
+            else:
+                rank_a = _brightness_rank(planet_a)
+                rank_b = _brightness_rank(planet_b)
+                if rank_a != rank_b:
+                    winner = planet_a if rank_a > rank_b else planet_b
+                    rationale = "brightness_order"
+                else:
+                    lon_a = pos_a.longitude % 360.0
+                    lon_b = pos_b.longitude % 360.0
+                    winner = planet_a if lon_a > lon_b else planet_b
+                    rationale = "greater_longitude"
+            loser = planet_b if winner == planet_a else planet_a
+            outcome = GrahaYuddhaOutcome(
+                planets=tuple(sorted((planet_a, planet_b))),
+                sign=sign_name(sign_a),
+                orb=orb,
+                winner=winner,
+                loser=loser,
+                rationale=rationale,
+            )
+            outcomes.append(outcome)
+    return outcomes

--- a/astroengine/jyotish/data.py
+++ b/astroengine/jyotish/data.py
@@ -1,0 +1,201 @@
+"""Reference tables for classical Jyotish dignity and rulership data.
+
+The constants in this module are drawn from widely cited Vedic astrology
+sources:
+
+* The house lordship scheme and natural significators (karakas) follow the
+  chapters on bhava and karaka assignments from *Brihat Parashara Hora
+  Shastra* (BPHS), notably chapters 4–6 in the public domain translation by
+  G. S. Kapoor (1967).
+* Exaltation, debilitation, and moolatrikona spans match the table compiled by
+  B. V. Raman in *Graha and Bhava Balas* (1984, Chapter 3) which itself
+  references BPHS and Saravali.  Only spans explicitly documented in those
+  texts are encoded here.
+* Friendship and enmity between planets mirror BPHS Chapter 45.  Nodes follow
+  the standard Parasara tradition where Rahu behaves like Saturn and Venus,
+  while Ketu mirrors Mars and Jupiter.
+* Combustion orbs are the values used by the `Muhurtha` tables reproduced in
+  Raman's work (op. cit., Chapter 5).  They match the orbs popularised in
+  classical Panchanga calculations.
+* Planetary war (graha yuddha) participants and judgement order follow BPHS
+  Chapter 28: only Mars, Mercury, Jupiter, Venus, and Saturn engage in war,
+  the planet with the greater geocentric latitude wins, and brightness order
+  (Venus, Jupiter, Mercury, Mars, Saturn) breaks remaining ties.
+
+The tables are written in Python so they can be indexed efficiently and so the
+rest of the engine can compute derived metrics without loading external files
+at runtime.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+__all__ = [
+    "SIGN_LORDS",
+    "SIGN_CO_LORDS",
+    "HOUSE_KARAKAS",
+    "EXALTATION_SIGNS",
+    "DEBILITATION_SIGNS",
+    "MOOLATRIKONA_SPANS",
+    "PLANET_FRIENDS",
+    "PLANET_ENEMIES",
+    "PLANET_NEUTRALS",
+    "COMBUSTION_LIMITS",
+    "SRISHTI_ASPECT_OFFSETS",
+    "PLANETARY_WAR_PARTICIPANTS",
+    "PLANETARY_WAR_BRIGHTNESS",
+]
+
+# Primary sign lords (classical Parasara scheme).
+SIGN_LORDS: Mapping[str, tuple[str, ...]] = {
+    "Aries": ("Mars",),
+    "Taurus": ("Venus",),
+    "Gemini": ("Mercury",),
+    "Cancer": ("Moon",),
+    "Leo": ("Sun",),
+    "Virgo": ("Mercury",),
+    "Libra": ("Venus",),
+    "Scorpio": ("Mars",),
+    "Sagittarius": ("Jupiter",),
+    "Capricorn": ("Saturn",),
+    "Aquarius": ("Saturn",),
+    "Pisces": ("Jupiter",),
+}
+
+# Nodes and modern co-lords referenced in many SolarFire catalogues.
+SIGN_CO_LORDS: Mapping[str, tuple[str, ...]] = {
+    "Scorpio": ("Ketu",),
+    "Aquarius": ("Rahu",),
+    "Pisces": ("Neptune",),
+}
+
+# Natural significators (karakas) for the twelve houses.
+HOUSE_KARAKAS: Mapping[int, tuple[str, ...]] = {
+    1: ("Sun", "Moon"),
+    2: ("Jupiter", "Mercury"),
+    3: ("Mars", "Mercury"),
+    4: ("Moon", "Venus"),
+    5: ("Jupiter", "Sun"),
+    6: ("Mars", "Saturn"),
+    7: ("Venus", "Jupiter"),
+    8: ("Saturn", "Ketu"),
+    9: ("Jupiter", "Sun"),
+    10: ("Sun", "Mercury"),
+    11: ("Jupiter", "Mercury"),
+    12: ("Saturn", "Ketu"),
+}
+
+EXALTATION_SIGNS: Mapping[str, str] = {
+    "Sun": "Aries",
+    "Moon": "Taurus",
+    "Mars": "Capricorn",
+    "Mercury": "Virgo",
+    "Jupiter": "Cancer",
+    "Venus": "Pisces",
+    "Saturn": "Libra",
+    "Rahu": "Taurus",
+    "Ketu": "Scorpio",
+}
+
+DEBILITATION_SIGNS: Mapping[str, str] = {
+    "Sun": "Libra",
+    "Moon": "Scorpio",
+    "Mars": "Cancer",
+    "Mercury": "Pisces",
+    "Jupiter": "Capricorn",
+    "Venus": "Virgo",
+    "Saturn": "Aries",
+    "Rahu": "Scorpio",
+    "Ketu": "Taurus",
+}
+
+# start_degree inclusive, end_degree exclusive (in sign-relative degrees)
+MOOLATRIKONA_SPANS: Mapping[str, tuple[str, float, float]] = {
+    "Sun": ("Leo", 0.0, 20.0),
+    "Moon": ("Taurus", 3.0, 30.0),
+    "Mars": ("Aries", 0.0, 12.0),
+    "Mercury": ("Virgo", 15.0, 20.0),
+    "Jupiter": ("Sagittarius", 0.0, 10.0),
+    "Venus": ("Libra", 0.0, 15.0),
+    "Saturn": ("Aquarius", 0.0, 20.0),
+    "Rahu": ("Gemini", 0.0, 15.0),
+    "Ketu": ("Sagittarius", 0.0, 15.0),
+}
+
+PLANET_FRIENDS: Mapping[str, tuple[str, ...]] = {
+    "Sun": ("Moon", "Mars", "Jupiter"),
+    "Moon": ("Sun", "Mercury"),
+    "Mars": ("Sun", "Moon", "Jupiter"),
+    "Mercury": ("Sun", "Venus"),
+    "Jupiter": ("Sun", "Moon", "Mars"),
+    "Venus": ("Mercury", "Saturn"),
+    "Saturn": ("Mercury", "Venus"),
+    "Rahu": ("Venus", "Saturn"),
+    "Ketu": ("Mars", "Jupiter"),
+}
+
+PLANET_ENEMIES: Mapping[str, tuple[str, ...]] = {
+    "Sun": ("Venus", "Saturn"),
+    "Moon": (),
+    "Mars": ("Mercury",),
+    "Mercury": ("Moon",),
+    "Jupiter": ("Venus", "Mercury"),
+    "Venus": ("Sun", "Moon"),
+    "Saturn": ("Sun", "Moon"),
+    "Rahu": ("Sun", "Moon"),
+    "Ketu": ("Sun", "Moon"),
+}
+
+PLANET_NEUTRALS: Mapping[str, tuple[str, ...]] = {
+    "Sun": ("Mercury",),
+    "Moon": ("Mars", "Jupiter", "Venus", "Saturn"),
+    "Mars": ("Venus", "Saturn"),
+    "Mercury": ("Mars", "Jupiter", "Saturn"),
+    "Jupiter": ("Saturn",),
+    "Venus": ("Mars", "Jupiter"),
+    "Saturn": ("Mars", "Jupiter"),
+    "Rahu": ("Mars", "Jupiter"),
+    "Ketu": ("Venus", "Saturn", "Mercury"),
+}
+
+# Combustion orbs measured in degrees of separation from the Sun.
+COMBUSTION_LIMITS: Mapping[str, float] = {
+    "Moon": 12.0,
+    "Mars": 17.0,
+    "Mercury": 12.0,
+    "Jupiter": 11.0,
+    "Venus": 10.0,
+    "Saturn": 15.0,
+    "Rahu": 8.0,
+    "Ketu": 8.0,
+}
+
+# Whole-sign (srishti) aspect offsets counted from the occupied house.
+SRISHTI_ASPECT_OFFSETS: Mapping[str, tuple[int, ...]] = {
+    "Sun": (7,),
+    "Moon": (7,),
+    "Mercury": (7,),
+    "Venus": (7,),
+    "Mars": (4, 7, 8),
+    "Jupiter": (5, 7, 9),
+    "Saturn": (3, 7, 10),
+    "Rahu": (5, 7, 9),
+    "Ketu": (5, 7, 9),
+}
+
+PLANETARY_WAR_PARTICIPANTS: tuple[str, ...] = (
+    "Mars",
+    "Mercury",
+    "Jupiter",
+    "Venus",
+    "Saturn",
+)
+
+PLANETARY_WAR_BRIGHTNESS: Mapping[str, int] = {
+    "Venus": 5,
+    "Jupiter": 4,
+    "Mercury": 3,
+    "Mars": 2,
+    "Saturn": 1,
+}

--- a/astroengine/jyotish/karaka.py
+++ b/astroengine/jyotish/karaka.py
@@ -1,0 +1,19 @@
+"""Natural significator helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from ..ephemeris import BodyPosition
+from .lords import karakas_for_house
+
+__all__ = ["match_karakas"]
+
+
+def match_karakas(
+    house: int, positions: Mapping[str, BodyPosition]
+) -> tuple[str, ...]:
+    """Return karaka planets present in ``positions`` for ``house``."""
+
+    wanted = karakas_for_house(house)
+    return tuple(planet for planet in wanted if planet in positions)

--- a/astroengine/jyotish/lords.py
+++ b/astroengine/jyotish/lords.py
@@ -1,0 +1,56 @@
+"""Helpers for mapping house lords, occupants, and karakas."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping
+
+from ..ephemeris import BodyPosition, HousePositions
+from .data import HOUSE_KARAKAS, SIGN_CO_LORDS, SIGN_LORDS
+from .utils import house_signs, planet_house_map
+
+__all__ = [
+    "determine_house_lords",
+    "house_occupants",
+    "karakas_for_house",
+]
+
+
+def determine_house_lords(
+    houses: HousePositions, *, include_co_lords: bool = True
+) -> dict[int, tuple[str, ...]]:
+    """Return the ruling planet sequence for each house."""
+
+    mapping: dict[int, tuple[str, ...]] = {}
+    for house, sign in house_signs(houses).items():
+        lords = list(SIGN_LORDS.get(sign, ()))
+        if include_co_lords and sign in SIGN_CO_LORDS:
+            lords.extend(SIGN_CO_LORDS[sign])
+        if lords:
+            mapping[house] = tuple(dict.fromkeys(lords))
+        else:
+            mapping[house] = ()
+    return mapping
+
+
+def house_occupants(
+    positions: Mapping[str, BodyPosition], houses: HousePositions
+) -> dict[int, tuple[str, ...]]:
+    """Return the occupants of each house sorted by zodiacal order."""
+
+    house_map = planet_house_map(positions, houses)
+    occupants: dict[int, list[tuple[float, str]]] = defaultdict(list)
+    for name, position in positions.items():
+        house_idx = house_map[name]
+        occupants[house_idx].append((position.longitude % 360.0, name))
+    sorted_map: dict[int, tuple[str, ...]] = {}
+    for house_idx, values in occupants.items():
+        values.sort(key=lambda item: item[0])
+        sorted_map[house_idx] = tuple(name for _, name in values)
+    return sorted_map
+
+
+def karakas_for_house(house: int) -> tuple[str, ...]:
+    """Return natural significators (karakas) for ``house``."""
+
+    return HOUSE_KARAKAS.get(house, ())

--- a/astroengine/jyotish/rules.py
+++ b/astroengine/jyotish/rules.py
@@ -1,0 +1,219 @@
+"""House claim resolution based on Jyotish strength scoring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Mapping
+
+from ..ephemeris import BodyPosition, HousePositions
+from ..chart.natal import NatalChart
+from .aspects import GrahaYuddhaOutcome, compute_srishti_aspects, detect_graha_yuddha
+from .karaka import match_karakas
+from .lords import determine_house_lords, house_occupants
+from .strength import StrengthScore, score_planet_strength
+from .utils import house_signs
+
+__all__ = [
+    "HouseClaim",
+    "HouseWinner",
+    "evaluate_house_claims",
+    "evaluate_house_claims_from_chart",
+]
+
+CLAIM_WEIGHTS: Mapping[str, float] = {
+    "ruler": 2.5,
+    "co_ruler": 2.0,
+    "occupant": 1.8,
+    "karaka": 1.2,
+    "aspect_full": 1.0,
+    "aspect_special": 0.8,
+}
+
+CLAIM_PRIORITY: Mapping[str, int] = {
+    "ruler": 0,
+    "co_ruler": 1,
+    "occupant": 2,
+    "karaka": 3,
+    "aspect_full": 4,
+    "aspect_special": 5,
+}
+
+
+@dataclass(frozen=True)
+class HouseClaim:
+    planet: str
+    claim_type: str
+    basis: str
+    weight: float
+    strength: StrengthScore
+    effective_score: float
+    metadata: Mapping[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class HouseWinner:
+    house: int
+    sign: str
+    winner: HouseClaim | None
+    claims: tuple[HouseClaim, ...]
+    graha_yuddha: tuple[GrahaYuddhaOutcome, ...]
+
+
+def _claim_sort_key(claim: HouseClaim) -> tuple[float, int, float, float, str]:
+    priority = CLAIM_PRIORITY.get(claim.claim_type, 99)
+    return (
+        -claim.effective_score,
+        priority,
+        -claim.strength.total,
+        -claim.weight,
+        claim.planet,
+    )
+
+
+def _build_graha_roles(
+    outcomes: Iterable[GrahaYuddhaOutcome],
+) -> dict[str, tuple[GrahaYuddhaOutcome, str]]:
+    roles: dict[str, tuple[GrahaYuddhaOutcome, str]] = {}
+    for outcome in outcomes:
+        roles[outcome.winner] = (outcome, "winner")
+        roles[outcome.loser] = (outcome, "loser")
+    return roles
+
+
+def evaluate_house_claims(
+    positions: Mapping[str, BodyPosition],
+    houses: HousePositions,
+    *,
+    include_co_lords: bool = True,
+) -> dict[int, HouseWinner]:
+    """Return the resolved house winners for the supplied chart geometry."""
+
+    lords = determine_house_lords(houses, include_co_lords=include_co_lords)
+    occupants = house_occupants(positions, houses)
+    karaka_matches = {
+        house: match_karakas(house, positions) for house in range(1, 13)
+    }
+    aspects = compute_srishti_aspects(positions, houses)
+    aspect_targets: dict[int, list] = {}
+    for aspect in aspects:
+        aspect_targets.setdefault(aspect.target_house, []).append(aspect)
+
+    graha_outcomes = detect_graha_yuddha(positions)
+    graha_roles = _build_graha_roles(graha_outcomes)
+
+    sun_position = positions.get("Sun")
+    strengths: dict[str, StrengthScore] = {}
+    for planet, position in positions.items():
+        strengths[planet] = score_planet_strength(
+            planet,
+            position,
+            houses=houses,
+            sun_position=sun_position,
+            graha_roles=graha_roles,
+        )
+
+    claims_by_house: dict[int, list[HouseClaim]] = {house: [] for house in range(1, 13)}
+    sign_map = house_signs(houses)
+
+    for house in range(1, 13):
+        house_claims = claims_by_house[house]
+        sign = sign_map[house]
+
+        for idx, planet in enumerate(lords.get(house, ())):
+            if planet not in strengths:
+                continue
+            claim_type = "ruler" if idx == 0 else "co_ruler"
+            weight = CLAIM_WEIGHTS[claim_type]
+            basis = f"{sign} {'ruler' if idx == 0 else 'co-ruler'}"
+            strength = strengths[planet]
+            effective = weight + strength.total
+            house_claims.append(
+                HouseClaim(
+                    planet=planet,
+                    claim_type=claim_type,
+                    basis=basis,
+                    weight=weight,
+                    strength=strength,
+                    effective_score=effective,
+                    metadata={"ordinal": idx},
+                )
+            )
+
+        for planet in occupants.get(house, ()):  # occupant weight
+            if planet not in strengths:
+                continue
+            weight = CLAIM_WEIGHTS["occupant"]
+            strength = strengths[planet]
+            effective = weight + strength.total
+            house_claims.append(
+                HouseClaim(
+                    planet=planet,
+                    claim_type="occupant",
+                    basis="occupant",
+                    weight=weight,
+                    strength=strength,
+                    effective_score=effective,
+                    metadata={"longitude": positions[planet].longitude},
+                )
+            )
+
+        for planet in karaka_matches.get(house, ()):  # karakas present
+            if planet not in strengths:
+                continue
+            weight = CLAIM_WEIGHTS["karaka"]
+            strength = strengths[planet]
+            effective = weight + strength.total
+            house_claims.append(
+                HouseClaim(
+                    planet=planet,
+                    claim_type="karaka",
+                    basis="natural_karaka",
+                    weight=weight,
+                    strength=strength,
+                    effective_score=effective,
+                    metadata=None,
+                )
+            )
+
+        for aspect in aspect_targets.get(house, ()):  # drishti
+            planet = aspect.planet
+            if planet not in strengths:
+                continue
+            claim_type = "aspect_full" if aspect.aspect_type == "full" else "aspect_special"
+            base_weight = CLAIM_WEIGHTS[claim_type]
+            weight = base_weight * aspect.weight
+            strength = strengths[planet]
+            effective = weight + strength.total
+            house_claims.append(
+                HouseClaim(
+                    planet=planet,
+                    claim_type=claim_type,
+                    basis=f"srishti_{aspect.aspect_type}",
+                    weight=weight,
+                    strength=strength,
+                    effective_score=effective,
+                    metadata={
+                        "source_house": aspect.source_house,
+                        "offset": aspect.offset,
+                    },
+                )
+            )
+
+    winners: dict[int, HouseWinner] = {}
+    for house, claims in claims_by_house.items():
+        claims_sorted = sorted(claims, key=_claim_sort_key)
+        winner_claim = claims_sorted[0] if claims_sorted else None
+        winners[house] = HouseWinner(
+            house=house,
+            sign=sign_map[house],
+            winner=winner_claim,
+            claims=tuple(claims_sorted),
+            graha_yuddha=tuple(graha_outcomes),
+        )
+    return winners
+
+
+def evaluate_house_claims_from_chart(chart: NatalChart) -> dict[int, HouseWinner]:
+    """Convenience wrapper accepting a :class:`NatalChart`."""
+
+    return evaluate_house_claims(chart.positions, chart.houses)

--- a/astroengine/jyotish/strength.py
+++ b/astroengine/jyotish/strength.py
@@ -1,0 +1,135 @@
+"""Planetary strength scoring for classical dignity conditions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from ..ephemeris import BodyPosition, HousePositions
+from ..detectors.ingresses import sign_index, sign_name
+from .aspects import GrahaYuddhaOutcome
+from .data import (
+    COMBUSTION_LIMITS,
+    DEBILITATION_SIGNS,
+    EXALTATION_SIGNS,
+    MOOLATRIKONA_SPANS,
+    PLANET_ENEMIES,
+    PLANET_FRIENDS,
+    SIGN_LORDS,
+)
+from .utils import circular_separation, degree_in_sign, house_index_for
+
+__all__ = ["StrengthScore", "score_planet_strength"]
+
+DIGNITY_WEIGHTS: Mapping[str, float] = {
+    "exaltation": 4.0,
+    "moolatrikona": 3.0,
+    "own_sign": 2.5,
+    "friend_sign": 1.5,
+    "neutral_sign": 0.5,
+    "enemy_sign": -1.5,
+    "debilitation": -4.0,
+}
+
+RETROGRADE_BONUS = 1.0
+COMBUSTION_PENALTY = -2.5
+GRAHA_WAR_WIN_BONUS = 1.5
+GRAHA_WAR_LOSS_PENALTY = -3.0
+
+_OWN_SIGN_CACHE: dict[str, tuple[str, ...]] | None = None
+
+
+def _own_signs() -> dict[str, tuple[str, ...]]:
+    global _OWN_SIGN_CACHE
+    if _OWN_SIGN_CACHE is None:
+        mapping: dict[str, list[str]] = {}
+        for sign, lords in SIGN_LORDS.items():
+            for lord in lords:
+                mapping.setdefault(lord, []).append(sign)
+        _OWN_SIGN_CACHE = {planet: tuple(signs) for planet, signs in mapping.items()}
+    return _OWN_SIGN_CACHE
+
+
+def _dignity(planet: str, sign: str, degree: float) -> str:
+    if EXALTATION_SIGNS.get(planet) == sign:
+        return "exaltation"
+    if DEBILITATION_SIGNS.get(planet) == sign:
+        return "debilitation"
+    span = MOOLATRIKONA_SPANS.get(planet)
+    if span and span[0] == sign and span[1] <= degree < span[2]:
+        return "moolatrikona"
+    if sign in _own_signs().get(planet, ()):  # own sign fallback
+        return "own_sign"
+    rulers = SIGN_LORDS.get(sign)
+    ruler = rulers[0] if rulers else None
+    if ruler in PLANET_FRIENDS.get(planet, ()):  # friend sign
+        return "friend_sign"
+    if ruler in PLANET_ENEMIES.get(planet, ()):  # enemy sign
+        return "enemy_sign"
+    return "neutral_sign"
+
+
+@dataclass(frozen=True)
+class StrengthScore:
+    planet: str
+    sign: str
+    house: int
+    dignity: str
+    contributions: Mapping[str, float]
+    total: float
+    is_retrograde: bool
+    is_combust: bool
+    graha_yuddha: GrahaYuddhaOutcome | None
+
+
+def score_planet_strength(
+    planet: str,
+    position: BodyPosition,
+    *,
+    houses: HousePositions,
+    sun_position: BodyPosition | None = None,
+    graha_roles: Mapping[str, tuple[GrahaYuddhaOutcome, str]] | None = None,
+) -> StrengthScore:
+    """Return a weighted strength score for ``planet`` at ``position``."""
+
+    house_idx = house_index_for(position.longitude, houses)
+    sign = sign_name(sign_index(position.longitude))
+    degree = degree_in_sign(position.longitude)
+    dignity = _dignity(planet, sign, degree)
+    contributions: dict[str, float] = {
+        "dignity": DIGNITY_WEIGHTS.get(dignity, 0.0)
+    }
+
+    is_retrograde = position.speed_longitude < 0
+    if is_retrograde:
+        contributions["retrograde"] = RETROGRADE_BONUS
+
+    is_combust = False
+    if planet != "Sun" and sun_position is not None:
+        limit = COMBUSTION_LIMITS.get(planet)
+        if limit is not None:
+            separation = circular_separation(position.longitude, sun_position.longitude)
+            if separation <= limit:
+                contributions["combustion"] = COMBUSTION_PENALTY
+                is_combust = True
+
+    graha_entry = None
+    if graha_roles and planet in graha_roles:
+        graha_entry = graha_roles[planet]
+        outcome, role = graha_entry
+        if role == "winner":
+            contributions["graha_yuddha"] = GRAHA_WAR_WIN_BONUS
+        else:
+            contributions["graha_yuddha"] = GRAHA_WAR_LOSS_PENALTY
+    total = sum(contributions.values())
+    return StrengthScore(
+        planet=planet,
+        sign=sign,
+        house=house_idx,
+        dignity=dignity,
+        contributions=contributions,
+        total=total,
+        is_retrograde=is_retrograde,
+        is_combust=is_combust,
+        graha_yuddha=graha_entry[0] if graha_entry else None,
+    )

--- a/astroengine/jyotish/utils.py
+++ b/astroengine/jyotish/utils.py
@@ -1,0 +1,81 @@
+"""Utility helpers for Jyotish calculations."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+from ..ephemeris import BodyPosition, HousePositions
+from ..detectors.ingresses import sign_index, sign_name
+
+__all__ = [
+    "norm360",
+    "circular_separation",
+    "degree_in_sign",
+    "house_index_for",
+    "house_signs",
+    "planet_house_map",
+]
+
+
+def norm360(value: float) -> float:
+    """Normalise ``value`` to the range [0, 360)."""
+
+    return value % 360.0
+
+
+def circular_separation(a: float, b: float) -> float:
+    """Return the smallest angular separation between ``a`` and ``b`` degrees."""
+
+    diff = abs((a - b + 180.0) % 360.0 - 180.0)
+    return diff
+
+
+def degree_in_sign(longitude: float) -> float:
+    """Return the degree within the active sign (0–30)."""
+
+    return norm360(longitude) % 30.0
+
+
+def house_index_for(longitude: float, houses: HousePositions) -> int:
+    """Return the 1-indexed house position for ``longitude`` given ``houses``.
+
+    The logic matches the Swiss Ephemeris definition used in SolarFire.  It is
+    essentially a direct copy of the private helper in
+    :mod:`astroengine.detectors.ingresses` but exposed here so Jyotish scoring
+    can reason about occupants without importing private symbols.
+    """
+
+    cusps = list(houses.cusps[:12])
+    values = [norm360(value) for value in cusps]
+    lon = norm360(longitude)
+    for idx in range(12):
+        start = values[idx]
+        end = values[(idx + 1) % 12]
+        if start <= end:
+            if start <= lon < end:
+                return idx + 1
+        else:
+            if lon >= start or lon < end:
+                return idx + 1
+    return 12
+
+
+def house_signs(houses: HousePositions) -> dict[int, str]:
+    """Return the zodiac sign for each house cusp."""
+
+    mapping: dict[int, str] = {}
+    for idx, cusp in enumerate(houses.cusps[:12], start=1):
+        mapping[idx] = sign_name(sign_index(cusp))
+    return mapping
+
+
+def planet_house_map(
+    positions: Mapping[str, BodyPosition], houses: HousePositions
+) -> dict[str, int]:
+    """Return the house index for each planet in ``positions``."""
+
+    return {
+        name: house_index_for(position.longitude, houses)
+        for name, position in positions.items()
+    }

--- a/astroengine/modules/__init__.py
+++ b/astroengine/modules/__init__.py
@@ -6,6 +6,7 @@ from .esoteric import register_esoteric_module
 from .event_detectors import register_event_detectors_module
 from .mundane import register_mundane_module
 from .narrative import register_narrative_module
+from .jyotish import register_jyotish_module
 from .predictive import register_predictive_module
 from .registry import (
     AstroChannel,
@@ -38,6 +39,7 @@ def bootstrap_default_registry() -> AstroRegistry:
     register_esoteric_module(registry)
 
     register_mundane_module(registry)
+    register_jyotish_module(registry)
     register_narrative_module(registry)
 
     register_ritual_module(registry)

--- a/astroengine/modules/jyotish/__init__.py
+++ b/astroengine/modules/jyotish/__init__.py
@@ -1,0 +1,120 @@
+"""Register Jyotish rule assets with the :class:`AstroRegistry`."""
+
+from __future__ import annotations
+
+from ...jyotish.data import (
+    COMBUSTION_LIMITS,
+    DEBILITATION_SIGNS,
+    EXALTATION_SIGNS,
+    HOUSE_KARAKAS,
+    MOOLATRIKONA_SPANS,
+    PLANETARY_WAR_BRIGHTNESS,
+    PLANETARY_WAR_PARTICIPANTS,
+    SIGN_CO_LORDS,
+    SIGN_LORDS,
+    SRISHTI_ASPECT_OFFSETS,
+)
+from ..registry import AstroModule, AstroRegistry
+
+__all__ = ["register_jyotish_module"]
+
+
+def register_jyotish_module(registry: AstroRegistry) -> AstroModule:
+    """Attach the bundled Jyotish rule metadata to ``registry``."""
+
+    module = registry.register_module(
+        "jyotish",
+        metadata={
+            "description": "Classical Parasara house lords, karakas, and dignity rules",
+            "sources": [
+                "Brihat Parashara Hora Shastra (Kapoor translation, 1967)",
+                "B. V. Raman — Graha and Bhava Balas (1984)",
+            ],
+        },
+    )
+
+    houses = module.register_submodule(
+        "houses",
+        metadata={
+            "description": "Ruling lords and natural significators for each bhava.",
+        },
+    )
+    lords_channel = houses.register_channel(
+        "lords",
+        metadata={"description": "Classical sign and co-lord assignments."},
+    )
+    lords_channel.register_subchannel(
+        "parasara",
+        metadata={"include_co_lords": False},
+        payload={
+            "sign_lords": {sign: list(lords) for sign, lords in SIGN_LORDS.items()},
+            "co_lords": {sign: list(lords) for sign, lords in SIGN_CO_LORDS.items()},
+        },
+    )
+    houses.register_channel(
+        "karakas",
+        metadata={"description": "Natural significators mapped to houses."},
+    ).register_subchannel(
+        "parasara",
+        metadata={"count": len(HOUSE_KARAKAS)},
+        payload={"house_karakas": {house: list(planets) for house, planets in HOUSE_KARAKAS.items()}},
+    )
+
+    strength = module.register_submodule(
+        "strength",
+        metadata={"description": "Dignity and combustion reference tables."},
+    )
+    dignity_channel = strength.register_channel(
+        "dignity",
+        metadata={"description": "Exaltation, debilitation, and moolatrikona spans."},
+    )
+    dignity_channel.register_subchannel(
+        "sign_status",
+        metadata={"planets": len(EXALTATION_SIGNS)},
+        payload={
+            "exaltation": dict(EXALTATION_SIGNS),
+            "debilitation": dict(DEBILITATION_SIGNS),
+            "moolatrikona": {
+                planet: {
+                    "sign": sign,
+                    "start_deg": start,
+                    "end_deg": end,
+                }
+                for planet, (sign, start, end) in MOOLATRIKONA_SPANS.items()
+            },
+        },
+    )
+    strength.register_channel(
+        "combustion",
+        metadata={"description": "Solar combustion orbs in degrees."},
+    ).register_subchannel(
+        "raman_tables",
+        metadata={"planets": len(COMBUSTION_LIMITS)},
+        payload={"limits": dict(COMBUSTION_LIMITS)},
+    )
+
+    aspects = module.register_submodule(
+        "aspects",
+        metadata={"description": "Whole-sign drishti and graha yuddha rules."},
+    )
+    aspects.register_channel(
+        "srishti",
+        metadata={"description": "Parasara special aspects."},
+    ).register_subchannel(
+        "classical",
+        metadata={},
+        payload={"offsets": {planet: list(offsets) for planet, offsets in SRISHTI_ASPECT_OFFSETS.items()}},
+    )
+    aspects.register_channel(
+        "graha_yuddha",
+        metadata={"description": "Planetary war participants and tie-break order."},
+    ).register_subchannel(
+        "classical",
+        metadata={"participants": len(PLANETARY_WAR_PARTICIPANTS)},
+        payload={
+            "participants": list(PLANETARY_WAR_PARTICIPANTS),
+            "brightness_priority": dict(PLANETARY_WAR_BRIGHTNESS),
+        },
+    )
+
+    return module

--- a/tests/test_jyotish_rules.py
+++ b/tests/test_jyotish_rules.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from astroengine.ephemeris import BodyPosition, HousePositions
+from astroengine.jyotish import (
+    determine_house_lords,
+    detect_graha_yuddha,
+    evaluate_house_claims,
+    score_planet_strength,
+)
+
+
+def _make_body(
+    name: str,
+    longitude: float,
+    *,
+    latitude: float = 0.0,
+    speed_longitude: float = 1.0,
+) -> BodyPosition:
+    return BodyPosition(
+        body=name,
+        julian_day=2451545.0,
+        longitude=longitude,
+        latitude=latitude,
+        distance_au=1.0,
+        speed_longitude=speed_longitude,
+        speed_latitude=0.0,
+        speed_distance=0.0,
+        declination=0.0,
+        speed_declination=0.0,
+    )
+
+
+def _aries_whole_sign_houses() -> HousePositions:
+    cusps = tuple(float(i * 30.0) for i in range(12))
+    return HousePositions(
+        system="whole_sign",
+        cusps=cusps,
+        ascendant=0.0,
+        midheaven=90.0,
+    )
+
+
+def _sample_positions() -> dict[str, BodyPosition]:
+    return {
+        "Sun": _make_body("Sun", 10.0),
+        "Moon": _make_body("Moon", 35.0),  # Taurus
+        "Mercury": _make_body("Mercury", 15.0),
+        "Venus": _make_body("Venus", 355.0),  # Pisces
+        "Mars": _make_body("Mars", 70.0),  # Gemini
+        "Jupiter": _make_body("Jupiter", 100.0),  # Cancer
+        "Saturn": _make_body("Saturn", 195.0, speed_longitude=-0.5),  # Libra retrograde
+    }
+
+
+def test_determine_house_lords_matches_parasara_tables() -> None:
+    houses = _aries_whole_sign_houses()
+    lords = determine_house_lords(houses)
+    assert lords[1][0] == "Mars"
+    assert lords[4][0] == "Moon"
+    assert lords[7][0] == "Venus"
+    assert lords[10][0] == "Saturn"
+
+
+def test_strength_scoring_flags_dignity_combustion_and_retrograde() -> None:
+    houses = _aries_whole_sign_houses()
+    positions = _sample_positions()
+    # Mercury is within 5° of the Sun and should be marked combust.
+    mercury_strength = score_planet_strength(
+        "Mercury",
+        positions["Mercury"],
+        houses=houses,
+        sun_position=positions["Sun"],
+        graha_roles={},
+    )
+    assert mercury_strength.is_combust
+    assert mercury_strength.contributions["dignity"] < 1.0
+    assert mercury_strength.contributions["combustion"] < 0.0
+
+    jupiter_strength = score_planet_strength(
+        "Jupiter",
+        positions["Jupiter"],
+        houses=houses,
+        sun_position=positions["Sun"],
+        graha_roles={},
+    )
+    assert jupiter_strength.dignity == "exaltation"
+    assert jupiter_strength.total > mercury_strength.total
+
+    saturn_strength = score_planet_strength(
+        "Saturn",
+        positions["Saturn"],
+        houses=houses,
+        sun_position=positions["Sun"],
+        graha_roles={},
+    )
+    assert saturn_strength.is_retrograde
+    assert "retrograde" in saturn_strength.contributions
+
+
+def test_house_claims_promote_exalted_ruler_over_exalted_occupant() -> None:
+    houses = _aries_whole_sign_houses()
+    positions = _sample_positions()
+    claims = evaluate_house_claims(positions, houses)
+
+    first_house = claims[1]
+    assert first_house.winner is not None
+    assert first_house.winner.planet == "Sun"
+    assert first_house.winner.strength.dignity == "exaltation"
+
+    fourth_house = claims[4]
+    assert fourth_house.winner is not None
+    # Moon should win as ruler despite Jupiter's exaltation in the house.
+    assert fourth_house.winner.planet == "Moon"
+    occupant_planets = {claim.planet for claim in fourth_house.claims if claim.claim_type == "occupant"}
+    assert "Jupiter" in occupant_planets
+
+
+def test_detect_graha_yuddha_uses_latitude_priority() -> None:
+    positions = {
+        "Sun": _make_body("Sun", 0.0),
+        "Mars": _make_body("Mars", 70.0, latitude=1.2),
+        "Mercury": _make_body("Mercury", 70.5, latitude=0.3),
+    }
+    outcomes = detect_graha_yuddha(positions)
+    assert outcomes, "Expected graha yuddha between Mars and Mercury"
+    war = outcomes[0]
+    assert {"Mars", "Mercury"} == set(war.planets)
+    assert war.winner == "Mars"
+    assert war.rationale == "higher_latitude"


### PR DESCRIPTION
## Summary
- add a dedicated `astroengine.jyotish` package with rulership data, strength scoring, srishti aspects, and house-claim resolution utilities
- register the Jyotish assets in the module registry and surface the new helpers through the top-level API
- exercise the new logic with focused unit tests and address the missing `AliasChoices` import for interpretation models

## Testing
- pytest tests/test_jyotish_rules.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dbf85f32f88324b58c1d48bd06f01c