### PR TITLE
Remove duplicate calendar dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ dependencies = [
   "python-multipart>=0.0.9",
   "SQLAlchemy>=2.0",
   "alembic>=1.13",
-  "ics>=0.7",
   "duckdb>=0.10",
   "timezonefinder>=8.1",
   "tzdata>=2024.1",
@@ -64,7 +63,6 @@ catalogs = [
 ]
 exporters = [
   "pyarrow>=16",
-  "ics>=0.7",
 ]
 narrative = [
   "jinja2>=3.1",
@@ -126,7 +124,6 @@ all = [
   "jplephem>=2.21",
   "astroquery>=0.4",
   "pyarrow>=16",
-  "ics>=0.7",
   "jinja2>=3.1",
   "numba>=0.58",
   "click>=8.1",

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -12,7 +12,6 @@ astroquery>=0.4
 # exporters
 
 pyarrow>=16
-ics>=0.7
 # document generators
 pypdf>=4.2
 weasyprint>=62

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,8 +31,6 @@ python-docx>=1.1
 pypdf>=4.2
 click>=8.1
 rich>=13.7
-ics>=0.7
-
 # Visualization / UI helpers
 plotly>=5.20
 streamlit>=1.35


### PR DESCRIPTION
## Summary
- drop the unused `ics` package from the core runtime and extras so only `icalendar` is required
- update requirements lockfiles to mirror the simplified dependency set

## Testing
- pytest tests/export/test_ics_exports.py tests/test_cli.py::test_cli_scan_with_stub

------
https://chatgpt.com/codex/tasks/task_e_68decc5f5a1c8324a1a1a2372b4c5b28