### PR TITLE
Standardize 429 rate limit responses

### DIFF
--- a/app/relationship_api/middleware.py
+++ b/app/relationship_api/middleware.py
@@ -76,8 +76,8 @@ class RequestContextMiddleware(BaseHTTPMiddleware):
             }
             if not result.allowed:
                 adapter.warning("rate.limit.exceeded", extra={"path": request.url.path})
-                payload = ApiError(code="RATE_LIMIT", message="Rate limit exceeded").model_dump()
-                headers = {"Retry-After": str(result.reset_seconds)}
+                payload = ApiError(code="rate_limited", message="Too many requests").model_dump()
+                headers = {"Retry-After": str(int(result.reset_seconds))}
                 headers.update(rate_headers)
                 headers["X-Request-ID"] = request_id
                 return JSONResponse(status_code=429, content=payload, headers=headers)

--- a/app/relationship_api/routes.py
+++ b/app/relationship_api/routes.py
@@ -64,6 +64,12 @@ def register_routes(app: FastAPI, settings: ServiceSettings) -> None:
         "/relationship/synastry",
         response_model=SynastryResponse,
         summary="Synastry hits, grid, overlay, and scores",
+        responses={
+            429: {
+                "model": ApiError,
+                "description": "Rate limited. Back off and retry after the number of seconds in the Retry-After header.",
+            }
+        },
     )
     async def synastry_endpoint(request: Request, response: Response, payload: SynastryRequest) -> SynastryResponse:
         logger = getattr(request.state, "logger", get_logger())
@@ -82,6 +88,12 @@ def register_routes(app: FastAPI, settings: ServiceSettings) -> None:
         "/relationship/composite",
         response_model=CompositeResponse,
         summary="Composite midpoint positions",
+        responses={
+            429: {
+                "model": ApiError,
+                "description": "Rate limited. Back off and retry after the number of seconds in the Retry-After header.",
+            }
+        },
     )
     async def composite_endpoint(request: Request, response: Response, payload: CompositeRequest) -> CompositeResponse:
         logger = getattr(request.state, "logger", get_logger())
@@ -99,6 +111,12 @@ def register_routes(app: FastAPI, settings: ServiceSettings) -> None:
         "/relationship/davison",
         response_model=DavisonResponse,
         summary="Davison midpoints and positions",
+        responses={
+            429: {
+                "model": ApiError,
+                "description": "Rate limited. Back off and retry after the number of seconds in the Retry-After header.",
+            }
+        },
     )
     async def davison_endpoint(request: Request, payload: DavisonRequest) -> DavisonResponse:
         logger = getattr(request.state, "logger", get_logger())


### PR DESCRIPTION
## Summary
- return a consistent ApiError payload for rate-limited requests and ensure Retry-After is an integer value
- document the 429 rate-limit schema on relationship API endpoints for accurate OpenAPI metadata

## Testing
- `pytest` *(fails: missing optional dependency `swisseph` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ae287edc8324ad1b2c1b43ea8d5a