### PR TITLE
Add transit overlay API and visualization engine

### DIFF
--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -13,13 +13,9 @@ def create_app() -> FastAPI:
     from .routers import plus as plus_router
     from .routers import scan as scan_router
     from .routers import synastry as synastry_router
-
-    from .routers import vedic as vedic_router
-
-
     from .routers import topocentric as topocentric_router
+    from .routers import transit_overlay as transit_overlay_router
     from .routers import vedic as vedic_router
-
 
     app = FastAPI(title="AstroEngine API")
     app.include_router(plus_router.router)
@@ -27,8 +23,8 @@ def create_app() -> FastAPI:
     app.include_router(scan_router.router, prefix="/v1/scan", tags=["scan"])
     app.include_router(synastry_router.router, prefix="/v1/synastry", tags=["synastry"])
     app.include_router(vedic_router.router)
-
     app.include_router(topocentric_router.router, prefix="/v1", tags=["topocentric"])
+    app.include_router(transit_overlay_router.router)
     app.include_router(vedic_router.router)
 
     return app

--- a/astroengine/api/routers/transit_overlay.py
+++ b/astroengine/api/routers/transit_overlay.py
@@ -1,0 +1,133 @@
+"""FastAPI router for the transit ↔ natal overlay visualisation."""
+from __future__ import annotations
+
+from dataclasses import asdict
+
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import ORJSONResponse, Response
+
+from ...chart.natal import ChartLocation
+from ...ux.maps.transit_overlay import (
+    AspectHit,
+    OverlayBodyState,
+    OverlayFrame,
+    OverlayOptions,
+    OverlayRequest,
+    TransitOverlayResult,
+    compute_overlay_frames,
+    compute_transit_aspects,
+    render_overlay_svg,
+)
+from ..schemas_transit_overlay import (
+    OverlayBodyPositionModel,
+    OverlayFrameModel,
+    TransitAspectModel,
+    TransitAspectRequest,
+    TransitAspectResponse,
+    TransitOverlayExportRequest,
+    TransitOverlayPositionRequest,
+    TransitOverlayPositionResponse,
+)
+
+router = APIRouter(
+    prefix="/v1/transit-overlay",
+    tags=["transit-overlay"],
+    default_response_class=ORJSONResponse,
+)
+
+
+@router.post("/positions", response_model=TransitOverlayPositionResponse)
+def positions(payload: TransitOverlayPositionRequest) -> TransitOverlayPositionResponse:
+    if not payload.bodies:
+        raise HTTPException(status_code=400, detail="At least one body must be requested")
+    options_mapping = payload.options.model_dump(exclude_none=True) if payload.options else None
+    request = OverlayRequest(
+        birth_dt=payload.birth_dt_utc,
+        birth_location=ChartLocation(
+            latitude=payload.birth_location.lat,
+            longitude=payload.birth_location.lon,
+        ),
+        transit_dt=payload.transit_dt_utc,
+        bodies=payload.bodies,
+        options=options_mapping,
+    )
+    try:
+        result = compute_overlay_frames(request)
+    except ModuleNotFoundError as exc:  # Swiss Ephemeris not available
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return _response_from_result(result)
+
+
+@router.post("/aspects", response_model=TransitAspectResponse)
+def aspects(payload: TransitAspectRequest) -> TransitAspectResponse:
+    natal = {name: _state_from_model(model) for name, model in payload.natal.geocentric.items()}
+    transit = {name: _state_from_model(model) for name, model in payload.transit.geocentric.items()}
+    overrides = {name: float(value) for name, value in (payload.orb_overrides or {}).items()}
+    hits = compute_transit_aspects(
+        natal,
+        transit,
+        conj_override=payload.conj_override,
+        opp_override=payload.opp_override,
+        per_body_overrides=overrides,
+    )
+    return TransitAspectResponse(aspects=[TransitAspectModel(**asdict(hit)) for hit in hits])
+
+
+@router.post("/export", response_class=Response)
+def export_svg(payload: TransitOverlayExportRequest) -> Response:
+    result = _result_from_response(payload.payload)
+    aspect_hits = [
+        AspectHit(
+            body=model.body,
+            kind=model.kind,
+            separation_deg=model.separation_deg,
+            orb_abs_deg=model.orb_abs_deg,
+        )
+        for model in (payload.aspects or [])
+    ]
+    width = payload.width or 900
+    height = payload.height or 900
+    theme = payload.theme or "light"
+    svg = render_overlay_svg(result, aspects=aspect_hits, width=width, height=height, theme=theme)
+    return Response(content=svg, media_type="image/svg+xml")
+
+
+def _response_from_result(result: TransitOverlayResult) -> TransitOverlayPositionResponse:
+    return TransitOverlayPositionResponse(
+        natal=OverlayFrameModel(**result.natal.to_dict()),
+        transit=OverlayFrameModel(**result.transit.to_dict()),
+        options=result.options.to_dict(),
+    )
+
+
+def _state_from_model(model: OverlayBodyPositionModel) -> OverlayBodyState:
+    return OverlayBodyState(
+        id=model.id,
+        lon_deg=model.lon_deg,
+        lat_deg=model.lat_deg,
+        radius_au=model.radius_au,
+        speed_lon_deg_per_day=model.speed_lon_deg_per_day,
+        speed_lat_deg_per_day=model.speed_lat_deg_per_day,
+        speed_radius_au_per_day=model.speed_radius_au_per_day,
+        retrograde=model.retrograde,
+        frame=model.frame,
+        metadata=dict(model.metadata or {}),
+    )
+
+
+def _frame_from_model(model: OverlayFrameModel) -> OverlayFrame:
+    return OverlayFrame(
+        timestamp=model.timestamp,
+        heliocentric={name: _state_from_model(body) for name, body in model.heliocentric.items()},
+        geocentric={name: _state_from_model(body) for name, body in model.geocentric.items()},
+        metadata=dict(model.metadata or {}),
+    )
+
+
+def _result_from_response(model: TransitOverlayPositionResponse) -> TransitOverlayResult:
+    options = OverlayOptions.from_mapping(model.options)
+    natal = _frame_from_model(model.natal)
+    transit = _frame_from_model(model.transit)
+    return TransitOverlayResult(natal=natal, transit=transit, options=options)

