### PR TITLE
Expose accuracy budget controls for transit scanning

### DIFF
--- a/astroengine/api/routers/scan.py
+++ b/astroengine/api/routers/scan.py
@@ -93,6 +93,12 @@ class TransitScanRequest(TimeWindow):
     aspects: Sequence[Any] | None = None
     orb: float = Field(default=1.0, ge=0.0, description="Maximum aspect orb in degrees")
     step_days: float = Field(default=1.0, gt=0.0)
+    accuracy_budget: Literal["fast", "default", "high"] = Field(
+        default="default",
+        description=(
+            "Trade precision for speed ('fast') or quality ('high')."
+        ),
+    )
     export: ExportOptions | None = None
 
     model_config = ConfigDict(extra="ignore")
@@ -455,6 +461,7 @@ def api_scan_transits(
             bodies=request.bodies,
             targets=request.targets,
             step_days=request.step_days,
+            accuracy_budget=request.accuracy_budget,
         )
     ]
 

--- a/astroengine/app_api.py
+++ b/astroengine/app_api.py
@@ -138,6 +138,7 @@ def _filter_kwargs_for(fn, proposed: dict[str, Any]) -> dict[str, Any]:
         "ayanamsha": ["ayanamsha", "ayanamsa", "sidereal_ayanamsha"],
         "detectors": ["detectors", "detector_flags", "features", "feature_flags"],
         "target_frames": ["target_frames", "target_frame", "frames", "target_contexts"],
+        "accuracy_budget": ["accuracy"],
     }
 
     final: dict[str, Any] = {}
@@ -241,6 +242,7 @@ def run_scan_or_raise(
     ayanamsha: str | None = None,
     entrypoints: Iterable[ScanSpec] | None = None,
     return_used_entrypoint: bool = False,
+    accuracy_budget: str | None = None,
     zodiac: str | None = None,
 ) -> list[dict[str, Any]] | tuple[list[dict[str, Any]], ScanCandidate]:
     """
@@ -284,6 +286,8 @@ def run_scan_or_raise(
             optional_kwargs["sidereal"] = bool(sidereal)
         if ayanamsha:
             optional_kwargs["ayanamsha"] = ayanamsha
+        if accuracy_budget:
+            optional_kwargs["accuracy_budget"] = accuracy_budget
         kwargs.update(optional_kwargs)
         call_kwargs = _filter_kwargs_for(fn, kwargs)
         try:

--- a/astroengine/cli.py
+++ b/astroengine/cli.py
@@ -1522,14 +1522,15 @@ def cmd_transits(args: argparse.Namespace) -> int:
             "parameters": {
                 "start_timestamp": args.start,
                 "end_timestamp": args.end,
-                "moving": args.moving,
-                "target": args.target,
-                "provider": args.provider,
-                "target_longitude": args.target_longitude,
-                "target_frame": args.target_frame,
-            },
-            "events": events_to_dicts(events),
-        }
+            "moving": args.moving,
+            "target": args.target,
+            "provider": args.provider,
+            "target_longitude": args.target_longitude,
+            "target_frame": args.target_frame,
+            "accuracy_budget": args.accuracy,
+        },
+        "events": events_to_dicts(events),
+    }
         if narrative_bundle is not None:
             payload["narrative"] = narrative_bundle.to_dict()
         Path(args.json).write_text(json.dumps(payload, indent=2), encoding="utf-8")
@@ -1615,6 +1616,7 @@ def cmd_scan(args: argparse.Namespace) -> int:
             sidereal=args.sidereal if args.sidereal is not None else None,
             ayanamsha=args.ayanamsha or None,
             entrypoints=entrypoints or None,
+            accuracy_budget=args.accuracy,
             return_used_entrypoint=True,
         )
     except RuntimeError as exc:  # pragma: no cover - exercised in integration tests
@@ -2366,6 +2368,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=60,
         help="Sampling cadence in minutes (default: %(default)s)",
+    )
+    scan.add_argument(
+        "--accuracy",
+        choices=["fast", "default", "high"],
+        default="default",
+        help="Accuracy budget to trade precision for speed (default: %(default)s)",
     )
     scan.add_argument("--export-json", help="Write canonical events to a JSON file")
     scan.add_argument("--export-sqlite", help="Write canonical events to a SQLite file")

--- a/astroengine/core/accuracy.py
+++ b/astroengine/core/accuracy.py
@@ -1,0 +1,30 @@
+"""Accuracy profiles governing scan precision/performance trade-offs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(slots=True, frozen=True)
+class AccuracyProfile:
+    """Parameters describing a precision budget for scan routines."""
+
+    tol_arcsec: float
+    """Target refinement tolerance expressed in arcseconds."""
+
+    max_iter: int
+    """Maximum refinement iterations to attempt."""
+
+    coarse_step_sec: float
+    """Baseline coarse sampling cadence expressed in seconds."""
+
+
+ACCURACY_PROFILES: dict[Literal["fast", "default", "high"], AccuracyProfile] = {
+    "fast": AccuracyProfile(tol_arcsec=0.5, max_iter=4, coarse_step_sec=120.0),
+    "default": AccuracyProfile(tol_arcsec=0.2, max_iter=8, coarse_step_sec=60.0),
+    "high": AccuracyProfile(tol_arcsec=0.05, max_iter=16, coarse_step_sec=30.0),
+}
+
+
+__all__ = ["AccuracyProfile", "ACCURACY_PROFILES"]

