### PR TITLE
Fix test target indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,8 @@ lint-code:
 	isort --check-only --profile=black .
 
 test:
-        python scripts/install_test_dependencies.py --quiet
-        pytest -q
+	python scripts/install_test_dependencies.py --quiet
+	pytest -q
 
 doctor:
 	python -m astroengine.diagnostics || true


### PR DESCRIPTION
## Summary
- replace space indentation in the Makefile test target with tabs so GNU Make can run it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68debd5b76408324be2427a93f2347ad