### PR TITLE
Defer heavy CLI and SQLite migrator dependencies

### DIFF
--- a/astroengine/cli/__init__.py
+++ b/astroengine/cli/__init__.py
@@ -4,9 +4,23 @@ from __future__ import annotations
 
 import json as _json
 
-from .__main__ import build_parser, main
-
 json = _json
+
+
+def build_parser():
+    """Lazily import the CLI parser builder to avoid early heavy dependencies."""
+
+    from .__main__ import build_parser as _build
+
+    return _build()
+
+
+def main(argv=None):
+    """Lazily import the CLI entrypoint to defer optional dependency loading."""
+
+    from .__main__ import main as _main
+
+    return _main(argv)
 
 
 def console_main() -> None:


### PR DESCRIPTION
## Summary
- lazily import the CLI entrypoints so importing `astroengine.cli` no longer loads the legacy CLI stack
- defer Alembic imports in the SQLite migrator to the functions that require them while keeping type hints available for tooling

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2bbbcc3ac8324bafb26824a7d1490