### PR TITLE
Fix phase 3 ops pipeline commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,13 @@ help:
 @echo "Targets: setup, install-optional, hooks, fmt, lint, lint-code, test, doctor, clean, deepclean, fullcheck, repair, build"
 
 setup:
-python -m pip install --upgrade pip
-@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
-python -m astroengine.diagnostics --strict || true
+	python -m pip install --upgrade pip
+	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
+	@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+	python -m astroengine.diagnostics --strict || true
 
 install-optional:
-python scripts/install_optional_dependencies.py
+	python scripts/install_optional_dependencies.py
 
 hooks:
 	python -m pip install -U pre-commit
@@ -55,3 +55,12 @@ repair:
 build:
 	python -m astroengine.maint --with-build || true
 # >>> AUTO-GEN END: Makefile v1.2
+
+# Custom operational helpers
+.PHONY: migrate cache-warm
+
+migrate:
+	.venv/bin/alembic upgrade head
+
+cache-warm:
+	python -m astroengine.pipeline.cache_warm

--- a/astroengine/pipeline/cache_warm.py
+++ b/astroengine/pipeline/cache_warm.py
@@ -1,0 +1,70 @@
+"""Operational helper for warming the ephemeris cache used in ops pipelines."""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Sequence
+
+from ..cache.positions_cache import warm_daily
+from ..detectors.common import enable_cache, iso_to_jd
+
+DEFAULT_BODIES: Sequence[str] = (
+    "sun",
+    "moon",
+    "mercury",
+    "venus",
+    "mars",
+    "jupiter",
+    "saturn",
+    "uranus",
+    "neptune",
+    "pluto",
+)
+DEFAULT_WINDOW_DAYS = 7
+
+
+def _ensure_environment() -> Path:
+    """Ensure AstroEngine directories and Swiss ephemeris path are configured."""
+
+    home = Path(os.environ.get("ASTROENGINE_HOME", Path.home() / ".astroengine"))
+    home.mkdir(parents=True, exist_ok=True)
+    os.environ.setdefault("ASTROENGINE_HOME", str(home))
+    os.environ.setdefault("SE_EPHE_PATH", str(Path("datasets/swisseph_stub").resolve()))
+    return home
+
+
+def warm_ephemeris_cache(
+    bodies: Sequence[str] = DEFAULT_BODIES,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+) -> tuple[str, str, int]:
+    """Warm the daily ephemeris cache for ``bodies`` over ``window_days`` days."""
+
+    if window_days < 1:
+        raise ValueError("window_days must be positive")
+
+    _ensure_environment()
+    enable_cache(True)
+
+    start = date.today()
+    end = start + timedelta(days=window_days - 1)
+    start_iso = start.isoformat()
+    end_iso = end.isoformat()
+    entries = warm_daily(bodies, iso_to_jd(start_iso), iso_to_jd(end_iso))
+    return start_iso, end_iso, int(entries)
+
+
+def main() -> int:
+    """CLI entry point used by the Makefile target."""
+
+    start_iso, end_iso, entries = warm_ephemeris_cache()
+    print(
+        f"Cache warmed [{', '.join(DEFAULT_BODIES)}] for {start_iso} "
+        f"→ {end_iso} ({entries} entries)"
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - operational entry point
+    raise SystemExit(main())

--- a/migrations/versions/20241115_0003_scope_indexes.py
+++ b/migrations/versions/20241115_0003_scope_indexes.py
@@ -28,11 +28,11 @@ def upgrade() -> None:
         ["module", "submodule", "channel", "subchannel"],
     )
     op.create_index("ix_orb_policies_created_at", "orb_policies", ["created_at"])
