### PR TITLE
Add permissions policy and cache defaults to FastAPI middleware

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,11 @@ async def security_headers(
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
     response.headers.setdefault("X-Frame-Options", "DENY")
     response.headers.setdefault("Referrer-Policy", "no-referrer")
+    response.headers.setdefault(
+        "Permissions-Policy", "geolocation=(), microphone=()"
+    )
+    if request.method == "GET":
+        response.headers.setdefault("Cache-Control", "public, max-age=60")
     return response
 
 


### PR DESCRIPTION
## Summary
- extend the security header middleware to include a permissions policy and light caching for GET responses

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ae0367888324ab17f05682406aee