### PR TITLE
Add base Dockerfile for AstroEngine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -U pip \
+    && pip install -e . \
+    && pip install uvicorn
+
+EXPOSE 8000
+ENV DATABASE_URL=sqlite:///./dev.db
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- add a Dockerfile that installs the project in editable mode inside a python 3.11 slim container
- configure the image to expose port 8000 and launch the FastAPI app with uvicorn

## Testing
- not run (container definition only)


------
https://chatgpt.com/codex/tasks/task_e_68deccaa6bac8324ba587a3ed9782029