### PR TITLE
docs: clarify DATABASE_URL usage for db workflows

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -3,6 +3,19 @@
 - **SE_EPHE_PATH** (canonical) — directory containing Swiss Ephemeris data files.
 - **SWE_EPH_PATH** (alias) — accepted for compatibility.
 
+## Database connections
+- **DATABASE_URL** — SQLAlchemy connection string consumed by the FastAPI app
+  (`app/db/session.py`) and Alembic migrations (`alembic.ini`). Export this
+  before running `uvicorn`, `python -m app.*`, or any `alembic` command:
+
+  ```bash
+  export DATABASE_URL="sqlite:///./dev.db"  # swap in your Postgres URL when needed
+  ```
+
+  The helpers do not read `DB_URL`; ensure automation and developer machines
+  consistently set `DATABASE_URL` so the API and migration stack point at the
+  same datastore.
+
 ## Skyfield kernels
 Searched in: `./kernels`, `~/.skyfield`, `~/.astroengine/kernels`. Use helper
 `astroengine.providers.skyfield_kernels.ensure_kernel(download=True)` to fetch `de440s.bsp`.

--- a/docs/runbook/troubleshooting.md
+++ b/docs/runbook/troubleshooting.md
@@ -4,7 +4,7 @@ This reference summarizes the fastest path to resolve high-frequency issues repo
 
 | Symptom | Immediate Fix |
 | --- | --- |
-| `ModuleNotFoundError: alembic` | Install the migration dependency and apply the latest head: `pip install alembic && alembic upgrade head`. |
+| `ModuleNotFoundError: alembic` | Install Alembic, set `DATABASE_URL`, then apply the latest head: `pip install alembic && export DATABASE_URL="sqlite:///./dev.db" && alembic upgrade head`. Replace the SQLite DSN with your staging/production URL as needed. |
 | `ModuleNotFoundError: pyswisseph` or build failures on Python 3.12 | Switch to Python 3.11 (our supported runtime) and install the Swiss Ephemeris bindings: `pyenv local 3.11 && pip install pyswisseph`. |
 | `OSError: sweph not found` | Export `SE_EPHE_PATH` to point to the directory that contains the Swiss Ephemeris data files before running the engine. |
 | `sqlite3.OperationalError: database is locked` | Confirm there is only one writer, enable WAL mode if disabled, and retry the job with exponential backoff. |


### PR DESCRIPTION
## Summary
- document that the API and migration stack rely on the `DATABASE_URL` environment variable
- update the troubleshooting runbook to export `DATABASE_URL` before invoking Alembic

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2bbc542188324ab6e3d01582617b5