### PR TITLE
Add troubleshooting quick fixes runbook

### DIFF
--- a/docs/runbook/oncall.md
+++ b/docs/runbook/oncall.md
@@ -5,6 +5,7 @@
 - PagerDuty: https://pagerduty.com/astroengine
 - Grafana Dashboards: https://grafana.astroengine.com
 - Incident Doc Template: https://docs.astroengine.com/incidents/template
+- [Troubleshooting Quick Fixes](troubleshooting.md)
 
 ## Triage Checklist
 

--- a/docs/runbook/troubleshooting.md
+++ b/docs/runbook/troubleshooting.md
@@ -1,0 +1,14 @@
+# Troubleshooting Quick Fixes
+
+This reference summarizes the fastest path to resolve high-frequency issues reported by the on-call rotation. Each fix should be applied only after confirming the associated error message in logs or terminal output.
+
+| Symptom | Immediate Fix |
+| --- | --- |
+| `ModuleNotFoundError: alembic` | Install the migration dependency and apply the latest head: `pip install alembic && alembic upgrade head`. |
+| `ModuleNotFoundError: pyswisseph` or build failures on Python 3.12 | Switch to Python 3.11 (our supported runtime) and install the Swiss Ephemeris bindings: `pyenv local 3.11 && pip install pyswisseph`. |
+| `OSError: sweph not found` | Export `SE_EPHE_PATH` to point to the directory that contains the Swiss Ephemeris data files before running the engine. |
+| `sqlite3.OperationalError: database is locked` | Confirm there is only one writer, enable WAL mode if disabled, and retry the job with exponential backoff. |
+| `Address already in use :8000` | Terminate the existing process bound to port 8000 or restart the service on an alternate port such as `--port 8001`. |
+| `ImportError: app.main` | Set the `APP_MODULE` environment variable to the fully qualified module path (for example, `app.main:app`). |
+
+For longer-term remediation, add notes to the incident retrospective and update automation so the underlying issue cannot recur silently.


### PR DESCRIPTION
## Summary
- add a runbook page documenting quick fixes for frequent operational errors
- link the new checklist from the on-call quick links section

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2b834f59883248dd2d65b4e5cd12c