### PR TITLE
Add middleware enforcing security headers

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,10 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from typing import Awaitable, Callable
+
+from fastapi import FastAPI, Request
+from starlette.responses import Response
 
 from app.routers import (
     aspects_router,
@@ -31,6 +34,18 @@ app.include_router(lots_router)
 app.include_router(relationship_router)
 app.include_router(interpret_router)
 app.include_router(reports_router)
+
+
+@app.middleware("http")
+async def security_headers(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    """Apply default security headers to every HTTP response."""
+    response = await call_next(request)
+    response.headers.setdefault("X-Content-Type-Options", "nosniff")
+    response.headers.setdefault("X-Frame-Options", "DENY")
+    response.headers.setdefault("Referrer-Policy", "no-referrer")
+    return response
 
 
 __all__ = ["app", "configure_position_provider", "clear_position_provider"]


### PR DESCRIPTION
## Summary
- add an HTTP middleware on the FastAPI app that sets default security headers for every response

## Testing
- pytest tests/test_aspects_events.py *(passes; command ends in an interactive pager that requires manual exit in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68decc7a27148324a12aca9732a539fa