--- a/astroengine/api/schemas_transit_overlay.py
+++ b/astroengine/api/schemas_transit_overlay.py
@@ -1,0 +1,100 @@
+"""Pydantic models for the transit ↔ natal overlay API."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from pydantic import BaseModel, ConfigDict, Field
+
+__all__ = [
+    "GeoPointModel",
+    "TransitOverlayOptionsModel",
+    "TransitOverlayPositionRequest",
+    "OverlayBodyPositionModel",
+    "OverlayFrameModel",
+    "TransitOverlayPositionResponse",
+    "TransitAspectModel",
+    "TransitAspectRequest",
+    "TransitAspectResponse",
+    "TransitOverlayExportRequest",
+]
+
+
+class GeoPointModel(BaseModel):
+    lat: float
+    lon: float
+    alt_m: float | None = 0.0
+
+
+class TransitOverlayOptionsModel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    eph_source: str | None = None
+    zodiac: str | None = None
+    ayanamsha: str | None = None
+    house_system: str | None = None
+    nodes_variant: str | None = None
+    lilith_variant: str | None = None
+    orbs_deg: Dict[str, float] | None = None
+    orb_overrides: Dict[str, float] | None = None
+
+
+class TransitOverlayPositionRequest(BaseModel):
+    birth_dt_utc: datetime
+    birth_location: GeoPointModel
+    transit_dt_utc: datetime
+    bodies: list[str]
+    options: TransitOverlayOptionsModel | None = None
+
+
+class OverlayBodyPositionModel(BaseModel):
+    id: str
+    lon_deg: float
+    lat_deg: float
+    radius_au: float
+    speed_lon_deg_per_day: float
+    speed_lat_deg_per_day: float
+    speed_radius_au_per_day: float
+    retrograde: bool
+    frame: str
+    metadata: Dict[str, Any] | None = None
+
+
+class OverlayFrameModel(BaseModel):
+    timestamp: datetime
+    heliocentric: Dict[str, OverlayBodyPositionModel]
+    geocentric: Dict[str, OverlayBodyPositionModel]
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitOverlayPositionResponse(BaseModel):
+    natal: OverlayFrameModel
+    transit: OverlayFrameModel
+    options: Dict[str, Any] = Field(default_factory=dict)
+
+
+class TransitAspectModel(BaseModel):
+    body: str
+    kind: str
+    separation_deg: float
+    orb_abs_deg: float
+
+
+class TransitAspectRequest(BaseModel):
+    natal: OverlayFrameModel
+    transit: OverlayFrameModel
+    conj_override: float | None = None
+    opp_override: float | None = None
+    orb_overrides: Dict[str, float] | None = None
+
+
+class TransitAspectResponse(BaseModel):
+    aspects: list[TransitAspectModel]
+
+
+class TransitOverlayExportRequest(BaseModel):
+    payload: TransitOverlayPositionResponse
+    aspects: list[TransitAspectModel] | None = None
+    width: int | None = None
+    height: int | None = None
+    theme: str | None = None

--- a/astroengine/modules/ux/__init__.py
+++ b/astroengine/modules/ux/__init__.py
@@ -75,6 +75,32 @@ def register_ux_module(registry: AstroRegistry) -> None:
         },
     )
 
+
+    overlay = maps.register_channel(
+        "transit_overlay",
+        metadata={
+            "renderer": "astroengine.ux.maps.transit_overlay.compute_overlay_frames",
+            "aspects": "astroengine.ux.maps.transit_overlay.compute_transit_aspects",
+            "export": "astroengine.ux.maps.transit_overlay.render_overlay_svg",
+        },
+    )
+    overlay.register_subchannel(
+        "heliocentric_biwheel",
+        metadata={
+            "description": "Heliocentric solar-system map overlaying natal and transit positions.",
+        },
+        payload={
+            "renderer": "astroengine.ux.maps.transit_overlay.compute_overlay_frames",
+            "aspects": "astroengine.ux.maps.transit_overlay.compute_transit_aspects",
+            "export": "astroengine.ux.maps.transit_overlay.render_overlay_svg",
+            "layout": "astroengine.ux.maps.transit_overlay.scale_au",
+            "datasets": [
+                "qa/artifacts/solarfire/2025-10-02/cross_engine.json",
+                "profiles/base_profile.yaml",
+            ],
+            "tests": ["tests/test_transit_overlay.py"],
+        },
+    )
     timelines = module.register_submodule(
         "timelines",
         metadata={

--- a/astroengine/ux/maps/transit_overlay/__init__.py
+++ b/astroengine/ux/maps/transit_overlay/__init__.py
@@ -1,32 +1,21 @@
-"""Locational visualization helpers (astrocartography, local space, maps)."""
-
+"""Transit ↔ natal heliocentric overlay utilities."""
 from __future__ import annotations
 
-from .astrocartography import (
-    LocalSpaceVector,
-    MapLine,
-    astrocartography_lines,
-    local_space_vectors,
-)
-from .transit_overlay import (
-    AspectHit,
+from .aspects import AspectHit, TRANSIT_ORB_LIMITS, compute_transit_aspects
+from .engine import (
     OverlayBodyState,
     OverlayFrame,
     OverlayOptions,
     OverlayRequest,
     TransitOverlayResult,
     compute_overlay_frames,
-    compute_transit_aspects,
-    render_overlay_svg,
-    scale_au,
 )
+from .layout import BREAKS, scale_au
+from .svg import render_overlay_svg
 
 __all__ = [
-    "LocalSpaceVector",
-    "MapLine",
-    "astrocartography_lines",
-    "local_space_vectors",
     "AspectHit",
+    "TRANSIT_ORB_LIMITS",
     "OverlayBodyState",
     "OverlayFrame",
     "OverlayOptions",
@@ -35,5 +24,6 @@ __all__ = [
     "compute_overlay_frames",
     "compute_transit_aspects",
     "render_overlay_svg",
+    "BREAKS",
     "scale_au",
 ]

--- a/astroengine/ux/maps/transit_overlay/aspects.py
+++ b/astroengine/ux/maps/transit_overlay/aspects.py
@@ -1,0 +1,82 @@
+"""Aspect detection for heliocentric transit ↔ natal overlays."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+from .engine import OverlayBodyState
+
+__all__ = [
+    "TRANSIT_ORB_LIMITS",
+    "AspectHit",
+    "compute_transit_aspects",
+]
+
+
+# Default orb allowances (degrees) keyed by canonical body name.
+TRANSIT_ORB_LIMITS: Mapping[str, float] = {
+    "sun": 6.0,
+    "moon": 5.0,
+    "mercury": 4.0,
+    "venus": 4.0,
+    "mars": 4.0,
+    "jupiter": 4.0,
+    "saturn": 3.0,
+    "uranus": 2.0,
+    "neptune": 2.0,
+    "pluto": 2.0,
+    "mean_node": 2.0,
+    "asc": 2.0,
+    "mc": 2.0,
+    "chiron": 2.0,
+}
+
+
+@dataclass(frozen=True)
+class AspectHit:
+    """Simple container describing an aspect between natal and transit placements."""
+
+    body: str
+    kind: str
+    separation_deg: float
+    orb_abs_deg: float
+
+
+def _circular_delta(a: float, b: float) -> float:
+    diff = (a - b) % 360.0
+    return 360.0 - diff if diff > 180.0 else diff
+
+
+def compute_transit_aspects(
+    natal: Mapping[str, OverlayBodyState],
+    transit: Mapping[str, OverlayBodyState],
+    *,
+    conj_override: float | None = None,
+    opp_override: float | None = None,
+    per_body_overrides: Mapping[str, float] | None = None,
+) -> list[AspectHit]:
+    """Return conjunction/opposition hits for matching bodies."""
+
+    overrides = dict(per_body_overrides or {})
+    hits: list[AspectHit] = []
+    for body, natal_state in natal.items():
+        transit_state = transit.get(body)
+        if transit_state is None:
+            continue
+        separation = _circular_delta(natal_state.lon_deg, transit_state.lon_deg)
+        orb_limit = overrides.get(body, TRANSIT_ORB_LIMITS.get(body, 2.0))
+        if conj_override is not None:
+            orb_limit = min(orb_limit, conj_override)
+        if separation <= orb_limit:
+            hits.append(
+                AspectHit(body=body, kind="conjunction", separation_deg=separation, orb_abs_deg=separation)
+            )
+        opp_delta = abs(180.0 - separation)
+        opp_limit = overrides.get(body, TRANSIT_ORB_LIMITS.get(body, 2.0))
+        if opp_override is not None:
+            opp_limit = min(opp_limit, opp_override)
+        if opp_delta <= opp_limit:
+            hits.append(
+                AspectHit(body=body, kind="opposition", separation_deg=180.0 - opp_delta, orb_abs_deg=opp_delta)
+            )
+    return hits

