### PR TITLE
Add shared pip constraints for FastAPI stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    env:
+      PIP_CONSTRAINT: constraints.txt
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +29,8 @@ jobs:
   tests:
     needs: lint
     runs-on: ${{ matrix.os }}
+    env:
+      PIP_CONSTRAINT: constraints.txt
     strategy:
       fail-fast: false
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,16 @@
 .PHONY: help setup install-optional hooks fmt lint lint-code test doctor clean deepclean fullcheck repair build
 
 help:
-@echo "Targets: setup, install-optional, hooks, fmt, lint, lint-code, test, doctor, clean, deepclean, fullcheck, repair, build"
+	@echo "Targets: setup, install-optional, hooks, fmt, lint, lint-code, test, doctor, clean, deepclean, fullcheck, repair, build"
 
 setup:
-python -m pip install --upgrade pip
-@if [ -f requirements-dev.txt ]; then PIP_CONSTRAINT=constraints.txt pip install -r requirements-dev.txt; fi
-@if [ -f pyproject.toml ] || [ -f setup.py ]; then PIP_CONSTRAINT=constraints.txt pip install -e . || true; fi
-python -m astroengine.diagnostics --strict || true
+	python -m pip install --upgrade pip
+	@if [ -f requirements-dev.txt ]; then PIP_CONSTRAINT=constraints.txt pip install -r requirements-dev.txt; fi
+	@if [ -f pyproject.toml ] || [ -f setup.py ]; then PIP_CONSTRAINT=constraints.txt pip install -e . || true; fi
+	python -m astroengine.diagnostics --strict || true
 
 install-optional:
-python scripts/install_optional_dependencies.py
+	python scripts/install_optional_dependencies.py
 
 hooks:
 	python -m pip install -U pre-commit

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ help:
 
 setup:
 python -m pip install --upgrade pip
-@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+@if [ -f requirements-dev.txt ]; then PIP_CONSTRAINT=constraints.txt pip install -r requirements-dev.txt; fi
+@if [ -f pyproject.toml ] || [ -f setup.py ]; then PIP_CONSTRAINT=constraints.txt pip install -e . || true; fi
 python -m astroengine.diagnostics --strict || true
 
 install-optional:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ channel, and subchannel remains intact and data-backed:
 1. **Python 3.11** recommended. Create a venv and install runtime + optional UI deps:
    ```bash
    python -m venv .venv && source .venv/bin/activate
+   export PIP_CONSTRAINT=constraints.txt
    pip install -e .[ui]
    # optional exports/providers:
    pip install pyarrow skyfield jplephem
@@ -461,7 +462,7 @@ pytest
 > The base development container only installs the core runtime so images stay
 > lightweight. API-facing dependencies such as `fastapi`, `uvicorn`,
 > `pydantic`, and `icalendar` therefore are not present until you explicitly
-> install the `api` extra (e.g. `pip install -e .[api,dev]`) or the mirrored
+> install the `api` extra (e.g. `export PIP_CONSTRAINT=constraints.txt && pip install -e .[api,dev]`) or the mirrored
 > bundle in `requirements-optional.txt`.
 
 Schema validation helpers reside in `astroengine/validation` and operate

--- a/apps/streamlit_transit_scanner.py
+++ b/apps/streamlit_transit_scanner.py
@@ -16,7 +16,8 @@ try:  # pragma: no cover - Streamlit import guarded for test environments
     import streamlit as st
 except Exception:  # pragma: no cover - surfacing missing dependency
     print(
-        "This app requires the UI extras. Install with: pip install -e .[ui]",
+        "This app requires the UI extras. Install with: "
+        "export PIP_CONSTRAINT=constraints.txt && pip install -e .[ui]",
         file=sys.stderr,
     )
     raise

--- a/astroengine/maint.py
+++ b/astroengine/maint.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -44,6 +45,8 @@ from .infrastructure.paths import project_root
 
 ROOT = project_root()
 REQ_DEV = ROOT / "requirements-dev.txt"
+_env_constraint = os.environ.get("PIP_CONSTRAINT")
+CONSTRAINT_FILE = Path(_env_constraint) if _env_constraint else ROOT / "constraints.txt"
 
 
 # ---------- helpers ----------
@@ -91,7 +94,10 @@ def pip_install(pkgs: Iterable[str]) -> int:
     pkgs = list(pkgs)
     if not pkgs:
         return 0
-    cmd = [sys.executable, "-m", "pip", "install", *pkgs]
+    cmd = [sys.executable, "-m", "pip", "install"]
+    if CONSTRAINT_FILE.exists():
+        cmd.extend(["--constraint", str(CONSTRAINT_FILE)])
+    cmd.extend(pkgs)
     code, _ = sh(cmd)
     return code
 

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,7 @@
+# AstroEngine dependency guardrails
+#
+# Pin FastAPI and its HTTP stack to versions validated with our runtime.
+# Adjust only after verifying upstream compatibility locally and in CI.
+fastapi==0.117.0
+starlette==0.38.2
+httpx==0.28.1

--- a/docs/DEV_ENV.md
+++ b/docs/DEV_ENV.md
@@ -6,6 +6,7 @@
 python -m venv .venv
 source .venv/bin/activate  # Windows: .venv\\Scripts\\activate
 python -m pip install --upgrade pip
+export PIP_CONSTRAINT=constraints.txt
 pip install -r requirements-dev.txt
 pip install -e .
 pre-commit install  # optional
@@ -16,6 +17,7 @@ pre-commit install  # optional
 ```bash
 conda create -n astroengine python=3.11 -y
 conda activate astroengine
