### PR TITLE
Clarify version fallback for editable installs

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -7,11 +7,22 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 try:
-    from importlib.metadata import version as _get_version
+    from importlib.metadata import PackageNotFoundError, version as _get_version
+except ImportError:  # pragma: no cover - fallback for Python <3.8 environments
+    from importlib_metadata import PackageNotFoundError, version as _get_version
 
+try:
     __version__ = _get_version("astroengine")
-except Exception:  # pragma: no cover - metadata may be unavailable in editable installs
-    __version__ = "0.0.0.dev"
+except PackageNotFoundError:  # pragma: no cover - metadata may be unavailable in editable installs
+    # When running from source without installed metadata (e.g., editable installs),
+    # surface an explicit unknown version to avoid implying a prerelease build.
+    __version__ = "0+unknown"
+
+
+def get_version() -> str:
+    """Return the resolved AstroEngine package version."""
+
+    return __version__
 
 
 from .atlas.tz import (  # noqa: F401


### PR DESCRIPTION
## Summary
- ensure `astroengine.__version__` reports `0+unknown` when package metadata is unavailable
- add a `get_version` helper for consumers needing the resolved version string

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2adda77e48324b1a22169643457bf