### PR TITLE
Add slots to high-volume ephemeris dataclasses

### DIFF
--- a/astroengine/core/common/cache.py
+++ b/astroengine/core/common/cache.py
@@ -9,7 +9,7 @@ K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
 
 
-@dataclass
+@dataclass(slots=True)
 class _Entry(Generic[V]):
     value: V
     expires_at: float

--- a/astroengine/ephemeris/adapter.py
+++ b/astroengine/ephemeris/adapter.py
@@ -57,7 +57,7 @@ __all__ = [
 LOG = logging.getLogger(__name__)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EphemerisConfig:
     """Ephemeris configuration passed to :class:`EphemerisAdapter`."""
 
@@ -71,7 +71,7 @@ class EphemerisConfig:
     sidereal_mode: str | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class TimeScaleContext:
     """Describe the input/output time scales used by the adapter."""
 
@@ -94,7 +94,7 @@ class TimeScaleContext:
         return f"{self.input_scale}→{self.ephemeris_scale}"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class ObserverLocation:
     """Observer location used when topocentric calculations are requested."""
 
@@ -106,7 +106,7 @@ class ObserverLocation:
         return (self.longitude_deg, self.latitude_deg, self.elevation_m)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EphemerisSample:
     """Ephemeris sample returned by :class:`EphemerisAdapter`."""
 

--- a/astroengine/ephemeris/refinement.py
+++ b/astroengine/ephemeris/refinement.py
@@ -16,7 +16,7 @@ __all__ = [
 SECONDS_PER_DAY: float = 86_400.0
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RefineResult:
     """Result metadata returned by :func:`refine_root` and :func:`refine_event`.
 

--- a/astroengine/ephemeris/support.py
+++ b/astroengine/ephemeris/support.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from typing import Iterable, List
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SupportIssue:
     """Represents an unsupported body probe against a provider."""
 

--- a/astroengine/ephemeris/swisseph_adapter.py
+++ b/astroengine/ephemeris/swisseph_adapter.py
@@ -139,7 +139,7 @@ def _rise_transit_events() -> Mapping[str, int]:
     }
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class BodyPosition:
     """Structured ephemeris output for a single body."""
 
@@ -155,7 +155,7 @@ class BodyPosition:
     speed_declination: float
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class EquatorialPosition:
     """Right ascension and declination details for a body."""
 
@@ -165,7 +165,7 @@ class EquatorialPosition:
     speed_declination: float
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SolarCycleEvents:
     """Sunrise, sunset, and transit metadata for a single day."""
 
@@ -188,7 +188,7 @@ class SolarCycleEvents:
         return payload
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class VariantConfig:
     """Per-run variant selection for lunar nodes and Black Moon Lilith."""
 
@@ -202,7 +202,7 @@ class VariantConfig:
         return "true" if self.lilith_variant.lower() == "true" else "mean"
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class HousePositions:
     """Container for house cusps, angles, and provenance metadata."""
 
@@ -240,7 +240,7 @@ class HousePositions:
         return payload
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class FixedStarPosition:
     """Computed coordinates for a fixed star via Swiss Ephemeris."""
 
@@ -256,7 +256,7 @@ class FixedStarPosition:
     computation_flags: int
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class RiseTransitResult:
     """Rise/set/transit metadata returned by Swiss Ephemeris."""
 


### PR DESCRIPTION
## Summary
- enable slots on the ephemeris adapter configuration, samples, and supporting structs to lower per-instance overhead
- apply slots to Swiss ephemeris value objects and cache entries that are created in tight loops
- update refinement and support dataclasses to benefit from the same memory and attribute access optimizations

## Testing
- ruff check . *(fails: pre-existing lint violations in unrelated Streamlit UI modules)*
- pytest -q *(fails: missing optional `swisseph` dependency required by the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e2afc588588324ab88050a696aa523