### PR TITLE
Handle optional ephemeris dependencies and stabilize vedic exports

### DIFF
--- a/astroengine/chart/natal.py
+++ b/astroengine/chart/natal.py
@@ -6,8 +6,6 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 
-import swisseph as swe
-
 from ..ephemeris import BodyPosition, HousePositions, SwissEphemerisAdapter
 from ..scoring import DEFAULT_ASPECTS, OrbCalculator
 from .config import ChartConfig
@@ -20,17 +18,18 @@ __all__ = [
     "compute_natal_chart",
 ]
 
+# Swiss Ephemeris body indexes (Sun=0 … Pluto=9) remain stable across releases.
 DEFAULT_BODIES: Mapping[str, int] = {
-    "Sun": swe.SUN,
-    "Moon": swe.MOON,
-    "Mercury": swe.MERCURY,
-    "Venus": swe.VENUS,
-    "Mars": swe.MARS,
-    "Jupiter": swe.JUPITER,
-    "Saturn": swe.SATURN,
-    "Uranus": swe.URANUS,
-    "Neptune": swe.NEPTUNE,
-    "Pluto": swe.PLUTO,
+    "Sun": 0,
+    "Moon": 1,
+    "Mercury": 2,
+    "Venus": 3,
+    "Mars": 4,
+    "Jupiter": 5,
+    "Saturn": 6,
+    "Uranus": 7,
+    "Neptune": 8,
+    "Pluto": 9,
 }
 
 

--- a/astroengine/engine/vedic/__init__.py
+++ b/astroengine/engine/vedic/__init__.py
@@ -37,6 +37,20 @@ from .gochar import (
     TransitWeightPolicy,
     analyse_gochar_transits,
 )
