### PR TITLE
Align CI Python matrix with supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,25 +32,16 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: "3.10"
-            coverage: false
-          - os: ubuntu-latest
             python-version: "3.11"
             coverage: true
           - os: ubuntu-latest
             python-version: "3.12"
             coverage: false
           - os: macos-latest
-            python-version: "3.10"
-            coverage: false
-          - os: macos-latest
             python-version: "3.11"
             coverage: false
           - os: macos-latest
             python-version: "3.12"
-            coverage: false
-          - os: windows-latest
-            python-version: "3.10"
             coverage: false
           - os: windows-latest
             python-version: "3.11"


### PR DESCRIPTION
## Summary
- drop Python 3.10 from the GitHub Actions matrix so CI matches the project's Python requirement

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68decc4493f08324a1cdb2a5f7c482ec