### PR TITLE
Generate requirements from pyproject metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,19 @@ These helpers ensure the module → submodule → channel → subchannel hierarc
 remains intact, particularly when integrating new Solar Fire derived datasets or
 augmenting the runtime with additional registries.
 
+### Updating dependency manifests
+
+`requirements.txt`, `requirements-dev.txt`, and `requirements-optional.txt`
+are generated from `pyproject.toml` so the dependency graph only has one
+source of truth. Regenerate them with:
+
+```bash
+python scripts/generate_requirements.py
+```
+
+Pass `--check` to verify whether the tracked files already match the
+`pyproject` declarations.
+
 # >>> AUTO-GEN BEGIN: AE README Providers Addendum v1.2
 ### Optional providers & catalogs
 Use the helper script to install the complete optional stack, including the

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,21 +3,15 @@ pip-tools>=7.4.0  # ENSURE-LINE
 pipdeptree>=2.20.0  # ENSURE-LINE
 pyswisseph==2.10.3.2; python_version < "3.12"  # ENSURE-LINE
 
-jinja2>=3.1
-fastapi>=0.117,<0.118
-pydantic>=2.11,<3
-httpx>=0.28,<0.29
+-r requirements.txt
 
-streamlit>=1.35
-
-# Core API/runtime dependencies required by tests
-orjson>=3.10
-pypdf>=4.2
-prometheus-client>=0.20
-
-
+# pyproject.toml [project.optional-dependencies.dev]
 pytest>=8.0.0  # ENSURE-LINE
-pytest-cov>=4.1.0  # ENSURE-LINE
 hypothesis>=6.92.0  # ENSURE-LINE
+ruff>=0.6.5
+mypy>=1.10
 pytest-benchmark>=4.0  # ENSURE-LINE
+
+pytest-cov>=4.1.0  # ENSURE-LINE
+
 genbadge[coverage]>=1.1.1  # ENSURE-LINE

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -1,46 +1,58 @@
 # >>> AUTO-GEN BEGIN: optional-reqs v1.0
+# Generated via scripts/generate_requirements.py; do not edit by hand.
 # Mirrors pyproject extras for non-pep517 workflows
-# ephem
+
+# [ephem]
 pyswisseph>=2.10; python_version < "3.12"
 pymeeus>=0.5.12
-# skyfield
+
+# [skyfield]
 skyfield>=1.49
 jplephem>=2.21
-# catalogs
+
+# [catalogs]
 astroquery>=0.4
 
-# exporters
-
+# [exporters]
 pyarrow>=16
 ics>=0.7
-# document generators
+
+# [narrative]
+jinja2>=3.1
+
+# [perf]
+numba>=0.58
+
+# [cli]
+click>=8.1
+rich>=13.7
+pluggy>=1.5
+
+# [reports]
 pypdf>=4.2
 weasyprint>=62
 python-docx>=1.1
 playwright>=1.45
 pypandoc>=1.12
-# narrative
-jinja2>=3.1
-# perf
-numba>=0.58
-# cli
-click>=8.1
-rich>=13.7
 
-pluggy>=1.5
-# streamlit
+# [streamlit]
 streamlit>=1.35
 plotly>=5.20
-# api
+
+# [ui]
+streamlit>=1.35
+plotly>=5.20
+
+# [api]
 fastapi>=0.117,<0.118
-uvicorn>=0.37
+uvicorn>=0.37,<0.38
 pydantic>=2.11,<3
 icalendar>=6
 httpx>=0.28,<0.29
-# providers
+
+# [providers]
+pyswisseph>=2.10
 timezonefinder>=8.1
 tzdata>=2024.1
-# shared helper
-requests>=2.31
 
 # >>> AUTO-GEN END: optional-reqs v1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,69 +1,28 @@
 # >>> AUTO-GEN BEGIN: AstroEngine Requirements v1.0
-pyswisseph>=2.10.3.2
-pymeeus>=0.5.12
-numpy>=1.26
-pandas>=2.2
-pyarrow>=16
-duckdb>=0.10
-SQLAlchemy>=2.0
+# Generated via scripts/generate_requirements.py; do not edit by hand.
 alembic>=1.13
-python-dateutil>=2.9
+cachetools>=5.3
+duckdb>=0.10
+fastapi>=0.117,<0.118
+httpx>=0.28,<0.29
+ics>=0.7
+jplephem>=2.21
+jsonschema>=4.21
+numpy>=1.26
+orjson>=3.10
+pandas>=2.2
+pluggy>=1.5
+prometheus-client>=0.20
 pydantic>=2.11,<3
