### PR TITLE
Add security audits to pre-commit and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,15 @@ jobs:
       - name: Install lint dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev.txt bandit pip-audit
       - name: Lint (Ruff)
         run: ruff check --output-format=github .
       - name: Format check (Black)
         run: black --check .
+      - name: Security scan (Bandit)
+        run: bandit -q -r astroengine app
+      - name: Dependency audit (pip-audit)
+        run: pip-audit --require-hashes=false
       - name: Type check
         run: |
           pip install mypy pydantic

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,11 +12,24 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
+  - repo: https://github.com/pycqa/ruff-pre-commit
     rev: v0.6.9
     hooks:
       - id: ruff
         args: ["--fix"]
+      - id: ruff-format
+        types_or: [python]
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.9
+    hooks:
+      - id: bandit
+        args: ["-q", "-r", "astroengine", "app"]
+        exclude: ^tests/
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.7.3
+    hooks:
+      - id: pip-audit
+        args: ["--require-hashes=false"]
   - repo: local
     hooks:
       - id: validate-fences

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,0 +1,3 @@
+# Minimal Bandit configuration; expand as security policies evolve.
+skips:
+  - B101


### PR DESCRIPTION
## Summary
- add Bandit and pip-audit hooks to the pre-commit suite alongside Ruff formatting support
- provide a baseline Bandit configuration to allow asserts while we iterate on policy
- extend the CI lint job to install and execute Bandit and pip-audit checks

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ae7c890c83248eaba52aa45163e8