### PR TITLE
Bump package version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "astroengine"
-version = "0.1.0"
+version = "1.0.0"
 description = "AstroEngine — modular transit engine and astrology toolkit"
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- update the core package metadata to publish AstroEngine as version 1.0.0 ahead of the v1 release tag

## Testing
- pytest tests/test_time_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68ddf2a11a90832494f1cdb5a234b54e