### PR TITLE
Pin CI actions and build artifacts in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.11"
           cache: pip
@@ -60,14 +60,14 @@ jobs:
             coverage: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
       - name: Cache Swiss ephemeris
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.astroengine/ephemeris
           key: ${{ runner.os }}-se-${{ hashFiles('datasets/swisseph_stub/**') }}
@@ -82,6 +82,10 @@ jobs:
           python -m pip install --upgrade pip
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
           if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+      - name: Build sdist/wheel
+        run: |
+          pip install build
+          python -m build
       - name: Doctor (strict)
         run: |
           python -m astroengine.diagnostics --json > diagnostics.json || true
@@ -105,13 +109,13 @@ jobs:
           git diff --exit-code docs/badges/coverage.svg
       - name: Upload diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: diagnostics-${{ matrix.python-version }}
           path: diagnostics.json
       - name: Upload coverage artifacts
         if: ${{ matrix.coverage == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: coverage-${{ matrix.python-version }}-${{ matrix.os }}
           path: |


### PR DESCRIPTION
## Summary
- pin the CI workflow's reusable GitHub Actions to specific commit SHAs
- add a packaging build step to the test job to exercise sdist/wheel creation

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68decc91e6c48324b02f1a9ee1d15e23