### PR TITLE
Add README hint for Swiss ephemeris environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ can be indexed safely without losing any modules during future edits.
 make setup    # or follow docs/DEV_ENV.md
 make doctor   # environment sanity (strict)
 make test     # run unit tests
+export SE_EPHE_PATH=/path/to/se/data   # optional for precision; falls back if missing
 ```
 
 ### One-command usability check


### PR DESCRIPTION
## Summary
- document the optional SE_EPHE_PATH export in the README quick start section to avoid Swiss precision warnings

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68debd8d46f4832481d7422913291fae