### PR TITLE
Respect proxy trust flag for client identity

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import os
+
 from typing import Awaitable, Callable
 
 from fastapi import FastAPI, Request
@@ -37,6 +39,13 @@ app.include_router(lots_router)
 app.include_router(relationship_router)
 app.include_router(interpret_router)
 app.include_router(reports_router)
+
+
+@app.on_event("startup")
+def _init_singletons() -> None:
+    """Initialize application-wide state on startup."""
+
+    app.state.trust_proxy = os.getenv("TRUST_PROXY", "0").lower() in {"1", "true", "yes"}
 
 
 @app.middleware("http")


### PR DESCRIPTION
## Summary
- gate use of X-Forwarded-For and X-Real-IP headers on a new trust_proxy flag
- default FastAPI startup to honor the TRUST_PROXY environment variable when populating app state

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*


------
https://chatgpt.com/codex/tasks/task_e_68e2ad320e188324a54033dab7bfe5af