### PR TITLE
Align dependency versions across manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,10 @@ classifiers = [
 
 # Core runtime deps kept lean. Everything else under extras.
 dependencies = [
-  "numpy>=1.24",
-  "pandas>=2.0",
+  "numpy>=1.26",
+  "pandas>=2.2",
   "python-dateutil>=2.8",
-  "pydantic>=2.11",
-  "jsonschema>=4.20",
+  "pydantic>=2.11,<3",
   "PyYAML>=6.0",
   "jsonschema>=4.21",
   "requests>=2.31",
@@ -33,13 +32,12 @@ dependencies = [
   "alembic>=1.13",
   "ics>=0.7",
   "duckdb>=0.10",
-  "timezonefinder>=6.2",
-  "tzdata>=2023.3",
+  "timezonefinder>=8.1",
+  "tzdata>=2024.1",
   "pluggy>=1.5",
   "skyfield>=1.49",
   "jplephem>=2.21",
   "fastapi>=0.117,<0.118",
-  "pydantic>=2.9,<3",
   "httpx>=0.28,<0.29",
   "orjson>=3.10",
   "redis>=5.0",
@@ -62,7 +60,7 @@ catalogs = [
   "astroquery>=0.4",
 ]
 exporters = [
-  "pyarrow>=15",
+  "pyarrow>=16",
   "ics>=0.7",
 ]
 narrative = [
@@ -99,14 +97,14 @@ ui = [
 api = [
   "fastapi>=0.117,<0.118",
   "uvicorn>=0.37,<0.38",
-  "pydantic>=2.9,<3",
+  "pydantic>=2.11,<3",
   "icalendar>=6",
-  "httpx>=0.27",
+  "httpx>=0.28,<0.29",
 ]
 providers = [
   "pyswisseph>=2.10",
-  "timezonefinder>=6",
-  "tzdata",
+  "timezonefinder>=8.1",
+  "tzdata>=2024.1",
 ]
 dev = [
   "pytest",
@@ -122,7 +120,7 @@ all = [
   "skyfield>=1.49",
   "jplephem>=2.21",
   "astroquery>=0.4",
-  "pyarrow>=15",
+  "pyarrow>=16",
   "ics>=0.7",
   "jinja2>=3.1",
   "numba>=0.58",
@@ -133,11 +131,11 @@ all = [
   "plotly>=5.20",
   "fastapi>=0.117,<0.118",
   "uvicorn>=0.37,<0.38",
-  "pydantic>=2.9,<3",
+  "pydantic>=2.11,<3",
   "icalendar>=6",
-  "httpx>=0.27",
-  "timezonefinder>=6",
-  "tzdata",
+  "httpx>=0.28,<0.29",
+  "timezonefinder>=8.1",
+  "tzdata>=2024.1",
   "pypdf>=4.2",
   "weasyprint>=62",
   "python-docx>=1.1",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,11 +4,11 @@ pipdeptree>=2.20.0  # ENSURE-LINE
 pyswisseph==2.10.3.2  # ENSURE-LINE
 
 jinja2>=3.1
-fastapi>=0.117
-pydantic>=2.11
-httpx>=0.28
+fastapi>=0.117,<0.118
+pydantic>=2.11,<3
+httpx>=0.28,<0.29
 
-streamlit>=1.39
+streamlit>=1.35
 
 # Core API/runtime dependencies required by tests
 orjson>=3.10

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -4,14 +4,14 @@
 pyswisseph>=2.10
 pymeeus>=0.5.12
 # skyfield
-skyfield>=1.48
+skyfield>=1.49
 jplephem>=2.21
 # catalogs
 astroquery>=0.4
 
 # exporters
 
-pyarrow>=15
+pyarrow>=16
 ics>=0.7
 # document generators
 pypdf>=4.2
@@ -32,14 +32,14 @@ pluggy>=1.5
 streamlit>=1.35
 plotly>=5.20
 # api
-fastapi>=0.117
+fastapi>=0.117,<0.118
 uvicorn>=0.37
-pydantic>=2.11
+pydantic>=2.11,<3
 icalendar>=6
-httpx>=0.27
+httpx>=0.28,<0.29
 # providers
-timezonefinder>=6
-tzdata
+timezonefinder>=8.1
+tzdata>=2024.1
 # shared helper
 requests>=2.31
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,12 @@ pyswisseph>=2.10.3.2
 pymeeus>=0.5.12
 numpy>=1.26
 pandas>=2.2
-pyarrow>=16.0
+pyarrow>=16
 duckdb>=0.10
 SQLAlchemy>=2.0
 alembic>=1.13
 python-dateutil>=2.9
-pydantic>=2.11
+pydantic>=2.11,<3
 timezonefinder>=8.1
 tzdata>=2024.1
 PyYAML>=6.0
@@ -17,7 +17,6 @@ requests>=2.31
 python-multipart>=0.0.9
 pluggy>=1.5
 fastapi>=0.117,<0.118
-pydantic>=2.9,<3
 httpx>=0.28,<0.29
 orjson>=3.10
 redis>=5.0
@@ -41,13 +40,13 @@ streamlit>=1.35
 hypothesis>=6.112
 pytest-benchmark>=4.0
 # Optional groups (comment in as needed):
-fastapi>=0.117
+fastapi>=0.117,<0.118
 # API server runtime
 uvicorn>=0.37
 icalendar>=6
 
 # Required for FastAPI TestClient
-httpx>=0.27
+httpx>=0.28,<0.29
 
 # uvicorn[standard]>=0.30
 # matplotlib>=3.8


### PR DESCRIPTION
## Summary
- align the pinned dependency floors in `pyproject.toml` with the preferred versions for numpy, pandas, fastapi/httpx, pydantic, jsonschema, timezonefinder, tzdata, and pyarrow
- sync optional extras and requirements text files to the same version ranges so downstream installs resolve consistently

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68debd626544832496a4284e45616d5a