+from .karmic import (
+    CharaKaraka,
+    EclipseAlignment,
+    IshtaKashtaResult,
+    KarakamshaLagna,
+    KarmaSegment,
+    KarmicProfile,
+    build_karmic_profile,
+    compute_chara_karakas,
+    eclipse_alignment_roles,
+    ishta_kashta_phala,
+    karakamsha_lagna,
+    karma_attributions,
+)
 
 from .nakshatra import (
     NAKSHATRA_ARC_DEGREES,
@@ -50,7 +64,15 @@ from .nakshatra import (
     position_for,
 )
 
-from .varga import VARGA_DEFINITIONS, compute_varga, dasamsa_sign, navamsa_sign
+from .panchang import NakshatraStatus
+from .shadbala import ShadbalaReport, ShadbalaScore, compute_shadbala
+from .varga import (
+    VARGA_DEFINITIONS,
+    compute_varga,
+    dasamsa_sign,
+    navamsa_sign,
+    saptamsa_sign,
+)
 
 
 __all__ = [
@@ -91,12 +113,27 @@ __all__ = [
     "nakshatra_of",
     "pada_of",
     "position_for",
+    "NakshatraStatus",
 
     "VARGA_DEFINITIONS",
 
     "compute_varga",
     "dasamsa_sign",
     "navamsa_sign",
+    "saptamsa_sign",
+
+    "CharaKaraka",
+    "KarakamshaLagna",
+    "IshtaKashtaResult",
+    "KarmaSegment",
+    "KarmicProfile",
+    "EclipseAlignment",
+    "compute_chara_karakas",
+    "karakamsha_lagna",
+    "ishta_kashta_phala",
+    "karma_attributions",
+    "eclipse_alignment_roles",
+    "build_karmic_profile",
 
     "Bhinnashtakavarga",
     "AshtakavargaSet",

--- a/astroengine/engine/vedic/varga.py
+++ b/astroengine/engine/vedic/varga.py
@@ -224,11 +224,25 @@ def _varga_components(longitude: float, definition: VargaDefinition) -> tuple[in
     return dest_sign, varga_longitude % 360.0, part_index + 1, start_sign
 
 
+def rasi_sign(longitude: float) -> tuple[int, float, dict[str, int | str]]:
+    """Return the base Rāśi sign index and longitude for ``longitude``."""
+
+    sign_idx = sign_index(longitude)
+    return sign_idx, longitude % 360.0, {}
+
+
 def navamsa_sign(longitude: float) -> tuple[int, float, int]:
     """Return the Navāṁśa sign index, longitude, and pada for ``longitude``."""
 
     dest_sign, lon, pada, _ = _varga_components(longitude, VARGA_DEFINITIONS["D9"])
     return dest_sign, lon, pada
+
+
+def saptamsa_sign(longitude: float) -> tuple[int, float, int]:
+    """Return the Saptāṁśa sign index, longitude, and part for ``longitude``."""
+
+    dest_sign, lon, part, _ = _varga_components(longitude, VARGA_DEFINITIONS["D7"])
+    return dest_sign, lon, part
 
 
 def dasamsa_sign(longitude: float) -> tuple[int, float, int]:

--- a/astroengine/modules/__init__.py
+++ b/astroengine/modules/__init__.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+from .data_packs import register_data_packs_module
+from .developer_platform import register_developer_platform_module
 from .esoteric import register_esoteric_module
 from .event_detectors import register_event_detectors_module
 from .integrations import register_integrations_module
 from .mundane import register_mundane_module
 from .narrative import register_narrative_module
 from .jyotish import register_jyotish_module
+from .interop import register_interop_module
 from .predictive import register_predictive_module
 from .registry import (
     AstroChannel,
@@ -16,6 +19,7 @@ from .registry import (
     AstroSubchannel,
     AstroSubmodule,
 )
+from .providers import register_providers_module
 from .ritual import register_ritual_module
 from .ux import register_ux_module
 from .vca import register_vca_module
@@ -47,6 +51,10 @@ def bootstrap_default_registry() -> AstroRegistry:
     register_predictive_module(registry)
     register_ux_module(registry)
     register_integrations_module(registry)
+    register_data_packs_module(registry)
+    register_providers_module(registry)
+    register_interop_module(registry)
+    register_developer_platform_module(registry)
     return registry
 
 

--- a/astroengine/modules/data_packs/__init__.py
+++ b/astroengine/modules/data_packs/__init__.py
@@ -1,0 +1,144 @@
+"""Registry wiring for bundled data packs and static profiles.
+
+This module captures the CSV/YAML/JSON datasets that ship with the
+repository and power runtime scoring. Documenting them inside the
+registry keeps provenance attached to each dataset reference so the
+engine never emits values that cannot be traced back to a Solar Fire or
+Swiss Ephemeris export.
+"""
+
+from __future__ import annotations
+
+from ..registry import AstroRegistry
+
+__all__ = ["register_data_packs_module"]
+
+
+DATA_PACKS_DOC = "docs/module/data-packs.md"
+
+
+def register_data_packs_module(registry: AstroRegistry) -> None:
+    """Attach the bundled CSV/YAML/JSON packs to the shared registry."""
+
+    module = registry.register_module(
+        "data_packs",
+        metadata={
+            "description": "Bundled Solar Fire aligned datasets and scoring profiles.",
+            "documentation": DATA_PACKS_DOC,
+            "datasets": [
+                "profiles/base_profile.yaml",
+                "profiles/dignities.csv",
+                "profiles/fixed_stars.csv",
+                "profiles/vca_outline.json",
+                "schemas/orbs_policy.json",
+                "datasets/star_names_iau.csv",
+            ],
+        },
+    )
+
+    profiles = module.register_submodule(
+        "profiles",
+        metadata={
+            "description": "Runtime scoring profiles derived from Solar Fire exports.",
+            "docs": [DATA_PACKS_DOC],
+        },
+    )
+    catalogue = profiles.register_channel(
+        "catalogue",
+        metadata={"description": "Profile documents consumed by detectors and scoring helpers."},
+    )
+    catalogue.register_subchannel(
+        "base_profile",
+        metadata={
+            "description": "Swiss Ephemeris calibrated base profile and feature toggles.",
+            "tests": [
+                "tests/test_vca_profile.py",
+                "tests/test_domain_scoring.py",
+            ],
+        },
+        payload={
+            "path": "profiles/base_profile.yaml",
+            "provenance": "Solar Fire 9 base profile parity checks recorded in docs/governance/data_revision_policy.md",
+        },
+    )
+    catalogue.register_subchannel(
+        "vca_outline",
+        metadata={
+            "description": "Venus Cycle Analytics module outline driving registry bootstrapping.",
+            "tests": ["tests/test_vca_profile.py"],
+        },
+        payload={
+            "path": "profiles/vca_outline.json",
+            "registry_path_key": "modules",
+        },
+    )
+
+    atlases = module.register_submodule(
+        "catalogs",
+        metadata={
+            "description": "CSV datasets that extend natal and transit scoring capabilities.",
+            "docs": [DATA_PACKS_DOC],
+        },
+    )
+    atlases_channel = atlases.register_channel(
+        "csv",
+        metadata={"description": "Static CSV packs bundled for deterministic lookups."},
+    )
+    atlases_channel.register_subchannel(
+        "dignities",
+        metadata={
+            "description": "Essential dignities and modifiers mirrored from Solar Fire tables.",
+            "tests": ["tests/test_domain_scoring.py"],
+        },
+        payload={
+            "path": "profiles/dignities.csv",
+            "provenance": "Solar Fire ESSENTIAL.DAT export cross-referenced with traditional sources.",
+        },
+    )
+    atlases_channel.register_subchannel(
+        "fixed_stars",
+        metadata={
+            "description": "FK6 aligned bright star catalogue consumed by fixed-star overlays.",
+            "tests": [
+                "tests/test_star_names_dataset.py",
+                "tests/test_fixed_stars.py",
+            ],
+        },
+        payload={
+            "path": "profiles/fixed_stars.csv",
+            "provenance": "Solar Fire Bright Stars export with documented checksum column.",
+        },
+    )
+    atlases_channel.register_subchannel(
+        "star_names",
+        metadata={
+            "description": "IAU Working Group star names derived from the HYG database.",
+            "tests": ["tests/test_star_names_dataset.py"],
+        },
+        payload={
+            "path": "datasets/star_names_iau.csv",
+            "provenance": "HYG Database v4.1 filtered to official WGSN designations.",
+        },
+    )
+
+    schemas = module.register_submodule(
+        "schemas",
+        metadata={
+            "description": "JSON datasets that keep client orb policies aligned with runtime defaults.",
+        },
+    )
+    schema_channel = schemas.register_channel(
+        "orbs",
+        metadata={"description": "Aspect orb definitions distributed for interoperability."},
+    )
+    schema_channel.register_subchannel(
+        "policy",
+        metadata={
+            "description": "Aspect families and multipliers for client configuration UIs.",
+            "tests": ["tests/test_orbs_policy.py"],
+        },
+        payload={
+            "path": "schemas/orbs_policy.json",
+            "provenance": "Matches Solar Fire default orb policy with documented profile multipliers.",
+        },
+    )

--- a/astroengine/modules/developer_platform/__init__.py
+++ b/astroengine/modules/developer_platform/__init__.py
@@ -1,0 +1,156 @@
+"""Registry wiring for developer platform artefacts (SDKs, CLI, portal)."""
+
+from __future__ import annotations
+
+from ..registry import AstroRegistry
+
+__all__ = ["register_developer_platform_module"]
+
+DEV_DOC = "docs/module/developer_platform.md"
+
+
+def register_developer_platform_module(registry: AstroRegistry) -> None:
+    """Expose developer platform deliverables and documentation."""
+
+    module = registry.register_module(
+        "developer_platform",
+        metadata={
+            "description": "SDKs, CLI workflows, and portal assets generated from OpenAPI specs.",
+            "documentation": DEV_DOC,
+            "status": "planned",
+        },
+    )
+
+    sdks = module.register_submodule(
+        "sdks",
+        metadata={
+            "description": "Typed SDK plans for interacting with AstroEngine services.",
+            "docs": ["docs/module/developer_platform/sdks.md"],
+        },
+    )
+    sdks.register_channel(
+        "languages",
+        metadata={"description": "Client SDK targets driven by frozen OpenAPI schemas."},
+    ).register_subchannel(
+        "typescript",
+        metadata={
+            "description": "TypeScript SDK generated via docs/module/developer_platform/sdks.md",
+            "status": "planned",
+        },
+        payload={
+            "generator": "docs/module/developer_platform/sdks.md#typescript",
+            "schemas": ["openapi/"],
+        },
+    )
+    sdks.get_channel("languages").register_subchannel(
+        "python",
+        metadata={
+            "description": "Python SDK outline referencing OpenAPI generator workflows.",
+            "status": "planned",
+        },
+        payload={
+            "generator": "docs/module/developer_platform/sdks.md#python",
+            "schemas": ["openapi/"],
+        },
+    )
+
+    cli = module.register_submodule(
+        "cli",
+        metadata={
+            "description": "Command line tooling aligned with runtime modules.",
+            "docs": ["docs/module/developer_platform/cli.md"],
+        },
+    )
+    cli.register_channel(
+        "workflows",
+        metadata={
+            "description": "Planned CLI entrypoints that mirror scan/event/election workflows.",
+        },
+    ).register_subchannel(
+        "transit_scan",
+        metadata={
+            "description": "Placeholder CLI for scan/election orchestration.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/cli.md",
+            "commands": ["astroengine scan", "astroengine returns"],
+        },
+    )
+
+    devportal = module.register_submodule(
+        "devportal",
+        metadata={
+            "description": "Developer portal assets (docs, playground, collection exports).",
+            "docs": ["docs/module/developer_platform/devportal.md"],
+        },
+    )
+    portals = devportal.register_channel(
+        "surfaces",
+        metadata={
+            "description": "Static site and playground deliverables documented under devportal.md.",
+        },
+    )
+    portals.register_subchannel(
+        "docs",
+        metadata={
+            "description": "Documentation site plan (Docusaurus) for the developer portal.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/devportal.md#documentation",
+        },
+    )
+    portals.register_subchannel(
+        "playground",
+        metadata={
+            "description": "API playground referencing frozen OpenAPI schemas.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/devportal.md#playground",
+        },
+    )
+    portals.register_subchannel(
+        "collections",
+        metadata={
+            "description": "Postman/Insomnia collection exports derived from openapi specs.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/devportal.md#collections",
+        },
+    )
+
+    webhooks = module.register_submodule(
+        "webhooks",
+        metadata={
+            "description": "Webhook delivery contracts and verification helpers.",
+            "docs": ["docs/module/developer_platform/webhooks.md"],
+        },
+    )
+    webhooks.register_channel(
+        "contracts",
+        metadata={
+            "description": "Webhook delivery jobs and signature verification flows.",
+        },
+    ).register_subchannel(
+        "jobs",
+        metadata={
+            "description": "Planned webhook job processing pipelines.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/webhooks.md#jobs",
+        },
+    )
+    webhooks.get_channel("contracts").register_subchannel(
+        "verification",
+        metadata={
+            "description": "Signature verification helpers outlined for webhook consumers.",
+            "status": "planned",
+        },
+        payload={
+            "documentation": "docs/module/developer_platform/webhooks.md#verification",
+        },
+    )

--- a/astroengine/modules/interop/__init__.py
+++ b/astroengine/modules/interop/__init__.py
@@ -1,0 +1,103 @@
+"""Registry wiring for schema interoperability artefacts."""
+
+from __future__ import annotations
+
+from ..registry import AstroRegistry
+
+__all__ = ["register_interop_module"]
+
+INTEROP_DOC = "docs/module/interop.md"
+
+
+def register_interop_module(registry: AstroRegistry) -> None:
+    """Expose JSON schema catalogue for export validation."""
+
+    module = registry.register_module(
+        "interop",
+        metadata={
+            "description": "Schema catalogue for export payloads and contact gating.",
+            "documentation": INTEROP_DOC,
+            "datasets": [
+                "schemas/result_schema_v1.json",
+                "schemas/result_schema_v1_with_domains.json",
+                "schemas/contact_gate_schema_v2.json",
+                "schemas/natal_input_v1_ext.json",
+                "schemas/orbs_policy.json",
+            ],
+        },
+    )
+
+    schemas = module.register_submodule(
+        "schemas",
+        metadata={
+            "description": "JSON schemas validated by astroengine.validation helpers.",
+        },
+    )
+    validation_channel = schemas.register_channel(
+        "json_schema",
+        metadata={
+            "description": "Schemas referenced by validate_payload and related helpers.",
+        },
+    )
+    validation_channel.register_subchannel(
+        "result_v1",
+        metadata={
+            "description": "Baseline result schema covering transit runs.",
+            "tests": ["tests/test_result_schema.py"],
+        },
+        payload={
+            "path": "schemas/result_schema_v1.json",
+            "schema_id": "result_v1",
+        },
+    )
+    validation_channel.register_subchannel(
+        "result_v1_with_domains",
+        metadata={
+            "description": "Result schema variant with domain annotations.",
+            "tests": ["tests/test_result_schema.py"],
+        },
+        payload={
+            "path": "schemas/result_schema_v1_with_domains.json",
+            "schema_id": "result_v1_with_domains",
+        },
+    )
+    validation_channel.register_subchannel(
+        "contact_gate_v2",
+        metadata={
+            "description": "Contact gate schema capturing audit trails for UI gating decisions.",
+            "tests": ["tests/test_contact_gate_schema.py"],
+        },
+        payload={
+            "path": "schemas/contact_gate_schema_v2.json",
+            "schema_id": "contact_gate_v2",
+        },
+    )
+    validation_channel.register_subchannel(
+        "natal_input_v1_ext",
+        metadata={
+            "description": "Extended natal input metadata accepted during Solar Fire imports.",
+            "tests": ["tests/test_result_schema.py"],
+        },
+        payload={
+            "path": "schemas/natal_input_v1_ext.json",
+            "schema_id": "natal_input_v1_ext",
+        },
+    )
+
+    data_channel = schemas.register_channel(
+        "json_data",
+        metadata={
+            "description": "Non-schema JSON documents distributed for interoperability.",
+        },
+    )
+    data_channel.register_subchannel(
+        "orbs_policy",
+        metadata={
+            "description": "Aspect orb definitions used by external clients.",
+            "tests": ["tests/test_orbs_policy.py"],
+        },
+        payload={
+            "path": "schemas/orbs_policy.json",
+            "loader": "astroengine.data.schemas.load_schema_document",
+        },
+    )

--- a/astroengine/modules/providers/__init__.py
+++ b/astroengine/modules/providers/__init__.py
@@ -1,0 +1,125 @@
+"""Registry wiring for ephemeris providers and frame preferences."""
+
+from __future__ import annotations
+
+from ..registry import AstroRegistry
+
+__all__ = ["register_providers_module"]
+
+PROVIDERS_DOC = "docs/module/providers_and_frames.md"
+
+
+def register_providers_module(registry: AstroRegistry) -> None:
+    """Expose provider contracts and bundled plugin metadata."""
+
+    module = registry.register_module(
+        "providers",
+        metadata={
+            "description": "Ephemeris provider protocol and bundled plugin configurations.",
+            "documentation": PROVIDERS_DOC,
+            "sources": [
+                "astroengine/providers/__init__.py",
+                "astroengine/providers/skyfield_provider.md",
+                "astroengine/providers/swe_provider.md",
+            ],
+        },
+    )
+
+    ephemeris = module.register_submodule(
+        "ephemeris",
+        metadata={
+            "description": "Provider implementations supplying Swiss Ephemeris and Skyfield data.",
+            "protocol": "astroengine.providers.EphemerisProvider",
+        },
+    )
+    plugins = ephemeris.register_channel(
+        "plugins",
+        metadata={
+            "description": "Built-in provider registry backed by astroengine.providers.",
+            "registry_module": "astroengine.providers",
+        },
+    )
+    plugins.register_subchannel(
+        "swiss_ephemeris",
+        metadata={
+            "description": "Swiss Ephemeris bridge with pyswisseph dependency management.",
+            "tests": [
+                "tests/test_swisseph_adapter.py",
+                "tests/test_swisseph_sidereal.py",
+            ],
+        },
+        payload={
+            "module": "astroengine.providers.swiss_provider",
+            "design_notes": "astroengine/providers/swe_provider.md",
+            "datasets": ["datasets/swisseph_stub"],
+        },
+    )
+    plugins.register_subchannel(
+        "skyfield",
+        metadata={
+            "description": "Skyfield DE ephemeris provider plan (implementation pending).",
+            "status": "planned",
+        },
+        payload={
+            "design_notes": "astroengine/providers/skyfield_provider.md",
+            "datasets": ["astroengine/providers/skyfield_kernels.py"],
+        },
+    )
+
+    cadence = module.register_submodule(
+        "cadence",
+        metadata={
+            "description": "Recommended sampling cadences and cache layout referenced by profiles.",
+        },
+    )
+    cadence_channel = cadence.register_channel(
+        "profiles",
+        metadata={
+            "description": "Cadence values sourced from profiles/base_profile.yaml.",
+        },
+    )
+    cadence_channel.register_subchannel(
+        "default",
+        metadata={
+            "description": "Default provider selection and cadence configuration.",
+            "tests": ["tests/test_vca_profile.py"],
+        },
+        payload={
+            "path": "profiles/base_profile.yaml",
+            "keys": [
+                "providers.default",
+                "providers.skyfield.cache_path",
+                "providers.swe.enabled",
+                "providers.*.cadence_hours",
+            ],
+        },
+    )
+
+    frames = module.register_submodule(
+        "frames",
+        metadata={
+            "description": "House systems and ayanamsha preferences tied to provider outputs.",
+        },
+    )
+    frames.register_channel(
+        "preferences",
+        metadata={
+            "description": "Frame toggles referenced by detectors and narrative overlays.",
+        },
+    ).register_subchannel(
+        "profile_flags",
+        metadata={
+            "description": "Feature flags controlling house system and sidereal settings.",
+            "tests": [
+                "tests/test_result_schema.py",
+                "tests/test_contact_gate_schema.py",
+            ],
+        },
+        payload={
+            "path": "profiles/base_profile.yaml",
+            "keys": [
+                "feature_flags.house_system",
+                "feature_flags.sidereal",
+            ],
+        },
+    )

--- a/astroengine/vca/houses.py
+++ b/astroengine/vca/houses.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+import importlib
+import importlib.util
+import math
+import weakref
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-import math
-import weakref
 from typing import Any, Mapping, Sequence
-
-import yaml
 
 from ..chart.config import ChartConfig
 from ..chart.natal import DEFAULT_BODIES, ChartLocation
@@ -71,6 +71,15 @@ _PROFILE_META: dict[int, dict[str, dict[str, Any]]] = {}
 _PROFILE_META_REFS: dict[int, weakref.ReferenceType[_ProfileDict]] = {}
 
 
+def _load_yaml_module():
+    if importlib.util.find_spec("yaml") is None:
+        raise ModuleNotFoundError(
+            "PyYAML is required to load house profiles. Install the 'pyyaml' extra to "
+            "enable astroengine.vca.houses.",
+        )
+    return importlib.import_module("yaml")
+
+
 def _default_profile_path() -> Path:
     return profiles_dir() / "domains" / "houses.yaml"
 
@@ -89,6 +98,7 @@ def load_house_profile(
     path: str | None = None,
 ) -> tuple[dict[int, DomainW], dict[str, dict[str, Any]]]:
     profile_path = Path(path) if path else _default_profile_path()
+    yaml = _load_yaml_module()
     data = yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
 
     profile: _ProfileDict = _ProfileDict()

--- a/docs/module/data-packs.md
+++ b/docs/module/data-packs.md
@@ -1,6 +1,6 @@
 # Data Packs Specification
 
-- **Module**: `data-packs`
+- **Module**: `data_packs` (docs slug `data-packs`)
 - **Maintainer**: Data Stewardship Team
 - **Source artifacts**:
   - `profiles/dignities.csv`
@@ -10,6 +10,17 @@
   - `profiles/base_profile.yaml`
 
 AstroEngine bundles a small number of static datasets that are consumed by the registry-backed modules. This document enumerates the files, their fields, and the validation coverage inside the repository so the assets remain traceable and no modules lose access to required inputs.
+
+## Registry mapping
+
+The default registry exposes the following paths for this module:
+
+- `data_packs.profiles.catalogue.base_profile`
+- `data_packs.profiles.catalogue.vca_outline`
+- `data_packs.catalogs.csv.{dignities,fixed_stars,star_names}`
+- `data_packs.schemas.orbs.policy`
+
+Each entry points to the datasets listed below with provenance metadata taken directly from the files or accompanying documentation.
 
 ## Dataset inventory
 

--- a/docs/module/developer_platform.md
+++ b/docs/module/developer_platform.md
@@ -6,6 +6,15 @@
 
 The developer platform module guarantees that external integrations are driven by the frozen OpenAPI specifications published under `openapi/` and that all runtime outputs are derived from verified Solar Fire exports, Swiss Ephemeris datasets, or database artefacts versioned in `datasets/`. Each submodule below inherits the following invariants:
 
+## Registry mapping
+
+- `developer_platform.sdks.languages.{typescript,python}`
+- `developer_platform.cli.workflows.transit_scan`
+- `developer_platform.devportal.surfaces.{docs,playground,collections}`
+- `developer_platform.webhooks.contracts.{jobs,verification}`
+
+The registry entries currently mark these surfaces as planned deliverables while anchoring them to the documentation listed in this file.
+
 1. **Source-of-truth alignment** – All generated artefacts originate from the `openapi/v*.json` schema files. Any hand-edit passes must log a provenance note referencing the schema hash and the Solar Fire or Swiss Ephemeris datasets used for validation.
 2. **Hierarchical integrity** – Submodules may extend the hierarchy with new channels/subchannels but must not delete or orphan existing modules. Regression tests confirm that registry entries in `astroengine/modules` still resolve.
 3. **Data fidelity** – SDK and CLI outputs surface only values produced by sanctioned providers (Swiss Ephemeris cache, natal chart datasets in `datasets/solarfire/`, or SQLite bundles shipped under `datasets/sqlite/`). Synthetic ephemerides or placeholder natal data are disallowed.

--- a/docs/module/interop.md
+++ b/docs/module/interop.md
@@ -12,6 +12,16 @@
 
 The AstroEngine validation layer loads JSON schemas and supporting data from `./schemas`. This document describes the current files so downstream exporters know which payloads are supported and how they are tested. The schema keys are registered via `astroengine.data.schemas` and exercised through `astroengine.validation.validate_payload`.
 
+## Registry mapping
+
+- `interop.schemas.json_schema.result_v1`
+- `interop.schemas.json_schema.result_v1_with_domains`
+- `interop.schemas.json_schema.contact_gate_v2`
+- `interop.schemas.json_schema.natal_input_v1_ext`
+- `interop.schemas.json_data.orbs_policy`
+
+These registry nodes ensure every export payload cites an audited schema or data document.
+
 ## Schema catalogue
 
 | Key | File | Purpose | Primary sections |

--- a/docs/module/providers_and_frames.md
+++ b/docs/module/providers_and_frames.md
@@ -10,6 +10,17 @@
 
 AstroEngine resolves ephemeris data through provider plugins that implement the `EphemerisProvider` protocol. The goal of this document is to record the contract expected by the runtime so that future providers remain deterministic, expose provenance, and keep the module/submodule/channel hierarchy intact.
 
+## Registry mapping
+
+The default registry exports the following provider paths:
+
+- `providers.ephemeris.plugins.swiss_ephemeris`
+- `providers.ephemeris.plugins.skyfield`
+- `providers.cadence.profiles.default`
+- `providers.frames.preferences.profile_flags`
+
+These nodes reference the files and documentation described below so the runtime always resolves provider metadata from audited sources.
+
 ## Provider protocol summary
 
 `astroengine/providers/__init__.py` defines the following structures:

--- a/docs/module/qa_acceptance.md
+++ b/docs/module/qa_acceptance.md
@@ -21,7 +21,7 @@ This plan captures the checks that must pass before shipping changes to the runt
 
 | Test file | Focus | Notes |
 | --- | --- | --- |
-| `tests/test_module_registry.py` | Ensures the default registry registers the `vca` module, its submodules, and channels. | Protects the module → submodule → channel hierarchy. |
+| `tests/test_module_registry.py` | Ensures the default registry registers key modules (`vca`, `integrations`) and their submodules/channels. | Protects the module → submodule → channel hierarchy. |
 | `tests/test_vca_ruleset.py` | Verifies aspect angles and orb lookups exposed through `astroengine.rulesets`. | Guards the values documented in `docs/module/core-transit-math.md`. |
 | `tests/test_vca_profile.py` | Loads JSON/YAML profiles and confirms active aspect angles match expectations. | Exercises `profiles/base_profile.yaml` and `profiles/vca_outline.json`. |
 | `tests/test_domain_scoring.py` | Checks domain weighting methods (`weighted`, `top`, `softmax`). | Ensures severity scaling remains deterministic. |

--- a/docs/module/release_ops.md
+++ b/docs/module/release_ops.md
@@ -21,13 +21,24 @@ The core package depends on `pyswisseph`, `numpy`, `pydantic>=2`, `python-dateut
 
 ## Registry compatibility snapshot
 
-The default registry currently exposes a single module:
+The default registry currently exposes the following modules:
 
-| Module | Submodules | Channels | Source |
-| --- | --- | --- | --- |
-| `vca` | `catalogs`, `profiles`, `rulesets` | `catalogs.bodies.{core,extended,centaurs,tnos,sensitive_points}`, `profiles.domain.{vca_neutral,vca_mind_plus,vca_body_plus,vca_spirit_plus}`, `rulesets.aspects.definitions` | `astroengine/modules/vca/__init__.py` |
+- `vca`: Venus Cycle Analytics datasets (`catalogs`, `profiles`, `uncertainty`, `rulesets`).
+- `event_detectors`: Stations, ingresses, lunations, declination, and overlay detectors backed by Swiss Ephemeris rulesets.
+- `esoterica`: Decans, tarot, numerology, and oracular correspondences tied to documented sources.
+- `mundane`: Solar ingress chart generation with aspect overlays.
+- `jyotish`: Parasara dignities, karakas, and graha yuddha reference tables.
+- `narrative`: Bundled narrative summaries, profile templates, and time-lord overlays.
+- `ritual`: Planetary day/hour tables, void-of-course filters, and electional guidelines.
+- `predictive`: Progressions, directions, returns, midpoint overlays, and vedic gochara scaffolding.
+- `ux`: Placeholder channels for maps, timelines, and plugin surfaces.
+- `integrations`: External tool catalogues (Swiss Ephemeris, Skyfield, Flatlib, Maitreya, JHora, Panchanga projects).
+- `data_packs`: CSV/YAML/JSON datasets such as `profiles/base_profile.yaml`, `profiles/dignities.csv`, and `schemas/orbs_policy.json`.
+- `providers`: Ephemeris provider registry metadata and cadence/frame preferences.
+- `interop`: Export schemas (`schemas/result_schema_v1.json`, `schemas/contact_gate_schema_v2.json`, etc.).
+- `developer_platform`: Planned SDKs, CLI workflows, portal surfaces, and webhook contracts.
 
-When new modules are registered, update this table and the documentation in `docs/module/event-detectors/overview.md` to preserve the module → submodule → channel → subchannel hierarchy.
+New modules must extend this list and keep their documentation in `docs/module/` aligned with the registry to preserve the module → submodule → channel → subchannel hierarchy.
 
 ## Release checklist
 


### PR DESCRIPTION
## Summary
- add guarded timezone lookup and PyYAML loading so optional datasets fail with clear guidance when extras are missing
- lazily load Swiss Ephemeris across adapters and natal chart defaults so registry bootstrap no longer crashes without swisseph installed
- expose the missing Vedic helpers and varga wrappers to keep engine imports aligned with the published API surface

## Testing
- pytest tests/test_module_registry.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcb23c58483248db7c6eee8dba74e