### PR TITLE
Add mypy type checking to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
         run: ruff check --output-format=github .
       - name: Format check (Black)
         run: black --check .
+      - name: Type check
+        run: |
+          pip install mypy pydantic
+          mypy .
   tests:
     needs: lint
     runs-on: ${{ matrix.os }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,3 +211,10 @@ skip_glob = [
 [tool.black]
 line-length = 88
 target-version = ["py311"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+plugins = ["pydantic.mypy"]
+warn_unused_ignores = true
+exclude = ["generated", "scripts", ".github"]


### PR DESCRIPTION
## Summary
- configure mypy with strict settings and the Pydantic plugin in the project configuration
- add a mypy step to the lint workflow so CI enforces type checking

## Testing
- pytest tests/test_angles_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68decc676bc88324acbd66bc42ac088b