--- a/astroengine/ux/maps/transit_overlay/engine.py
+++ b/astroengine/ux/maps/transit_overlay/engine.py
@@ -1,0 +1,415 @@
+"""Position engine powering the transit ↔ natal overlay."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from functools import lru_cache
+from typing import Dict, Mapping, Sequence
+
+try:  # pragma: no cover - optional dependency during docs builds
+    import swisseph as swe  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    swe = None
+
+from ....chart.config import ChartConfig
+from ....chart.natal import ChartLocation
+from ....core.bodies import canonical_name
+from ....core.time import ensure_utc
+from ....ephemeris.swisseph_adapter import SwissEphemerisAdapter
+from ....providers.swisseph_adapter import (
+    VariantConfig as ProviderVariantConfig,
+    position_vec,
+    position_with_variants,
+)
+
+__all__ = [
+    "OverlayBodyState",
+    "OverlayFrame",
+    "OverlayOptions",
+    "OverlayRequest",
+    "TransitOverlayResult",
+    "compute_overlay_frames",
+]
+
+
+@dataclass(frozen=True)
+class OverlayOptions:
+    """Options controlling ephemeris and orb policy for the overlay."""
+
+    eph_source: str = "swiss"
+    zodiac: str = "tropical"
+    ayanamsha: str | None = None
+    house_system: str = "placidus"
+    nodes_variant: str = "mean"
+    lilith_variant: str = "mean"
+    orb_conjunction: float | None = None
+    orb_opposition: float | None = None
+    orb_overrides: Mapping[str, float] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "eph_source", (self.eph_source or "swiss").lower())
+        object.__setattr__(self, "zodiac", (self.zodiac or "tropical").lower())
+        object.__setattr__(self, "house_system", (self.house_system or "placidus").lower())
+        object.__setattr__(self, "nodes_variant", (self.nodes_variant or "mean").lower())
+        object.__setattr__(self, "lilith_variant", (self.lilith_variant or "mean").lower())
+        if self.orb_conjunction is not None:
+            object.__setattr__(self, "orb_conjunction", float(self.orb_conjunction))
+        if self.orb_opposition is not None:
+            object.__setattr__(self, "orb_opposition", float(self.orb_opposition))
+        overrides: Dict[str, float] = {}
+        for key, value in dict(self.orb_overrides or {}).items():
+            canonical = canonical_name(str(key))
+            overrides[canonical] = float(value)
+        object.__setattr__(self, "orb_overrides", overrides)
+
+    @classmethod
+    def from_mapping(cls, payload: Mapping[str, object] | None) -> "OverlayOptions":
+        if payload is None:
+            return cls()
+        if isinstance(payload, OverlayOptions):
+            return payload
+        data = dict(payload)
+        orbs_deg = data.get("orbs_deg")
+        conj = data.get("orb_conjunction")
+        opp = data.get("orb_opposition")
+        if isinstance(orbs_deg, Mapping):
+            conj = orbs_deg.get("conj", conj)
+            opp = orbs_deg.get("opp", opp)
+        overrides = data.get("orb_overrides")
+        if isinstance(overrides, Mapping):
+            overrides_map = {str(k): float(v) for k, v in overrides.items()}
+        else:
+            overrides_map = {}
+        ayanamsha = data.get("ayanamsha")
+        return cls(
+            eph_source=str(data.get("eph_source", "swiss")),
+            zodiac=str(data.get("zodiac", "tropical")),
+            ayanamsha=str(ayanamsha) if ayanamsha is not None else None,
+            house_system=str(data.get("house_system", "placidus")),
+            nodes_variant=str(data.get("nodes_variant", "mean")),
+            lilith_variant=str(data.get("lilith_variant", "mean")),
+            orb_conjunction=float(conj) if conj is not None else None,
+            orb_opposition=float(opp) if opp is not None else None,
+            orb_overrides=overrides_map,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "eph_source": self.eph_source,
+            "zodiac": self.zodiac,
+            "house_system": self.house_system,
+            "nodes_variant": self.nodes_variant,
+            "lilith_variant": self.lilith_variant,
+        }
+        if self.ayanamsha is not None:
+            payload["ayanamsha"] = self.ayanamsha
+        if self.orb_conjunction is not None or self.orb_opposition is not None:
+            payload["orbs_deg"] = {
+                "conj": self.orb_conjunction,
+                "opp": self.orb_opposition,
+            }
+        if self.orb_overrides:
+            payload["orb_overrides"] = dict(self.orb_overrides)
+        return payload
+
+
+@dataclass(frozen=True)
+class OverlayBodyState:
+    """Position snapshot for a single body in a specific frame."""
+
+    id: str
+    lon_deg: float
+    lat_deg: float
+    radius_au: float
+    speed_lon_deg_per_day: float
+    speed_lat_deg_per_day: float
+    speed_radius_au_per_day: float
+    retrograde: bool
+    frame: str
+    metadata: Mapping[str, object] | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "id": self.id,
+            "lon_deg": self.lon_deg,
+            "lat_deg": self.lat_deg,
+            "radius_au": self.radius_au,
+            "speed_lon_deg_per_day": self.speed_lon_deg_per_day,
+            "speed_lat_deg_per_day": self.speed_lat_deg_per_day,
+            "speed_radius_au_per_day": self.speed_radius_au_per_day,
+            "retrograde": self.retrograde,
+            "frame": self.frame,
+        }
+        if self.metadata:
+            payload["metadata"] = dict(self.metadata)
+        return payload
+
+
+@dataclass(frozen=True)
+class OverlayFrame:
+    """Collection of heliocentric and geocentric placements for a timestamp."""
+
+    timestamp: datetime
+    heliocentric: Mapping[str, OverlayBodyState]
+    geocentric: Mapping[str, OverlayBodyState]
+    metadata: Mapping[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "timestamp": self.timestamp,
+            "heliocentric": {k: v.to_dict() for k, v in self.heliocentric.items()},
+            "geocentric": {k: v.to_dict() for k, v in self.geocentric.items()},
+            "metadata": dict(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class OverlayRequest:
+    """Input required to compute an overlay."""
+
+    birth_dt: datetime
+    birth_location: ChartLocation
+    transit_dt: datetime
+    bodies: Sequence[str]
+    options: OverlayOptions | Mapping[str, object] | None = None
+
+
+@dataclass(frozen=True)
+class TransitOverlayResult:
+    """Bundle containing natal and transit frames plus provenance."""
+
+    natal: OverlayFrame
+    transit: OverlayFrame
+    options: OverlayOptions
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "natal": self.natal.to_dict(),
+            "transit": self.transit.to_dict(),
+            "options": self.options.to_dict(),
+        }
+
+
+def compute_overlay_frames(
+    request: OverlayRequest,
+    *,
+    adapter: SwissEphemerisAdapter | None = None,
+) -> TransitOverlayResult:
+    """Compute natal and transit frames for ``request``."""
+
+    options = OverlayOptions.from_mapping(request.options)
+    if options.eph_source != "swiss":
+        raise ValueError("Only Swiss Ephemeris calculations are supported for overlays")
+    _ensure_swisseph()
+    adapter = adapter or _adapter_from_options(options)
+
+    bodies = _normalize_bodies(request.bodies)
+    natal_frame = _build_frame(adapter, request.birth_dt, request.birth_location, bodies, options)
+    transit_frame = _build_frame(adapter, request.transit_dt, request.birth_location, bodies, options)
+    return TransitOverlayResult(natal=natal_frame, transit=transit_frame, options=options)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_PLANET_CODES: dict[str, int] = {}
+if swe is not None:  # pragma: no branch - evaluated once at import time
+    for name in (
+        "sun",
+        "moon",
+        "mercury",
+        "venus",
+        "earth",
+        "mars",
+        "jupiter",
+        "saturn",
+        "uranus",
+        "neptune",
+        "pluto",
+    ):
+        attr = name.upper()
+        code = getattr(swe, attr, None)
+        if code is not None:
+            _PLANET_CODES[name] = int(code)
+    chiron = getattr(swe, "CHIRON", None)
+    if chiron is not None:
+        _PLANET_CODES["chiron"] = int(chiron)
+
+
+def _ensure_swisseph() -> None:
+    if swe is None:
+        raise ModuleNotFoundError(
+            "pyswisseph is required for the transit overlay. Install the 'pyswisseph' extra."
+        )
+
+
+_ADAPTER_CACHE: dict[tuple[str, str | None, str, str, str], SwissEphemerisAdapter] = {}
+
+
+def _adapter_from_options(options: OverlayOptions) -> SwissEphemerisAdapter:
+    key = (
+        options.zodiac,
+        options.ayanamsha,
+        options.house_system,
+        options.nodes_variant,
+        options.lilith_variant,
+    )
+    try:
+        return _ADAPTER_CACHE[key]
+    except KeyError:
+        config = ChartConfig(
+            zodiac=options.zodiac,
+            ayanamsha=options.ayanamsha,
+            house_system=options.house_system,
+            nodes_variant=options.nodes_variant,
+            lilith_variant=options.lilith_variant,
+        )
+        adapter = SwissEphemerisAdapter.from_chart_config(config)
+        _ADAPTER_CACHE[key] = adapter
+        return adapter
+
+
+def _normalize_datetime(moment: datetime) -> datetime:
+    normalized = ensure_utc(moment)
+    if normalized.tzinfo is None:
+        normalized = normalized.replace(tzinfo=UTC)
+    return normalized
+
+
+def _normalize_bodies(bodies: Sequence[str]) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for name in bodies:
+        canonical = canonical_name(name)
+        if not canonical or canonical in seen:
+            continue
+        ordered.append(canonical)
+        seen.add(canonical)
+    return tuple(ordered)
+
+
+def _build_frame(
+    adapter: SwissEphemerisAdapter,
+    moment: datetime,
+    location: ChartLocation,
+    bodies: Sequence[str],
+    options: OverlayOptions,
+) -> OverlayFrame:
+    timestamp = _normalize_datetime(moment)
+    jd_ut = adapter.julian_day(timestamp)
+
+    heliocentric: dict[str, OverlayBodyState] = {}
+    for body in bodies:
+        values = _position_for_body(body, jd_ut, options, helio=True)
+        if values is None:
+            continue
+        heliocentric[body] = _state_from_values(body, values, frame="heliocentric")
+
+    geocentric: dict[str, OverlayBodyState] = {}
+    angles_requested = False
+    for body in bodies:
+        if body in {"asc", "mc"}:
+            angles_requested = True
+            continue
+        values = _position_for_body(body, jd_ut, options, helio=False)
+        if values is None:
+            continue
+        geocentric[body] = _state_from_values(body, values, frame="geocentric")
+
+    metadata: dict[str, object] = {}
+    if angles_requested:
+        houses = adapter.houses(jd_ut, location.latitude, location.longitude, system=options.house_system)
+        metadata["houses"] = houses.to_dict()
+        if "asc" in bodies:
+            geocentric["asc"] = _state_from_values(
+                "asc",
+                (houses.ascendant % 360.0, 0.0, 1.0, 0.0, 0.0, 0.0),
+                frame="geocentric",
+                metadata={"kind": "angle"},
+            )
+        if "mc" in bodies:
+            geocentric["mc"] = _state_from_values(
+                "mc",
+                (houses.midheaven % 360.0, 0.0, 1.0, 0.0, 0.0, 0.0),
+                frame="geocentric",
+                metadata={"kind": "angle"},
+            )
+
+    return OverlayFrame(
+        timestamp=timestamp,
+        heliocentric=heliocentric,
+        geocentric=geocentric,
+        metadata=metadata,
+    )
+
+
+@lru_cache(maxsize=32768)
+def _cached_planet_position(body_code: int, jd_ut: float, flags: int) -> tuple[float, float, float, float, float, float]:
+    values = position_vec(body_code, jd_ut, flags=flags)
+    lon, lat, dist, lon_spd, lat_spd, dist_spd = values
+    return (lon % 360.0, lat, dist, lon_spd, lat_spd, dist_spd)
+
+
+@lru_cache(maxsize=32768)
+def _cached_variant_position(
+    name: str,
+    jd_ut: float,
+    nodes_variant: str,
+    lilith_variant: str,
+    flags: int,
+) -> tuple[float, float, float, float, float, float]:
+    config = ProviderVariantConfig(nodes_variant=nodes_variant, lilith_variant=lilith_variant)
+    values = position_with_variants(name, jd_ut, config, flags=flags)
+    lon, lat, dist, lon_spd, lat_spd, dist_spd = values
+    return (lon % 360.0, lat, dist, lon_spd, lat_spd, dist_spd)
+
+
+def _position_for_body(
+    name: str,
+    jd_ut: float,
+    options: OverlayOptions,
+    *,
+    helio: bool,
+) -> tuple[float, float, float, float, float, float] | None:
+    if swe is None:
+        return None
+    canonical = canonical_name(name)
+    if not canonical:
+        return None
+    if helio and canonical not in _PLANET_CODES:
+        return None
+    flags = int(getattr(swe, "FLG_SWIEPH", 256) | getattr(swe, "FLG_SPEED", 256))
+    if helio:
+        flags |= int(getattr(swe, "FLG_HELCTR", 0))
+    if canonical in _PLANET_CODES:
+        return _cached_planet_position(_PLANET_CODES[canonical], jd_ut, flags)
+    return _cached_variant_position(
+        canonical,
+        jd_ut,
+        options.nodes_variant,
+        options.lilith_variant,
+        flags,
+    )
+
+
+def _state_from_values(
+    body: str,
+    values: tuple[float, float, float, float, float, float],
+    *,
+    frame: str,
+    metadata: Mapping[str, object] | None = None,
+) -> OverlayBodyState:
+    lon, lat, dist, lon_spd, lat_spd, dist_spd = values
+    return OverlayBodyState(
+        id=body,
+        lon_deg=lon % 360.0,
+        lat_deg=lat,
+        radius_au=dist,
+        speed_lon_deg_per_day=lon_spd,
+        speed_lat_deg_per_day=lat_spd,
+        speed_radius_au_per_day=dist_spd,
+        retrograde=lon_spd < 0.0,
+        frame=frame,
+        metadata=metadata,
+    )

--- a/astroengine/ux/maps/transit_overlay/layout.py
+++ b/astroengine/ux/maps/transit_overlay/layout.py
@@ -1,0 +1,32 @@
+"""Layout helpers for transit ↔ natal heliocentric overlays."""
+from __future__ import annotations
+
+from typing import Sequence
+
+__all__ = ["BREAKS", "scale_au"]
+
+# Piecewise linear distance scaling to keep inner planets legible.
+BREAKS: Sequence[tuple[float, float, float]] = (
+    (0.0, 1.7, 220.0),
+    (1.7, 5.5, 60.0),
+    (5.5, 40.0, 12.0),
+)
+
+
+def scale_au(distance_au: float) -> float:
+    """Return a pixel radius for ``distance_au`` using the piecewise profile."""
+
+    if distance_au <= 0.0:
+        return 0.0
+    clamped = min(max(distance_au, 0.0), BREAKS[-1][1])
+    total = 0.0
+    remaining = clamped
+    for start, end, factor in BREAKS:
+        if remaining <= start:
+            continue
+        span = min(remaining, end) - start
+        if span > 0:
+            total += span * factor
+        if remaining <= end:
+            break
+    return total

--- a/astroengine/ux/maps/transit_overlay/svg.py
+++ b/astroengine/ux/maps/transit_overlay/svg.py
@@ -1,0 +1,317 @@
+"""SVG export for the transit ↔ natal overlay."""
+from __future__ import annotations
+
+import math
+from typing import Iterable, Mapping, Sequence
+
+from ....viz import SvgDocument, SvgElement
+from .aspects import AspectHit
+from .engine import OverlayBodyState, TransitOverlayResult
+from .layout import scale_au
+
+__all__ = ["render_overlay_svg"]
+
+
+_THEMES: Mapping[str, Mapping[str, str]] = {
+    "light": {
+        "background": "#ffffff",
+        "orbit": "#d0d7de",
+        "natal_helio": "#1f6feb",
+        "transit_helio": "#d97706",
+        "natal_geo": "#0f172a",
+        "transit_geo": "#be123c",
+        "aspect": "#7c3aed",
+        "text": "#111827",
+        "zodiac": "#9ca3af",
+    },
+    "dark": {
+        "background": "#0b1120",
+        "orbit": "#334155",
+        "natal_helio": "#38bdf8",
+        "transit_helio": "#fbbf24",
+        "natal_geo": "#f8fafc",
+        "transit_geo": "#fca5a5",
+        "aspect": "#c084fc",
+        "text": "#e2e8f0",
+        "zodiac": "#475569",
+    },
+}
+
+_ZODIAC_LABELS: Sequence[str] = (
+    "Aries",
+    "Taurus",
+    "Gemini",
+    "Cancer",
+    "Leo",
+    "Virgo",
+    "Libra",
+    "Scorpio",
+    "Sagittarius",
+    "Capricorn",
+    "Aquarius",
+    "Pisces",
+)
+
+_BODY_GLYPHS: Mapping[str, str] = {
+    "sun": "☉",
+    "moon": "☽",
+    "mercury": "☿",
+    "venus": "♀",
+    "mars": "♂",
+    "jupiter": "♃",
+    "saturn": "♄",
+    "uranus": "♅",
+    "neptune": "♆",
+    "pluto": "♇",
+    "mean_node": "☊",
+    "true_node": "☊",
+    "south_node": "☋",
+    "asc": "Asc",
+    "mc": "MC",
+    "chiron": "⚷",
+}
+
+
+def render_overlay_svg(
+    result: TransitOverlayResult,
+    aspects: Sequence[AspectHit] | None = None,
+    *,
+    width: int = 900,
+    height: int = 900,
+    theme: str = "light",
+) -> str:
+    """Return an SVG string representing ``result``."""
+
+    palette = _THEMES.get(theme, _THEMES["light"])
+    doc = SvgDocument(
+        width=width,
+        height=height,
+        viewbox=(0.0, 0.0, float(width), float(height)),
+        background=palette["background"],
+        metadata={
+            "natal_timestamp": result.natal.timestamp.isoformat(),
+            "transit_timestamp": result.transit.timestamp.isoformat(),
+            "theme": theme,
+        },
+    )
+    cx = width / 2.0
+    cy = height / 2.0
+
+    orbit_radii = _collect_orbit_radii(result)
+    max_orbit = orbit_radii[-1] if orbit_radii else 200.0
+    geoc_radius = max_orbit + 90.0
+    zodiac_radius = geoc_radius + 28.0
+
+    for radius in orbit_radii:
+        doc.circle(cx, cy, radius, stroke=palette["orbit"], fill="none", stroke_width=1.2, opacity=0.8)
+
+    _draw_heliocentric(doc, result.natal.heliocentric, cx, cy, palette["natal_helio"], solid=True)
+    _draw_heliocentric(doc, result.transit.heliocentric, cx, cy, palette["transit_helio"], solid=False)
+
+    doc.circle(cx, cy, geoc_radius, stroke=palette["orbit"], fill="none", stroke_width=1.6)
+    _draw_geocentric(doc, result.natal.geocentric, cx, cy, geoc_radius - 6.0, palette["natal_geo"], solid=True)
+    _draw_geocentric(doc, result.transit.geocentric, cx, cy, geoc_radius + 6.0, palette["transit_geo"], solid=False)
+
+    _draw_zodiac(doc, cx, cy, geoc_radius, zodiac_radius, palette)
+    _draw_aspects(doc, aspects or (), result, cx, cy, geoc_radius, palette)
+    _draw_caption(doc, cx, height - 32.0, palette, result)
+    return doc.to_string(pretty=True)
+
+
+def _collect_orbit_radii(result: TransitOverlayResult) -> list[float]:
+    radii: list[float] = []
+    seen: set[float] = set()
+    for frame in (result.natal, result.transit):
+        for state in frame.heliocentric.values():
+            radius_px = round(scale_au(max(state.radius_au, 0.0)), 6)
+            if radius_px not in seen:
+                radii.append(radius_px)
+                seen.add(radius_px)
+    radii.sort()
+    return radii
+
+
+def _draw_heliocentric(
+    doc: SvgDocument,
+    positions: Mapping[str, OverlayBodyState],
+    cx: float,
+    cy: float,
+    color: str,
+    *,
+    solid: bool,
+) -> None:
+    for body, state in positions.items():
+        radius = scale_au(max(state.radius_au, 0.0))
+        x, y = _polar_to_xy(cx, cy, radius, state.lon_deg)
+        label = _format_label(body, state)
+        group = SvgElement("g", {"role": "img"})
+        group.add(SvgElement("title", text=label))
+        if solid:
+            group.add(
+                SvgElement("circle").set(
+                    cx=x,
+                    cy=y,
+                    r=6.0,
+                    fill=color,
+                    stroke="#ffffff",
+                    **{"stroke-width": 1.0},
+                )
+            )
+        else:
+            group.add(
+                SvgElement("circle").set(
+                    cx=x,
+                    cy=y,
+                    r=7.0,
+                    fill="none",
+                    stroke=color,
+                    **{"stroke-width": 2.0},
+                )
+            )
+        doc.add(group)
+
+
+def _draw_geocentric(
+    doc: SvgDocument,
+    positions: Mapping[str, OverlayBodyState],
+    cx: float,
+    cy: float,
+    radius: float,
+    color: str,
+    *,
+    solid: bool,
+) -> None:
+    for body, state in positions.items():
+        x, y = _polar_to_xy(cx, cy, radius, state.lon_deg)
+        label = _format_label(body, state)
+        glyph = _BODY_GLYPHS.get(body, body.title())
+        group = SvgElement("g", {"role": "img"})
+        group.add(SvgElement("title", text=label))
+        if solid:
+            group.add(
+                SvgElement("circle").set(
+                    cx=x,
+                    cy=y,
+                    r=5.0,
+                    fill=color,
+                    stroke="#ffffff",
+                    **{"stroke-width": 1.0},
+                )
+            )
+        else:
+            group.add(
+                SvgElement("circle").set(
+                    cx=x,
+                    cy=y,
+                    r=6.0,
+                    fill="none",
+                    stroke=color,
+                    **{"stroke-width": 1.6},
+                )
+            )
+        group.add(
+            SvgElement("text", text=glyph).set(
+                x=x,
+                y=y + 14.0,
+                fill=color,
+                **{"font-size": 11, "text-anchor": "middle", "dominant-baseline": "middle"},
+            )
+        )
+        doc.add(group)
+
+
+def _draw_zodiac(
+    doc: SvgDocument,
+    cx: float,
+    cy: float,
+    inner_radius: float,
+    outer_radius: float,
+    palette: Mapping[str, str],
+) -> None:
+    tick_group = doc.group(stroke=palette["zodiac"], fill="none", **{"stroke-width": 1.0})
+    for sign, name in enumerate(_ZODIAC_LABELS):
+        angle = sign * 30.0
+        x1, y1 = _polar_to_xy(cx, cy, inner_radius, angle)
+        x2, y2 = _polar_to_xy(cx, cy, outer_radius, angle)
+        tick_group.add(SvgElement("line").set(x1=x1, y1=y1, x2=x2, y2=y2))
+        label_angle = angle + 15.0
+        lx, ly = _polar_to_xy(cx, cy, outer_radius + 20.0, label_angle)
+        doc.text(lx, ly, name, fill=palette["text"], **{"text-anchor": "middle", "font-size": 11})
+
+    doc.add(tick_group)
+
+
+def _draw_aspects(
+    doc: SvgDocument,
+    aspects: Iterable[AspectHit],
+    result: TransitOverlayResult,
+    cx: float,
+    cy: float,
+    base_radius: float,
+    palette: Mapping[str, str],
+) -> None:
+    for hit in aspects:
+        natal_state = result.natal.geocentric.get(hit.body)
+        transit_state = result.transit.geocentric.get(hit.body)
+        if natal_state is None or transit_state is None:
+            continue
+        inner = base_radius - 18.0
+        outer = base_radius + 18.0
+        angle = _midpoint_angle(natal_state.lon_deg, transit_state.lon_deg)
+        x1, y1 = _polar_to_xy(cx, cy, inner, angle)
+        x2, y2 = _polar_to_xy(cx, cy, outer, angle)
+        attrs = {
+            "stroke": palette["aspect"],
+            "stroke-width": 1.6,
+        }
+        if hit.kind.lower().startswith("opp"):
+            attrs["stroke-dasharray"] = "6,4"
+        doc.line(x1, y1, x2, y2, **attrs)
+
+
+def _draw_caption(
+    doc: SvgDocument,
+    cx: float,
+    y: float,
+    palette: Mapping[str, str],
+    result: TransitOverlayResult,
+) -> None:
+    caption = doc.group(fill=palette["text"])
+    caption.add(
+        SvgElement("text", text=(
+            f"Natal: {result.natal.timestamp.isoformat()} • "
+            f"Transit: {result.transit.timestamp.isoformat()}"
+        )).set(x=cx, y=y, **{"text-anchor": "middle", "font-size": 14})
+    )
+    doc.add(caption)
+
+
+def _format_label(body: str, state: OverlayBodyState) -> str:
+    deg = state.lon_deg % 360.0
+    d = int(deg)
+    minutes = int(round((deg - d) * 60.0))
+    if minutes == 60:
+        d = (d + 1) % 360
+        minutes = 0
+    retro = " R" if state.retrograde else ""
+    return f"{body} {d:03d}°{minutes:02d}′ • {state.frame}{retro}"
+
+
+def _polar_to_xy(cx: float, cy: float, radius: float, lon_deg: float) -> tuple[float, float]:
+    angle_rad = math.radians(lon_deg - 90.0)
+    return (
+        cx + radius * math.cos(angle_rad),
+        cy + radius * math.sin(angle_rad),
+    )
+
+
+def _midpoint_angle(a: float, b: float) -> float:
+    ax = math.cos(math.radians(a))
+    ay = math.sin(math.radians(a))
+    bx = math.cos(math.radians(b))
+    by = math.sin(math.radians(b))
+    mx = ax + bx
+    my = ay + by
+    if mx == 0.0 and my == 0.0:
+        return (a + 180.0) % 360.0
+    return (math.degrees(math.atan2(my, mx)) + 360.0) % 360.0

--- a/tests/test_transit_overlay.py
+++ b/tests/test_transit_overlay.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from astroengine.chart.natal import ChartLocation
+from astroengine.ux.maps.transit_overlay import (
+    OverlayBodyState,
+    OverlayOptions,
+    OverlayRequest,
+    compute_overlay_frames,
+    compute_transit_aspects,
+    render_overlay_svg,
+    scale_au,
+)
+
+
+def _state(body: str, lon: float) -> OverlayBodyState:
+    return OverlayBodyState(
+        id=body,
+        lon_deg=lon,
+        lat_deg=0.0,
+        radius_au=1.0,
+        speed_lon_deg_per_day=0.0,
+        speed_lat_deg_per_day=0.0,
+        speed_radius_au_per_day=0.0,
+        retrograde=False,
+        frame="geocentric",
+        metadata=None,
+    )
+
+
+def test_scale_au_piecewise() -> None:
+    inner = scale_au(0.5)
+    middle = scale_au(2.0)
+    outer = scale_au(10.0)
+    assert inner < middle < outer
+    assert scale_au(0.0) == 0.0
+
+
+def test_compute_transit_aspects_detection() -> None:
+    natal = {"sun": _state("sun", 10.0)}
+    transit = {"sun": _state("sun", 10.4)}
+    hits = compute_transit_aspects(natal, transit)
+    assert hits and hits[0].kind == "conjunction"
+
+    transit["sun"] = _state("sun", 190.0)
+    hits = compute_transit_aspects(natal, transit)
+    assert any(hit.kind == "opposition" for hit in hits)
+
+
+def test_compute_overlay_frames_smoke() -> None:
+    pytest.importorskip("swisseph")
+    request = OverlayRequest(
+        birth_dt=datetime(1990, 1, 1, 12, tzinfo=timezone.utc),
+        birth_location=ChartLocation(latitude=40.7128, longitude=-74.0060),
+        transit_dt=datetime(2024, 3, 20, 12, tzinfo=timezone.utc),
+        bodies=[
+            "sun",
+            "moon",
+            "mercury",
+            "venus",
+            "mars",
+            "jupiter",
+            "saturn",
+            "uranus",
+            "neptune",
+            "pluto",
+            "mean_node",
+            "asc",
+            "mc",
+        ],
+        options=OverlayOptions(),
+    )
+    result = compute_overlay_frames(request)
+    assert "sun" in result.natal.heliocentric
+    assert "sun" in result.transit.geocentric
+    aspects = compute_transit_aspects(result.natal.geocentric, result.transit.geocentric)
+    svg = render_overlay_svg(result, aspects=aspects, width=600, height=600)
+    assert svg.startswith("<svg")


### PR DESCRIPTION
## Summary
- introduce a transit overlay engine with geocentric/heliocentric snapshots, aspect detection, and SVG export utilities
- expose the overlay through dedicated FastAPI schemas/routes and register the channel in the UX module registry
- add regression tests covering scale conversion, aspect detection, and a Swiss Ephemeris backed smoke test

## Testing
- pytest tests/test_transit_overlay.py

------
https://chatgpt.com/codex/tasks/task_e_68df1b9e48808324bfccadfc8a561730