### PR TITLE
Fix AliasChoices import for interpret models

### DIFF
--- a/astroengine/chart/natal.py
+++ b/astroengine/chart/natal.py
@@ -133,7 +133,7 @@ def compute_natal_chart(
 
     zodiac = chart_config.zodiac
     ayanamsa_name = chart_config.ayanamsha if zodiac == "sidereal" else None
-    ayanamsa_degrees = swe.get_ayanamsa_ut(jd_ut) if ayanamsa_name else None
+    ayanamsa_degrees = adapter.ayanamsa(jd_ut) if ayanamsa_name else None
     provenance: dict[str, object] = {"zodiac": zodiac, "house_system": chart_config.house_system}
     if ayanamsa_name:
         provenance.update(

--- a/astroengine/ephemeris/__init__.py
+++ b/astroengine/ephemeris/__init__.py
@@ -18,7 +18,13 @@ from .refinement import (
     refine_root,
 )
 from .support import SupportIssue, filter_supported
-from .swisseph_adapter import BodyPosition, HousePositions, SwissEphemerisAdapter
+from .swisseph_adapter import (
+    BodyPosition,
+    FixedStarPosition,
+    HousePositions,
+    RiseTransitResult,
+    SwissEphemerisAdapter,
+)
 
 __all__ = [
     "EphemerisAdapter",
@@ -34,6 +40,8 @@ __all__ = [
     "SwissEphemerisAdapter",
     "BodyPosition",
     "HousePositions",
+    "FixedStarPosition",
+    "RiseTransitResult",
     "TimeScaleContext",
     "SupportIssue",
     "filter_supported",

--- a/astroengine/interpret/models.py
+++ b/astroengine/interpret/models.py
@@ -6,13 +6,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-
-
 from datetime import UTC, datetime
 from typing import Any, Iterable, Literal, Mapping, Sequence
 
-
 from pydantic import (
+    AliasChoices,
     AwareDatetime,
     BaseModel,
     ConfigDict,
@@ -22,14 +20,6 @@ from pydantic import (
 )
 
 from astroengine.core.aspects_plus.harmonics import BASE_ASPECTS
-
-
-from dataclasses import dataclass
-from typing import Any, Iterable, Literal
-
-from pydantic import AwareDatetime, BaseModel, ConfigDict, Field, field_validator
-
-
 
 Body = Literal[
     "Sun",

--- a/astroengine/timelords/vimshottari.py
+++ b/astroengine/timelords/vimshottari.py
@@ -7,8 +7,6 @@ from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
-import swisseph as swe
-
 from .context import TimelordContext
 from .models import TimelordPeriod
 from .utils import clamp_end
@@ -86,7 +84,7 @@ def _cycle(start_ruler: str) -> Iterable[_PeriodSeed]:
 
 def _sidereal_moon_longitude(context: TimelordContext) -> float:
     moon = context.chart.positions["Moon"]
-    ayanamsa = swe.get_ayanamsa_ut(context.chart.julian_day)
+    ayanamsa = context.adapter.ayanamsa(context.chart.julian_day)
     return (moon.longitude - ayanamsa) % 360.0
 
 

--- a/tests/test_swisseph_adapter_extensions.py
+++ b/tests/test_swisseph_adapter_extensions.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from astroengine.ephemeris import SwissEphemerisAdapter
+
+swe = pytest.importorskip("swisseph")
+
+
+def test_julian_day_roundtrip_precision() -> None:
+    adapter = SwissEphemerisAdapter()
+    moment = datetime(2024, 3, 1, 12, 34, 56, 789123, tzinfo=UTC)
+    jd = adapter.julian_day(moment)
+    restored = adapter.from_julian_day(jd)
+    delta = abs((restored - moment).total_seconds())
+    assert delta < 5e-4
+
+
+def test_rise_transit_alignment_with_swisseph() -> None:
+    adapter = SwissEphemerisAdapter()
+    jd = swe.julday(2024, 6, 1, 0.0)
+    latitude = 40.7128
+    longitude = -74.0060
+    ours = adapter.rise_transit(
+        jd,
+        swe.SUN,
+        latitude=latitude,
+        longitude=longitude,
+        event="rise",
+        flags=adapter._calc_flags,  # noqa: SLF001 - intentional test access
+        body_name="Sun",
+    )
+    expected_status, expected_tret = swe.rise_trans(
+        jd,
+        swe.SUN,
+        swe.CALC_RISE,
+        (longitude, latitude, 0.0),
+        0.0,
+        0.0,
+        adapter._calc_flags,  # noqa: SLF001 - intentional test access
+    )
+    assert ours.status == expected_status
+    assert ours.julian_day is not None
+    assert abs(ours.julian_day - expected_tret[0]) < 1e-6
+
+
+def test_fixed_star_matches_native_computation() -> None:
+    adapter = SwissEphemerisAdapter()
+    jd = swe.julday(2024, 1, 1, 0.0)
+    star = adapter.fixed_star("Aldebaran", jd, flags=adapter._calc_flags)
+    values, name, retflags = swe.fixstar_ut("Aldebaran", jd, adapter._calc_flags)
+    assert star.name.strip().lower() == name.strip().lower()
+    assert abs(star.longitude - values[0]) < 1e-6
+    assert abs(star.latitude - values[1]) < 1e-6
+    assert star.flags == retflags
+
+
+def test_ayanamsa_variants() -> None:
+    adapter = SwissEphemerisAdapter(zodiac="sidereal", ayanamsa="lahiri")
+    jd = swe.julday(2024, 5, 10, 0.0)
+    ut_value = adapter.ayanamsa(jd)
+    expected_ut = swe.get_ayanamsa_ut(jd)
+    assert abs(ut_value - expected_ut) < 1e-8
+
+    true_value = adapter.ayanamsa(jd, true_longitude=True)
+    expected_true = swe.get_ayanamsa(jd + swe.deltat(jd))
+    assert abs(true_value - expected_true) < 1e-8
+
+    details = adapter.ayanamsa_details(jd)
+    flags, expected = swe.get_ayanamsa_ex_ut(jd, int(swe.SIDM_LAHIRI))
+    assert details["mode"] == int(swe.SIDM_LAHIRI)
+    assert details["flags"] == flags
+    assert abs(details["value"] - expected) < 1e-8
+
+
+def test_planet_name_resolution() -> None:
+    name = SwissEphemerisAdapter.planet_name(int(swe.MARS))
+    assert "mars" in name.lower()


### PR DESCRIPTION
## Summary
- extend the SwissEphemerisAdapter with reusable dataclasses plus helpers for Julian day conversion, ayanamsa metadata, rise/transit computations, and fixed star queries
- adopt the new Swiss Ephemeris helpers across natal, horary, timelord, and fixed star utilities to ensure consistent Swiss-backed data
- add focused tests covering the enhanced Swiss adapter behaviours
- resolve the interpret ProfileDefinition NameError by importing AliasChoices from pydantic and cleaning duplicate imports

## Testing
- pytest tests/interpret/test_engine_profiles.py

------
https://chatgpt.com/codex/tasks/task_e_68dbfa837b1c8324aa59c67922dcdb4c