### PR TITLE
docs: add api and streamlit two-command quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ python -m astroengine.maint --full --strict --auto-install all --yes
 ```
 
 See `docs/DIAGNOSTICS.md`, `docs/SWISS_EPHEMERIS.md`, and `docs/QUALITY_GATE.md` for details.
+
+### Run API + Streamlit in 2 commands
+
+```bash
+export DATABASE_URL="sqlite+pysqlite:///${PWD}/dev.db" SE_EPHE_PATH="$HOME/.sweph/ephe"
+(uvicorn app.relationship_api:create_app --factory --host 0.0.0.0 --port 8000 & streamlit run ui/streamlit/pages/05_Synastry_Composite.py)
+```
+
+The first command pins the SQLite dev database (`dev.db` in the repo root) and
+points Swiss Ephemeris to your local data so neither service falls back to the
+reduced-precision providers. The subshell then launches the FastAPI service and
+Streamlit playground together so the UI can call the freshly started API.
 # >>> AUTO-GEN END: README Quick Start v1.1
 
 ### First transit sanity check


### PR DESCRIPTION
## Summary
- add a README quick start block demonstrating how to launch the API and Streamlit together
- document the dev SQLite path and required SE_EPHE_PATH export to avoid downgraded ephemeris warnings

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68deccb1a3008324a79db1215e257081