### PR TITLE
Run diagnostics during setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ setup:
 python -m pip install --upgrade pip
 @if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 @if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+python -m astroengine.diagnostics --strict || true
 
 install-optional:
 python scripts/install_optional_dependencies.py


### PR DESCRIPTION
## Summary
- run the strict astroengine diagnostics step at the end of `make setup` so environment gaps are reported immediately

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68debd84392c83249facf95400c1da0c