### PR TITLE
Add bootstrap script and compose setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: "3.10"
+services:
+  api:
+    build: .
+    command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    environment:
+      PYTHONUNBUFFERED: "1"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/app

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+python -m pip install --upgrade pip
+
+if [[ -f "${PROJECT_ROOT}/requirements.txt" ]]; then
+  pip install -r "${PROJECT_ROOT}/requirements.txt"
+fi
+
+if [[ -f "${PROJECT_ROOT}/requirements-dev.txt" ]]; then
+  pip install -r "${PROJECT_ROOT}/requirements-dev.txt"
+fi
+
+if [[ -f "${PROJECT_ROOT}/pyproject.toml" ]] || [[ -f "${PROJECT_ROOT}/setup.py" ]]; then
+  pip install -e "${PROJECT_ROOT}" || true
+fi
+


### PR DESCRIPTION
## Summary
- add a bootstrap helper script that upgrades pip, installs requirements, and installs the package in editable mode when available
- add a docker compose definition for running the FastAPI service with live reload

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b803301083248ce5a00916802154