### PR TITLE
Lazy load heavy CLI dependencies

### DIFF
--- a/astroengine/infrastructure/storage/sqlite/engine.py
+++ b/astroengine/infrastructure/storage/sqlite/engine.py
@@ -9,8 +9,6 @@ from pathlib import Path
 from alembic import command
 from alembic.config import Config
 from alembic.runtime.migration import MigrationContext
-from sqlalchemy import create_engine
-from sqlalchemy.pool import NullPool
 
 
 def _absolute_sqlite_url(db_path: str | Path) -> str:
@@ -46,6 +44,9 @@ class SQLiteMigrator:
         command.downgrade(self._config(), revision)
 
     def current(self) -> str | None:
+        from sqlalchemy import create_engine
+        from sqlalchemy.pool import NullPool
+
         engine = create_engine(
             _absolute_sqlite_url(self.db_path), future=True, poolclass=NullPool
         )


### PR DESCRIPTION
## Summary
- defer importing heavy canonical exporters in the CLI by routing through lightweight helper functions
- lazily load optional `pyarrow` support inside `astroengine.exporters` so CLI startup avoids importing it unless needed
- move the SQLAlchemy imports for the SQLite migrator to call sites to prevent eager loading during CLI initialization

## Testing
- `pytest` *(interrupted after ~33 minutes with 163 passed / 38 skipped due to runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68decc7fed348324881797f7e0318ca4