-    op.create_unique_constraint(
-        "uq_orb_policies_scope_name",
-        "orb_policies",
-        ["module", "submodule", "channel", "subchannel", "name"],
-    )
+    with op.batch_alter_table("orb_policies", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_orb_policies_scope_name",
+            ["module", "submodule", "channel", "subchannel", "name"],
+        )
 
     op.create_index(
         "ix_severity_profiles_scope_full",
@@ -55,11 +55,11 @@ def upgrade() -> None:
         "traditional_runs",
         ["created_at"],
     )
-    op.create_unique_constraint(
-        "uq_traditional_runs_scope_run_id",
-        "traditional_runs",
-        ["module", "submodule", "channel", "subchannel", "run_id"],
-    )
+    with op.batch_alter_table("traditional_runs", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_traditional_runs_scope_run_id",
+            ["module", "submodule", "channel", "subchannel", "run_id"],
+        )
 
     op.create_index(
         "ix_charts_scope_full",
@@ -68,11 +68,11 @@ def upgrade() -> None:
     )
     op.create_index("ix_charts_dt_utc", "charts", ["dt_utc"])
     op.create_index("ix_charts_created_at", "charts", ["created_at"])
-    op.create_unique_constraint(
-        "uq_charts_scope_key",
-        "charts",
-        ["module", "submodule", "channel", "subchannel", "chart_key"],
-    )
+    with op.batch_alter_table("charts", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_charts_scope_key",
+            ["module", "submodule", "channel", "subchannel", "chart_key"],
+        )
 
     op.create_index(
         "ix_ruleset_versions_scope_full",
@@ -84,11 +84,11 @@ def upgrade() -> None:
         "ruleset_versions",
         ["created_at"],
     )
-    op.create_unique_constraint(
-        "uq_ruleset_versions_scope_key_version",
-        "ruleset_versions",
-        ["module", "submodule", "channel", "subchannel", "ruleset_key", "version"],
-    )
+    with op.batch_alter_table("ruleset_versions", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_ruleset_versions_scope_key_version",
+            ["module", "submodule", "channel", "subchannel", "ruleset_key", "version"],
+        )
 
     event_time_column = _events_time_column(inspector)
     op.create_index(
@@ -102,11 +102,11 @@ def upgrade() -> None:
         [event_time_column, "module", "channel"],
     )
     op.create_index("ix_events_created_at", "events", ["created_at"])
-    op.create_unique_constraint(
-        "uq_events_scope_key",
-        "events",
-        ["module", "submodule", "channel", "subchannel", "event_key"],
-    )
+    with op.batch_alter_table("events", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_events_scope_key",
+            ["module", "submodule", "channel", "subchannel", "event_key"],
+        )
 
     op.create_index(
         "ix_asteroid_meta_scope_full",
@@ -118,11 +118,11 @@ def upgrade() -> None:
         "asteroid_meta",
         ["created_at"],
     )
-    op.create_unique_constraint(
-        "uq_asteroid_meta_scope_designation",
-        "asteroid_meta",
-        ["module", "submodule", "channel", "subchannel", "designation"],
-    )
+    with op.batch_alter_table("asteroid_meta", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_asteroid_meta_scope_designation",
+            ["module", "submodule", "channel", "subchannel", "designation"],
+        )
 
     op.create_index(
         "ix_export_jobs_scope_full",
@@ -139,50 +139,57 @@ def upgrade() -> None:
         "export_jobs",
         ["completed_at"],
     )
-    op.create_unique_constraint(
-        "uq_export_jobs_scope_key",
-        "export_jobs",
-        ["module", "submodule", "channel", "subchannel", "job_key"],
-    )
+    with op.batch_alter_table("export_jobs", schema=None) as batch:
+        batch.create_unique_constraint(
+            "uq_export_jobs_scope_key",
+            ["module", "submodule", "channel", "subchannel", "job_key"],
+        )
 
 
 def downgrade() -> None:
