### PR TITLE
Add test dependency bootstrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,8 @@ lint-code:
 	isort --check-only --profile=black .
 
 test:
-	pytest -q
+        python scripts/install_test_dependencies.py --quiet
+        pytest -q
 
 doctor:
 	python -m astroengine.diagnostics || true

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ developer activities.  Run `make` (or `make help`) to view the curated targets.
 - `make format` — apply Ruff autofixes alongside Black and isort formatting.
 - `make lint` — check code style without mutating the working tree.
 - `make typecheck` — execute `mypy` on the typed package surfaces.
-- `make test` — run the full `pytest` suite, including CLI and ephemeris tests.
+- `make test` — ensure the test dependency stack is installed and then run the
+  full `pytest` suite, including CLI and ephemeris tests.
 - `make check` — convenience target that executes linting, type checking,
   and tests in sequence to validate merge readiness.
 

--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -47,3 +47,13 @@ pip install -e . --upgrade
 
 If you prefer a clean install, remove the ``.venv`` directory and repeat
 steps 1–3.
+
+## 5) Running the test suite
+
+Before invoking ``pytest``, execute::
+
+    python scripts/install_test_dependencies.py --quiet
+
+The helper validates that FastAPI, pandas, Jinja2, PyYAML, and the Swiss
+Ephemeris bindings are present (installing them when necessary) so the test
+suite no longer aborts during collection.

--- a/scripts/dependency_utils.py
+++ b/scripts/dependency_utils.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import subprocess
+import sys
+from pathlib import Path
+from typing import Iterable, Tuple
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def version_tuple(raw: str) -> Tuple[int, ...]:
+    """Return a comparable tuple extracted from a version string."""
+
+    parts: list[int] = []
+    for segment in raw.split('.'):
+        digits = ''.join(ch for ch in segment if ch.isdigit())
+        if digits:
+            parts.append(int(digits))
+        else:
+            break
+    return tuple(parts)
+
+
+def needs_install(dist_name: str, minimum: Tuple[int, ...]) -> bool:
+    """Determine whether the distribution is missing or below the minimum version."""
+
+    try:
+        current = importlib.metadata.version(dist_name)
+    except importlib.metadata.PackageNotFoundError:
+        return True
+    return version_tuple(current) < minimum
+
+
+def ensure(
+    spec: str,
+    *,
+    pip_args: Iterable[str] = (),
+    import_name: str | None = None,
+    minimum: Tuple[int, ...] | None = None,
+    install: bool = True,
+    quiet: bool = False,
+) -> bool:
+    """Ensure the requested dependency is importable.
+
+    Parameters
+    ----------
+    spec:
+        The pip requirement specifier used for installation (e.g. ``"fastapi>=0.117,<0.118"``).
+    pip_args:
+        Additional command-line arguments to forward to ``pip install``.
+    import_name:
+        Optional module name to import after installation.  Defaults to the
+        distribution name inferred from ``spec``.
+    minimum:
+        Minimum acceptable version for the dependency.  ``(0,)`` by default.
+    install:
+        When ``True`` (the default), missing or out-of-date dependencies are
+        installed automatically.  When ``False``, a ``ModuleNotFoundError`` is
+        raised if the dependency is unavailable.
+    quiet:
+        When ``True``, suppress ``pip`` output during installation.
+
+    Returns
+    -------
+    bool
+        ``True`` if an installation occurred, ``False`` otherwise.
+    """
+
+    dist_segment = spec.split(';', 1)[0]
+    for delimiter in ('==', '>=', '<=', '~=', '!='):
+        dist_segment = dist_segment.split(delimiter)[0]
+    dist_name = dist_segment.strip()
+    target_import = (import_name or dist_name).strip()
+    if minimum is None:
+        minimum = version_tuple('0')
+
+    if needs_install(dist_name, minimum):
+        if not install:
+            raise ModuleNotFoundError(
+                f"Dependency '{dist_name}' is missing or below the required version"
+            )
+        cmd = [sys.executable, '-m', 'pip', 'install', spec, *pip_args]
+        kwargs = {}
+        if quiet:
+            kwargs['stdout'] = subprocess.DEVNULL
+            kwargs['stderr'] = subprocess.DEVNULL
+        subprocess.check_call(cmd, **kwargs)
+        installed = True
+    else:
+        installed = False
+
+    importlib.import_module(target_import)
+    return installed
+
+
+def install_requirements(path: Path, *, quiet: bool = False) -> bool:
+    """Install a requirements file if it exists."""
+
+    if not path.exists():
+        return False
+    cmd = [sys.executable, '-m', 'pip', 'install', '-r', str(path)]
+    kwargs = {}
+    if quiet:
+        kwargs['stdout'] = subprocess.DEVNULL
+        kwargs['stderr'] = subprocess.DEVNULL
+    subprocess.check_call(cmd, **kwargs)
+    return True

--- a/scripts/install_optional_dependencies.py
+++ b/scripts/install_optional_dependencies.py
@@ -4,64 +4,30 @@
 from __future__ import annotations
 
 import argparse
-import importlib
-import importlib.metadata
 import subprocess
 import sys
 from pathlib import Path
-from typing import Iterable, Tuple
 
-PROJECT_ROOT = Path(__file__).resolve().parents[1]
+from dependency_utils import ensure, install_requirements, PROJECT_ROOT
+
 REQUIREMENTS_OPTIONAL = PROJECT_ROOT / "requirements-optional.txt"
