### PR TITLE
Remove duplicate PyYAML dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ dependencies = [
   "python-dateutil>=2.8",
   "pydantic>=2.11,<3",
 
-  "PyYAML>=6.0",
-
   "jsonschema>=4.21",
   "PyYAML>=6.0",
   "requests>=2.31",


### PR DESCRIPTION
## Summary
- remove the duplicated PyYAML requirement from the core dependency list to avoid resolver confusion

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2bbb28a3c8324af6a04ea464b056d