### PR TITLE
Document prerequisite checks for env setup

### DIFF
--- a/docs/ENV_SETUP.md
+++ b/docs/ENV_SETUP.md
@@ -4,6 +4,19 @@ The project now relies on plain Python virtual environments and no longer
 requires Conda/Mamba tooling.  Use the steps below to create an isolated
 runtime and verify the interpreter health.
 
+## 0) Confirm platform prerequisites
+
+Before creating the virtual environment, ensure the host system provides the
+tools AstroEngine expects during development:
+
+- **Python 3.11.x** — verify with `python3.11 --version` to confirm the
+  interpreter matches the supported series.
+- **Git 2.30+** — required for cloning the repository and managing updates.
+- **Build toolchain** — install `build-essential` on Linux or the Xcode
+  Command Line Tools on macOS so native extensions compile without issues.
+
+With the prerequisites in place, proceed to the virtual environment setup.
+
 ## 1) Create and activate a virtual environment
 
 ```bash


### PR DESCRIPTION
## Summary
- add a prerequisite checklist to the environment setup guide covering Python 3.11, Git, and native build tools
- clarify that confirming these dependencies should precede virtual environment creation

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2b7fcd1208324a9a75f52a1058a55