### PR TITLE
Add production Dockerfile with extras and dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+*.swp
+*.log
+.cache
+.venv
+.env
+build/
+dist/
+.eggs/
+.pytest_cache/
+.mypy_cache/
+**/.ruff_cache/
+**/.pytest_cache/
+.git
+.gitignore
+# eph/  # uncomment if you mount these externally instead of COPY

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,32 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential curl ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY . /app
+COPY pyproject.toml README.md ./
+COPY astroengine ./astroengine
+COPY app ./app
 
-RUN pip install --no-cache-dir -U pip \
-    && pip install -e . \
-    && pip install uvicorn
+# Install with API+provider extras
+RUN pip install -U pip && \
+    pip install ".[api,providers]" "uvicorn[standard]"
+
+# Optional: ship Swiss ephemeris files in-image
+# COPY eph/ /opt/eph/
+# ENV SE_EPHE_PATH=/opt/eph
+
+# Non-root user
+RUN useradd -r -u 10001 astro && chown -R astro:astro /app
+USER astro
 
 EXPOSE 8000
-ENV DATABASE_URL=sqlite:///./dev.db
+HEALTHCHECK --interval=30s --timeout=3s --retries=3 \
+  CMD curl -fsS http://127.0.0.1:8000/health/plus || exit 1
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]


### PR DESCRIPTION
## Summary
- update the Dockerfile to install the API/provider extras, run as a non-root user, and define a healthcheck
- add a .dockerignore to keep unnecessary files out of Docker build contexts

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e2accd4cac8324a1fc60dd2a4c50cf