### PR TITLE
Extend lint/type excludes to generated datasets

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,15 @@
+[mypy]
+exclude = (?x)(
+    ^apps/
+  | ^datasets/
+  | ^db/
+  | ^generated/
+  | ^profiles/
+  | ^registry/
+  | ^rulesets/
+  | ^scripts/
+  | ^\.github/
+  | ^astroengine/modules/
+  | ^astroengine/mundane/
+  | ^astroengine/narrative/
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,12 @@ select = ["E","F","I","UP","B"]
 target-version = "py311"
 extend-exclude = [
     "apps",
+    "datasets",
+    "db",
     "generated",
+    "profiles",
+    "registry",
+    "rulesets",
     "scripts",
     ".github",
     "astroengine/modules",


### PR DESCRIPTION
## Summary
- extend Ruff's exclude list to skip large generated datasets and registries
- add a mypy configuration that mirrors the expanded excludes for faster runs

## Testing
- not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68decc9eddec832487d2e79dc3a1247a