+python-dateutil>=2.8
+python-multipart>=0.0.9
+PyYAML>=6.0
+redis>=5.0
+requests>=2.31
+skyfield>=1.49
+SQLAlchemy>=2.0
 timezonefinder>=8.1
 tzdata>=2024.1
-PyYAML>=6.0
-jsonschema>=4.21
-requests>=2.31
-python-multipart>=0.0.9
-pluggy>=1.5
-fastapi>=0.117,<0.118
-httpx>=0.28,<0.29
-orjson>=3.10
-redis>=5.0
-cachetools>=5.3
 zstandard>=0.22
-prometheus-client>=0.20
-jinja2>=3.1
-markdown-it-py>=2.2
-mdit-py-plugins>=0.4
-weasyprint>=62
-python-docx>=1.1
-pypdf>=4.2
-click>=8.1
-rich>=13.7
-ics>=0.7
 
-# Visualization / UI helpers
-plotly>=5.20
-streamlit>=1.35
-# QA / property-based testing (used by tests)
-hypothesis>=6.112
-pytest-benchmark>=4.0
-# Optional groups (comment in as needed):
-fastapi>=0.117,<0.118
-# API server runtime
-uvicorn>=0.37
-icalendar>=6
-
-# Required for FastAPI TestClient
-httpx>=0.28,<0.29
-
-# uvicorn[standard]>=0.30
-# matplotlib>=3.8
-# pyproj>=3.6
-# shapely>=2.0
-# geographiclib>=2.0
-skyfield>=1.49
-jplephem>=2.21
-# jplephem>=2.21
-# Dev:
-# pytest>=8.2
-# pytest-cov>=5.0
-# hypothesis>=6.112
-# ruff>=0.6.5
-# black>=24.8
-# isort>=5.13
 # >>> AUTO-GEN END: AstroEngine Requirements v1.0
-
-pyswisseph==2.10.3.2; python_version < "3.12"  # ENSURE-LINE
-fpdf2>=2.7