-
-
-def _version_tuple(raw: str) -> Tuple[int, ...]:
-    parts: list[int] = []
-    for segment in raw.split('.'):
-        digits = ''.join(ch for ch in segment if ch.isdigit())
-        if digits:
-            parts.append(int(digits))
-        else:
-            break
-    return tuple(parts)
-
-
-def _needs_install(dist_name: str, minimum: Tuple[int, ...]) -> bool:
-    try:
-        current = importlib.metadata.version(dist_name)
-    except importlib.metadata.PackageNotFoundError:
-        return True
-    return _version_tuple(current) < minimum
-
-
-def _ensure(
-    spec: str,
-    *,
-    pip_args: Iterable[str] = (),
-    import_name: str | None = None,
-    minimum: Tuple[int, ...] | None = None,
-) -> None:
-    target_dist = (import_name or spec.split('==')[0].split('>=')[0]).strip()
-    if minimum is None:
-        minimum = _version_tuple('0')
-    if _needs_install(target_dist, minimum):
-        cmd = [sys.executable, '-m', 'pip', 'install', spec, *pip_args]
-        subprocess.check_call(cmd)
-    importlib.import_module(import_name or target_dist)
 
 
 def install_optional_dependencies() -> None:
     """Install optional stacks and validate that critical imports succeed."""
 
     # Ensure pyswisseph is present before handling flatlib.
-    _ensure('pyswisseph==2.10.3.2', import_name='swisseph', minimum=(2, 10, 3, 2))
+    ensure('pyswisseph==2.10.3.2', import_name='swisseph', minimum=(2, 10, 3, 2))
     # Install flatlib without its upstream dependency pin so pyswisseph 2.10.x stays active.
-    _ensure('flatlib==0.2.3', pip_args=('--no-deps',), import_name='flatlib', minimum=(0, 2, 3))
+    ensure(
+        'flatlib==0.2.3',
+        pip_args=('--no-deps',),
+        import_name='flatlib',
+        minimum=(0, 2, 3),
+    )
 
     if REQUIREMENTS_OPTIONAL.exists():
-        subprocess.check_call(
-            [sys.executable, '-m', 'pip', 'install', '-r', str(REQUIREMENTS_OPTIONAL)]
-        )
+        install_requirements(REQUIREMENTS_OPTIONAL)
 
     # Validate a subset of optional libraries commonly exercised in tests.
     for spec, import_name, minimum in (
@@ -71,7 +37,7 @@ def install_optional_dependencies() -> None:
         ('skyfield>=1.49', 'skyfield', (1, 49)),
         ('jplephem>=2.21', 'jplephem', (2, 21)),
     ):
-        _ensure(spec, import_name=import_name, minimum=minimum)
+        ensure(spec, import_name=import_name, minimum=minimum)
 
 
 def main() -> None:

--- a/scripts/install_test_dependencies.py
+++ b/scripts/install_test_dependencies.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import Tuple
+
+from dependency_utils import ensure
+
+TEST_DEPENDENCIES: list[tuple[str, str, Tuple[int, ...]]] = [
+    ("pyswisseph>=2.10.3.2", "swisseph", (2, 10, 3, 2)),
+    ("pymeeus>=0.5.12", "pymeeus", (0, 5, 12)),
+    ("PyYAML>=6.0", "yaml", (6, 0, 0)),
+    ("pydantic>=2.11", "pydantic", (2, 11)),
+    ("fastapi>=0.117,<0.118", "fastapi", (0, 117)),
+    ("httpx>=0.28,<0.29", "httpx", (0, 28)),
+    ("pandas>=2.2", "pandas", (2, 2)),
+    ("alembic>=1.13", "alembic", (1, 13)),
+    ("jinja2>=3.1", "jinja2", (3, 1)),
+    ("markdown-it-py>=4.0", "markdown_it", (4, 0)),
+    ("mdit-py-plugins>=0.5", "mdit_py_plugins", (0, 5)),
+]
+
+
+def _upgrade_pip(quiet: bool) -> None:
+    cmd: list[str] = [sys.executable, "-m", "pip", "install", "--upgrade", "pip"]
+    kwargs = {}
+    if quiet:
+        kwargs["stdout"] = subprocess.DEVNULL
+        kwargs["stderr"] = subprocess.DEVNULL
+    subprocess.check_call(cmd, **kwargs)
+
+
+def install_test_dependencies(*, install: bool = True, quiet: bool = False) -> None:
+    """Ensure the core test dependency set is importable."""
+
+    missing: list[str] = []
+    for spec, import_name, minimum in TEST_DEPENDENCIES:
+        try:
+            ensure(
+                spec,
+                import_name=import_name,
+                minimum=minimum,
+                install=install,
+                quiet=quiet,
+            )
+        except ModuleNotFoundError:
+            missing.append(f"{import_name} ({spec})")
+    if missing:
+        formatted = "\n  - ".join([""] + missing)
+        raise RuntimeError(
+            "Missing required runtime dependencies before tests can execute:"
+            f"{formatted}\nRe-run without --check-only to install them automatically."
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--upgrade-pip",
+        action="store_true",
+        help="Upgrade pip before verifying dependencies.",
+    )
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help="Only verify that dependencies are present without installing them.",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress pip output when packages are already satisfied.",
+    )
+    args = parser.parse_args()
+
+    if args.upgrade_pip:
+        _upgrade_pip(args.quiet)
+
+    try:
+        install_test_dependencies(install=not args.check_only, quiet=args.quiet)
+    except RuntimeError as exc:
+        parser.exit(status=1, message=f"{exc}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a shared dependency utility helper and reuse it from the optional installer
- introduce a dedicated script for ensuring test dependencies and run it from `make test`
- document the new bootstrap workflow in the README and environment setup guide

## Testing
- python scripts/install_test_dependencies.py --check-only --quiet
- pytest tests/test_report_relationship_export.py

------
https://chatgpt.com/codex/tasks/task_e_68ddd77aa5cc8324b70fda0c16e541c2