### PR TITLE
Add guard for optional dependency version alignment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,11 +105,9 @@ api = [
   "httpx>=0.28,<0.29",
 ]
 providers = [
-
   "pyswisseph>=2.10",
   "timezonefinder>=8.1",
   "tzdata>=2024.1",
-
 ]
 dev = [
   "pytest",

--- a/tests/test_dependency_versions.py
+++ b/tests/test_dependency_versions.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import tomllib
+from packaging.requirements import Requirement
+
+
+def _specifier_for(dependency_list: list[str], package: str) -> str:
+    for item in dependency_list:
+        requirement = Requirement(item)
+        if requirement.name == package:
+            return str(requirement.specifier)
+    raise AssertionError(f"Package {package!r} not found in dependency list")
+
+
+def test_optional_versions_match_core_dependencies() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    data = tomllib.loads(pyproject_path.read_text())
+
+    project = data["project"]
+    core_deps = project["dependencies"]
+    optional_deps = project["optional-dependencies"]
+
+    expected_specifiers = {
+        package: _specifier_for(core_deps, package)
+        for package in ("httpx", "timezonefinder", "tzdata")
+    }
+
+    extras_to_validate = {
+        "api": ("httpx",),
+        "providers": ("timezonefinder", "tzdata"),
+        "all": ("httpx", "timezonefinder", "tzdata"),
+    }
+
+    for extra_name, packages in extras_to_validate.items():
+        extra = optional_deps[extra_name]
+        for package in packages:
+            expected = expected_specifiers[package]
+            assert (
+                _specifier_for(extra, package) == expected
+            ), f"{extra_name} extra for {package} drifted from core dependencies"


### PR DESCRIPTION
## Summary
- normalize the providers extra formatting so the httpx, timezonefinder, and tzdata specifiers mirror the core dependency list
- add a regression test that loads `pyproject.toml` and ensures the `api`, `providers`, and `all` extras stay aligned with the core specs for httpx, timezonefinder, and tzdata

## Testing
- `pytest tests/test_dependency_versions.py`
- `pytest` *(partial run; interrupted after ~31 minutes to avoid excessive wall-clock time)*

------
https://chatgpt.com/codex/tasks/task_e_68decc526c148324b6462654c7599740