+export PIP_CONSTRAINT=constraints.txt
 pip install -r requirements-dev.txt
 pip install -e .
 ```

--- a/docs/DEV_SETUP.md
+++ b/docs/DEV_SETUP.md
@@ -3,6 +3,7 @@
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # Windows: .\\.venv\\Scripts\\Activate.ps1
+export PIP_CONSTRAINT=constraints.txt
 pip install -e .[dev]
 ```
 

--- a/docs/SWISS_EPHEMERIS.md
+++ b/docs/SWISS_EPHEMERIS.md
@@ -5,7 +5,7 @@ AstroEngine can use `pyswisseph` (Swiss Ephemeris). Without data files, it will 
 
 ## Install the library
 ```bash
-pip install pyswisseph
+PIP_CONSTRAINT=constraints.txt pip install pyswisseph
 ```
 
 ## Data files (optional, for high precision)

--- a/environment.yml
+++ b/environment.yml
@@ -5,5 +5,6 @@ dependencies:
   - python>=3.10,<3.13
   - pip
   - pip:
+      - -c constraints.txt
       - -r requirements-dev.txt
 # >>> AUTO-GEN END: Conda Env v1.0

--- a/ops/pipelines/github-actions.yaml
+++ b/ops/pipelines/github-actions.yaml
@@ -14,7 +14,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -r requirements-dev.txt
+      - env:
+          PIP_CONSTRAINT: constraints.txt
+        run: pip install -r requirements-dev.txt
       - run: make lint
   unit:
     runs-on: ubuntu-latest
@@ -24,7 +26,9 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -r requirements-dev.txt
+      - env:
+          PIP_CONSTRAINT: constraints.txt
+        run: pip install -r requirements-dev.txt
       - run: pytest --junitxml=reports/unit.xml
       - uses: actions/upload-artifact@v3
         with:

--- a/scripts/dev_setup.ps1
+++ b/scripts/dev_setup.ps1
@@ -7,6 +7,7 @@ if ($Conda) {
   python -m venv .venv
   .\.venv\Scripts\Activate.ps1
   python -m pip install --upgrade pip
+  $env:PIP_CONSTRAINT = "constraints.txt"
   pip install -e .[dev]
 }
 python -m astroengine env

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 python -m venv .venv
 . .venv/bin/activate
 python -m pip install --upgrade pip
+export PIP_CONSTRAINT=constraints.txt
 pip install -e .[dev]
 python -m astroengine env || true
 # >>> AUTO-GEN END: AE Dev Setup (bash) v1.1

--- a/streamlit/relationship_lab/app.py
+++ b/streamlit/relationship_lab/app.py
@@ -12,7 +12,10 @@ from typing import Any, Dict
 try:  # pragma: no cover - Streamlit import guarded for tests
     import streamlit as st
 except Exception:  # pragma: no cover - surfaced to CLI when dependencies missing
-    print("This app requires the UI extras. Install with: pip install -e .[ui]")
+    print(
+        "This app requires the UI extras. Install with: "
+        "export PIP_CONSTRAINT=constraints.txt && pip install -e .[ui]"
+    )
     raise
 
 from .api import build_backend


### PR DESCRIPTION
## Summary
- add a shared constraints.txt that pins the FastAPI/Starlette/httpx versions validated for AstroEngine
- teach CI workflows, setup scripts, and the maintainer tooling to respect the shared constraints file
- refresh developer documentation and UI helper messages to mention setting `PIP_CONSTRAINT=constraints.txt`

## Testing
- pytest tests/test_utils_hits_to_df.py -q


------
https://chatgpt.com/codex/tasks/task_e_68decc99db308324bddc2145aa6aaba3