### PR TITLE
Add guardrail GitHub Actions workflow

### DIFF
--- a/.github/workflows/phase7-ci-guardrails.yml
+++ b/.github/workflows/phase7-ci-guardrails.yml
@@ -1,0 +1,52 @@
+name: Phase 7 CI Guardrails
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  guardrails:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+
+      - name: Prepare environment
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install black
+          if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+
+      - name: Prepare ephemeris dataset
+        run: |
+          mkdir -p "$HOME/.astroengine/ephemeris"
+          cp -a datasets/swisseph_stub/. "$HOME/.astroengine/ephemeris/" 2>/dev/null || true
+          echo "SE_EPHE_PATH=$HOME/.astroengine/ephemeris" >> "$GITHUB_ENV"
+
+      - name: Byte-compile sources
+        run: |
+          python -m compileall astroengine tests
+
+      - name: Lint
+        run: |
+          ruff check .
+          black --check .
+
+      - name: Static type checks (best effort)
+        continue-on-error: true
+        run: |
+          mypy --config-file mypy.ini .
+
+      - name: Run tests
+        run: |
+          python scripts/install_test_dependencies.py --quiet
+          pytest -q


### PR DESCRIPTION
## Summary
- add a dedicated Phase 7 CI Guardrails workflow that runs on pushes to main and pull requests
- ensure the workflow installs project dependencies, prepares the ephemeris dataset, and executes compileall, lint, mypy, and pytest checks

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b82948e08324871ce2d696ae7dea