-    op.drop_constraint("uq_export_jobs_scope_key", "export_jobs", type_="unique")
+    with op.batch_alter_table("export_jobs", schema=None) as batch:
+        batch.drop_constraint("uq_export_jobs_scope_key", type_="unique")
     op.drop_index("ix_export_jobs_completed_at", table_name="export_jobs")
     op.drop_index("ix_export_jobs_requested_at", table_name="export_jobs")
     op.drop_index("ix_export_jobs_scope_full", table_name="export_jobs")
 
-    op.drop_constraint("uq_asteroid_meta_scope_designation", "asteroid_meta", type_="unique")
+    with op.batch_alter_table("asteroid_meta", schema=None) as batch:
+        batch.drop_constraint("uq_asteroid_meta_scope_designation", type_="unique")
     op.drop_index("ix_asteroid_meta_created_at", table_name="asteroid_meta")
     op.drop_index("ix_asteroid_meta_scope_full", table_name="asteroid_meta")
 
-    op.drop_constraint("uq_events_scope_key", "events", type_="unique")
+    with op.batch_alter_table("events", schema=None) as batch:
+        batch.drop_constraint("uq_events_scope_key", type_="unique")
     op.drop_index("ix_events_created_at", table_name="events")
     op.drop_index("ix_events_event_time_scope", table_name="events")
     op.drop_index("ix_events_scope_full", table_name="events")
 
-    op.drop_constraint(
-        "uq_ruleset_versions_scope_key_version",
-        "ruleset_versions",
-        type_="unique",
-    )
+    with op.batch_alter_table("ruleset_versions", schema=None) as batch:
+        batch.drop_constraint(
+            "uq_ruleset_versions_scope_key_version",
+            type_="unique",
+        )
     op.drop_index("ix_ruleset_versions_created_at", table_name="ruleset_versions")
     op.drop_index("ix_ruleset_versions_scope_full", table_name="ruleset_versions")
 
-    op.drop_constraint("uq_charts_scope_key", "charts", type_="unique")
+    with op.batch_alter_table("charts", schema=None) as batch:
+        batch.drop_constraint("uq_charts_scope_key", type_="unique")
     op.drop_index("ix_charts_created_at", table_name="charts")
     op.drop_index("ix_charts_dt_utc", table_name="charts")
     op.drop_index("ix_charts_scope_full", table_name="charts")
 
-    op.drop_constraint(
-        "uq_traditional_runs_scope_run_id", "traditional_runs", type_="unique"
-    )
+    with op.batch_alter_table("traditional_runs", schema=None) as batch:
+        batch.drop_constraint(
+            "uq_traditional_runs_scope_run_id",
+            type_="unique",
+        )
     op.drop_index("ix_traditional_runs_created_at", table_name="traditional_runs")
     op.drop_index("ix_traditional_runs_scope_full", table_name="traditional_runs")
 
     op.drop_index("ix_severity_profiles_created_at", table_name="severity_profiles")
     op.drop_index("ix_severity_profiles_scope_full", table_name="severity_profiles")
 
-    op.drop_constraint("uq_orb_policies_scope_name", "orb_policies", type_="unique")
+    with op.batch_alter_table("orb_policies", schema=None) as batch:
+        batch.drop_constraint("uq_orb_policies_scope_name", type_="unique")
     op.drop_index("ix_orb_policies_created_at", table_name="orb_policies")
     op.drop_index("ix_orb_policies_scope_full", table_name="orb_policies")


### PR DESCRIPTION
## Summary
- restore tabbed recipes in the Makefile and add migrate/cache-warm helpers backed by a new pipeline module
- add `astroengine.pipeline.cache_warm` to prepare the Swiss ephemeris cache for the default planet set
- update migration 20241115_0003 to use `batch_alter_table` so SQLite can apply the new unique constraints and drop the stale ops log

## Testing
- `.venv/bin/alembic upgrade head`
- `make cache-warm`
- `make migrate`
- `python -m pytest -q` *(fails: missing optional dependencies such as Pillow, PyArrow, Jinja2, and PyPDF in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b812021c8324a703b4026851d4b0