--- a/tests/test_accuracy_budget.py
+++ b/tests/test_accuracy_budget.py
@@ -1,0 +1,119 @@
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+if "swisseph" not in sys.modules:
+    class _StubSwiss(types.ModuleType):
+        def __getattr__(self, name: str):
+            if name == "julday":
+                return lambda *args, **kwargs: 0.0
+            if name == "revjul":
+                return lambda *args, **kwargs: (2000, 1, 1, 0.0)
+            if name.startswith("calc"):
+                return lambda *args, **kwargs: (0.0, 0.0, 0.0)
+            if name.startswith("set_"):
+                return lambda *args, **kwargs: None
+            if name.isupper():
+                return 0
+            raise AttributeError(name)
+
+    sys.modules["swisseph"] = _StubSwiss("swisseph")
+
+from astroengine.core.accuracy import ACCURACY_PROFILES
+import astroengine.core.transit_engine as transit_engine
+
+
+@pytest.fixture
+def stub_adapter(monkeypatch):
+    adapter = SimpleNamespace(
+        julian_day=lambda dt: 0.0,
+        body_position=lambda jd, body_code, body_name="": SimpleNamespace(longitude=0.0),
+    )
+    monkeypatch.setattr(
+        transit_engine.SwissEphemerisAdapter,
+        "get_default_adapter",
+        classmethod(lambda cls: adapter),
+    )
+    return adapter
+
+
+def test_scan_transits_applies_accuracy_profile(monkeypatch, stub_adapter):
+    captured: dict[str, object] = {}
+
+    class FakeTransitEngine:
+        def __init__(self, adapter, config):
+            self.adapter = adapter
+            self._config = config
+
+        @classmethod
+        def with_default_adapter(cls, config=None, *, engine_config=None):
+            captured["config"] = engine_config
+            return cls(stub_adapter, engine_config)
+
+        def scan_longitude_crossing(self, *args, step_hours=None, **kwargs):
+            captured.setdefault("step_hours", []).append(step_hours)
+            return []
+
+    monkeypatch.setattr(transit_engine, "TransitEngine", FakeTransitEngine)
+
+    result = transit_engine.scan_transits(
+        natal_ts="2000-01-01T00:00:00Z",
+        start_ts="2000-01-02T00:00:00Z",
+        end_ts="2000-01-03T00:00:00Z",
+        bodies=["Sun"],
+        targets=["Sun"],
+        aspects=["conjunction"],
+        step_days=1.0,
+        accuracy_budget="high",
+    )
+
+    assert result == []
+    config = captured["config"]
+    profile = ACCURACY_PROFILES["high"]
+    default_profile = ACCURACY_PROFILES["default"]
+    assert config.accurate_iterations == profile.max_iter
+    expected_min_step = transit_engine.TransitEngineConfig().accurate_min_step_seconds * (
+        profile.tol_arcsec / default_profile.tol_arcsec
+    )
+    assert pytest.approx(config.accurate_min_step_seconds, rel=1e-6) == expected_min_step
+    expected_step_hours = 24.0 * (profile.coarse_step_sec / default_profile.coarse_step_sec)
+    assert pytest.approx(captured["step_hours"][0], rel=1e-6) == expected_step_hours
+
+
+def test_run_scan_or_raise_threads_accuracy(monkeypatch):
+    from astroengine import app_api
+
+    called: dict[str, object] = {}
+
+    class FakeModule(types.SimpleNamespace):
+        pass
+
+    def fake_import(name):
+        module = FakeModule()
+
+        def _scan(*, accuracy_budget=None, **kwargs):
+            called.update(kwargs)
+            called["accuracy_budget"] = accuracy_budget
+            return [kwargs]
+
+        module.scan = _scan
+        return module
+
+    monkeypatch.setattr(app_api.importlib, "import_module", fake_import)
+
+    events = app_api.run_scan_or_raise(
+        start_utc="2000-01-01T00:00:00Z",
+        end_utc="2000-01-02T00:00:00Z",
+        moving=["Sun"],
+        targets=["Sun"],
+        provider=None,
+        profile_id=None,
+        step_minutes=60,
+        entrypoints=[("fake", "scan")],
+        accuracy_budget="fast",
+    )
+
+    assert events
+    assert called["accuracy_budget"] == "fast"


### PR DESCRIPTION
## Summary
- add reusable accuracy profiles for transit scans and apply them in the core transit engine
- thread an accuracy_budget option through the API, CLI, and legacy scan_contacts entry point
- cover the new threading and scaling logic with focused tests

## Testing
- pytest tests/test_accuracy_budget.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b05abe4c8324a84c3a15b7a7a440