### PR TITLE
Align runtime default database URL with Alembic configuration

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -4,7 +4,7 @@ from contextlib import contextmanager
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-DB_URL = os.getenv("DATABASE_URL", "sqlite+pysqlite:///:memory:")
+DB_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
 engine = create_engine(DB_URL, echo=False, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
 


### PR DESCRIPTION
## Summary
- update the runtime SQLAlchemy session to default to the dev SQLite file
  so it matches Alembic's default configuration

## Testing
- pytest tests/test_angles_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68decc5819588324874ecca96a9fee13