### PR TITLE
Guard pyswisseph for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
 [project.optional-dependencies]
 # Core astroengine stacks
 ephem = [
-  "pyswisseph>=2.10",
+  "pyswisseph>=2.10; python_version < \"3.12\"",
   "pymeeus>=0.5.12",
 ]
 skyfield = [
@@ -104,7 +104,7 @@ api = [
   "httpx>=0.27",
 ]
 providers = [
-  "pyswisseph>=2.10",
+  "pyswisseph>=2.10; python_version < \"3.12\"",
   "timezonefinder>=6",
   "tzdata",
 ]
@@ -117,7 +117,7 @@ dev = [
 ]
 
 all = [
-  "pyswisseph>=2.10",
+  "pyswisseph>=2.10; python_version < \"3.12\"",
   "pymeeus>=0.5.12",
   "skyfield>=1.49",
   "jplephem>=2.21",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 typing_extensions>=4.9.0  # ENSURE-LINE
 pip-tools>=7.4.0  # ENSURE-LINE
 pipdeptree>=2.20.0  # ENSURE-LINE
-pyswisseph==2.10.3.2  # ENSURE-LINE
+pyswisseph==2.10.3.2; python_version < "3.12"  # ENSURE-LINE
 
 jinja2>=3.1
 fastapi>=0.117

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,7 +1,7 @@
 # >>> AUTO-GEN BEGIN: optional-reqs v1.0
 # Mirrors pyproject extras for non-pep517 workflows
 # ephem
-pyswisseph>=2.10
+pyswisseph>=2.10; python_version < "3.12"
 pymeeus>=0.5.12
 # skyfield
 skyfield>=1.48


### PR DESCRIPTION
## Summary
- add a Python <3.12 environment marker to every pyswisseph optional dependency entry
- mirror the same guard in development and optional requirements files

## Testing
- pytest tests/test_swe_import.py -q

------
https://chatgpt.com/codex/tasks/task_e_68debd6b09648324af173fd4db963caa