### PR TITLE
Tighten CORS defaults outside development

### DIFF
--- a/app/observability.py
+++ b/app/observability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from time import perf_counter
 from typing import Callable
 from uuid import uuid4
@@ -97,9 +98,11 @@ def configure_observability(app: FastAPI) -> None:
     """Install middleware and the /metrics endpoint."""
 
     app.add_middleware(GZipMiddleware)
+    environment = os.getenv("ENV", "dev")
+    allow_origins = ["*"] if environment == "dev" else []
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=allow_origins,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/app/relationship_api/config.py
+++ b/app/relationship_api/config.py
@@ -12,6 +12,7 @@ class ServiceSettings:
     """Container for environment-derived settings."""
 
     cors_allow_origins: tuple[str, ...] = field(default_factory=tuple)
+    environment: str = "dev"
     rate_limit_per_minute: int = 60
     redis_url: str | None = None
     gzip_minimum_size: int = 512
@@ -31,6 +32,7 @@ class ServiceSettings:
         gzip_min_size = int(os.getenv("RELATIONSHIP_GZIP_MIN", "512"))
         request_max = int(os.getenv("RELATIONSHIP_REQUEST_MAX", "1000000"))
         enable_etag = os.getenv("RELATIONSHIP_DISABLE_ETAG") not in {"1", "true", "TRUE"}
+        environment = os.getenv("ENV", "dev")
         return cls(
             cors_allow_origins=_parse_origins(os.getenv("CORS_ALLOW_ORIGINS")),
             rate_limit_per_minute=max(1, rate_limit),
@@ -38,12 +40,15 @@ class ServiceSettings:
             gzip_minimum_size=max(128, gzip_min_size),
             request_max_bytes=max(32_768, request_max),
             enable_etag=enable_etag,
+            environment=environment,
         )
 
     def cors_origin_list(self) -> Iterable[str]:
         if self.cors_allow_origins:
             return self.cors_allow_origins
-        return ("*",)
+        if self.environment == "dev":
+            return ("*",)
+        return tuple()
 
 
 __all__ = ["ServiceSettings"]


### PR DESCRIPTION
## Summary
- limit default CORS wildcarding in the observability middleware to development environments
- persist the current environment in relationship service settings so production defaults require explicit origins

## Testing
- pytest *(fails: requires `swisseph` dependency that is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2acedc0588324a0568ca58edd7a86