### PR TITLE
Document Streamlit shim usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ channel, and subchannel remains intact and data-backed:
    streamlit run apps/streamlit_transit_scanner.py
    ```
 
+   > **Heads-up:** the repository ships a ``streamlit/`` testing shim for
+   > unit suites. Always start UI scripts with ``streamlit run`` rather than
+   > ``python`` so the real Streamlit package loads before the shim.
+
 * **Scan Transits**: choose provider/time window/bodies/targets; optionally pin an entrypoint; previews canonical events and exports to SQLite/Parquet.
 * **Swiss Smoketest**: runs `scripts/swe_smoketest.py` to validate Swiss setup.
 * The sidebar lists detected scan entrypoints and environment overrides; install `pandas` for the tabular preview.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -94,6 +94,10 @@ pip install -e .[ui]
 streamlit run apps/streamlit_transit_scanner.py
 ```
 
+> **Tip:** a ``streamlit/`` testing shim exists for unit exercises. Launch UI
+> scripts with ``streamlit run`` rather than invoking them with ``python`` so the
+> real Streamlit package is imported first.
+
 If you installed AstroEngine with the ``streamlit`` extra you can also launch
 the Aspect Search dashboard directly:
 


### PR DESCRIPTION
## Summary
- document the repository's local Streamlit shim in the README
- note in the quickstart guide that UI scripts should be launched with `streamlit run`

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2bbcea1a88324aa878063511807d3