--- a/scripts/generate_requirements.py
+++ b/scripts/generate_requirements.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Generate requirement lock files from ``pyproject.toml`` definitions."""
+
+from __future__ import annotations
+
+import argparse
+from collections import OrderedDict
+from pathlib import Path
+import tomllib
+
+ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = ROOT / "pyproject.toml"
+REQ_MAIN = ROOT / "requirements.txt"
+REQ_DEV = ROOT / "requirements-dev.txt"
+REQ_OPTIONAL = ROOT / "requirements-optional.txt"
+
+HEADER_MAIN = "# >>> AUTO-GEN BEGIN: AstroEngine Requirements v1.0"
+FOOTER_MAIN = "# >>> AUTO-GEN END: AstroEngine Requirements v1.0"
+HEADER_OPTIONAL = "# >>> AUTO-GEN BEGIN: optional-reqs v1.0"
+FOOTER_OPTIONAL = "# >>> AUTO-GEN END: optional-reqs v1.0"
+
+DEV_ENSURE_LINES = [
+    "typing_extensions>=4.9.0  # ENSURE-LINE",
+    "pip-tools>=7.4.0  # ENSURE-LINE",
+    "pipdeptree>=2.20.0  # ENSURE-LINE",
+    "pyswisseph==2.10.3.2; python_version < \"3.12\"  # ENSURE-LINE",
+]
+
+DEV_EXTRA_OVERRIDES = {
+    "pytest": "pytest>=8.0.0  # ENSURE-LINE",
+    "hypothesis": "hypothesis>=6.92.0  # ENSURE-LINE",
+    "pytest-benchmark": "pytest-benchmark>=4.0  # ENSURE-LINE",
+    "pytest-cov": "pytest-cov>=4.1.0  # ENSURE-LINE",
+    "ruff": "ruff>=0.6.5",
+    "mypy": "mypy>=1.10",
+}
+
+ADDITIONAL_DEV_LINES = [
+    "genbadge[coverage]>=1.1.1  # ENSURE-LINE",
+]
+
+OPTIONAL_SKIP_EXTRAS = {"all", "dev"}
+
+
+def canonical_name(spec: str) -> str:
+    spec = spec.split(";", 1)[0]
+    spec = spec.split("[", 1)[0]
+    for token in ("==", "!=", ">=", "<=", "~=", ">", "<"):
+        if token in spec:
+            spec = spec.split(token, 1)[0]
+            break
+    return spec.strip().lower().replace("-", "_")
+
+
+def dedupe_preserve(items: list[str]) -> list[str]:
+    seen: OrderedDict[str, str] = OrderedDict()
+    for raw in items:
+        item = raw.strip()
+        if not item or item.startswith("#"):
+            continue
+        key = (item.split(" ", 1)[0], canonical_name(item))
+        if key not in seen:
+            seen[key] = item
+    return list(seen.values())
+
+
+def load_pyproject() -> tuple[list[str], dict[str, list[str]]]:
+    data = tomllib.loads(PYPROJECT.read_text())
+    project = data.get("project", {})
+    base = dedupe_preserve(list(project.get("dependencies", [])))
+    extras_raw: dict[str, list[str]] = project.get("optional-dependencies", {})
+    extras: dict[str, list[str]] = {}
+    for name, values in extras_raw.items():
+        extras[name] = dedupe_preserve(list(values))
+    return base, extras
+
+
+def format_with_header(header: str, body: list[str], footer: str) -> str:
+    lines: list[str] = [header, "# Generated via scripts/generate_requirements.py; do not edit by hand."]
+    lines.extend(body)
+    if body and body[-1] != "":
+        lines.append("")
+    lines.append(footer)
+    return "\n".join(lines) + "\n"
+
+
+def generate_requirements_txt(base: list[str]) -> str:
+    ordered = sorted(base, key=canonical_name)
+    return format_with_header(HEADER_MAIN, ordered + [""], FOOTER_MAIN)
+
+
+def generate_optional_txt(extras: dict[str, list[str]]) -> str:
+    body: list[str] = ["# Mirrors pyproject extras for non-pep517 workflows", ""]
+    for name, pkgs in extras.items():
+        if name in OPTIONAL_SKIP_EXTRAS:
+            continue
+        body.append(f"# [{name}]")
+        body.extend(pkgs)
+        body.append("")
+    if body and body[-1] == "":
+        body.pop()
+    return format_with_header(HEADER_OPTIONAL, body, FOOTER_OPTIONAL)
+
+
+def generate_dev_txt(base: list[str], extras: dict[str, list[str]]) -> str:
+    body: list[str] = []
+    body.extend(DEV_ENSURE_LINES)
+    body.append("")
+    body.append("-r requirements.txt")
+    body.append("")
+    dev_extra = extras.get("dev", [])
+    overrides = {canonical_name(k): v for k, v in DEV_EXTRA_OVERRIDES.items()}
+    seen: set[str] = set()
+    if dev_extra:
+        body.append("# pyproject.toml [project.optional-dependencies.dev]")
+        for spec in dev_extra:
+            name = canonical_name(spec)
+            seen.add(name)
+            override = overrides.get(name)
+            body.append(override or spec)
+        body.append("")
+    for name, override in overrides.items():
+        if name not in seen:
+            body.append(override)
+    if ADDITIONAL_DEV_LINES:
+        body.append("")
+        body.extend(ADDITIONAL_DEV_LINES)
+    return "\n".join(body).strip() + "\n"
+
+
+def write_if_changed(path: Path, content: str) -> None:
+    if path.exists() and path.read_text() == content:
+        return
+    path.write_text(content)
+
+
+def main(check: bool = False) -> int:
+    base, extras = load_pyproject()
+    main_txt = generate_requirements_txt(base)
+    optional_txt = generate_optional_txt(extras)
+    dev_txt = generate_dev_txt(base, extras)
+
+    if check:
+        mismatches: list[str] = []
+        if REQ_MAIN.read_text() != main_txt:
+            mismatches.append("requirements.txt")
+        if REQ_OPTIONAL.read_text() != optional_txt:
+            mismatches.append("requirements-optional.txt")
+        if REQ_DEV.read_text() != dev_txt:
+            mismatches.append("requirements-dev.txt")
+        if mismatches:
+            print("Out-of-date files: " + ", ".join(mismatches))
+            return 1
+        return 0
+
+    write_if_changed(REQ_MAIN, main_txt)
+    write_if_changed(REQ_OPTIONAL, optional_txt)
+    write_if_changed(REQ_DEV, dev_txt)
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="Only verify whether files are current.")
+    args = parser.parse_args()
+    raise SystemExit(main(check=args.check))


### PR DESCRIPTION
## Summary
- add a generator script that reads pyproject.toml and rewrites requirements manifests to avoid manual drift
- regenerate requirements.txt, requirements-dev.txt, and requirements-optional.txt from the single pyproject source of truth
- document the new workflow in the README so contributors know how to refresh or check the manifests

## Testing
- pytest -q --benchmark-skip *(terminates with KeyboardInterrupt after reporting full pass due to pytest-benchmark shutdown latency)*

------
https://chatgpt.com/codex/tasks/task_e_68decc4abfc08324bd43754d642d52b2