### PR TITLE
Document v1 release verification log

### DIFF
--- a/docs/governance/v1_readiness.md
+++ b/docs/governance/v1_readiness.md
@@ -14,6 +14,14 @@ AstroEngine has satisfied every specification acceptance checkpoint, and the fin
 - UX overlays now document atlas and timezone inputs in `docs/module/ux/overlays_data_sources.md`, closing the final documentation dependency prior to enabling runtime overlays.
 - QA validation, including environment capture, pytest execution, and cross-engine comparisons, is documented in the archived artefacts at `qa/artifacts/`.
 
+## Verification log
+
+| Checkpoint | Evidence | Status | Notes |
+| ---------- | -------- | ------ | ----- |
+| Specification deliverables match the v1 completion plan | `SPEC_COMPLETION_PLAN.md` | ✅ Complete | All modules, channels, and subchannels retain documented requirements without removals, covering transit math through release operations.
+| Burndown tracker reflects closure of tasks I-1 through I-14 | `docs/burndown.md` | ✅ Complete | Final entries confirm Solar Fire provenance and UX overlay evidence, leaving no outstanding actions before release.
+| Governance acceptance checklist remains signed off | `docs/governance/acceptance_checklist.md` | ✅ Complete | Checklists capture data integrity, documentation coverage, and QA provenance aligned with the v1 launch gate.
+
 ## Outstanding actions before v1
 
 None. All burndown items are closed, evidence is archived, and the acceptance checklist has been refreshed with the latest sign-off date.


### PR DESCRIPTION
## Summary
- add a verification log to the v1 readiness assessment that captures evidence for key specification checkpoints
- reference the completion plan, burndown tracker, and acceptance checklist to show v1 release readiness remains satisfied

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ddf1595ed4832484ca4b18095271b4