### PR TITLE
Document pytest root requirement for generated shim

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ developer activities.  Run `make` (or `make help`) to view the curated targets.
 - `make typecheck` — execute `mypy` on the typed package surfaces.
 - `make test` — ensure the test dependency stack is installed and then run the
   full `pytest` suite, including CLI and ephemeris tests.
+  - When invoking `pytest` manually, run it from the repository root so the
+    `pytest.ini` entry `pythonpath = generated` stays in effect.  This keeps the
+    deprecated compatibility package `generated.astroengine` visible to tests
+    and local scripts that still import from that namespace.
 - `make check` — convenience target that executes linting, type checking,
   and tests in sequence to validate merge readiness.
 


### PR DESCRIPTION
## Summary
- clarify in the development workflow section of the README that pytest should be run from the repository root
- explain that this preserves the pytest.ini pythonpath override so generated.astroengine remains importable

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68debd7cbc10832494f5031687353a56