### PR TITLE
Fix AliasChoices import for interpret models

### DIFF
--- a/astroengine/ephemeris/__init__.py
+++ b/astroengine/ephemeris/__init__.py
@@ -18,7 +18,12 @@ from .refinement import (
     refine_root,
 )
 from .support import SupportIssue, filter_supported
-from .swisseph_adapter import BodyPosition, HousePositions, SwissEphemerisAdapter
+from .swisseph_adapter import (
+    BodyPosition,
+    HousePositions,
+    SolarCycleEvents,
+    SwissEphemerisAdapter,
+)
 
 __all__ = [
     "EphemerisAdapter",
@@ -34,6 +39,7 @@ __all__ = [
     "SwissEphemerisAdapter",
     "BodyPosition",
     "HousePositions",
+    "SolarCycleEvents",
     "TimeScaleContext",
     "SupportIssue",
     "filter_supported",

--- a/astroengine/interpret/models.py
+++ b/astroengine/interpret/models.py
@@ -13,6 +13,7 @@ from typing import Any, Iterable, Literal, Mapping, Sequence
 
 
 from pydantic import (
+    AliasChoices,
     AwareDatetime,
     BaseModel,
     ConfigDict,


### PR DESCRIPTION
## Summary
- add the missing AliasChoices import to astroengine.interpret.models so Pydantic alias definitions resolve at runtime

## Testing
- pytest tests/interpret/test_loader_schema.py

------
https://chatgpt.com/codex/tasks/task_e_68dbf71e09c08324913f79b11a3d59ff