### PR TITLE
docs: clarify DATABASE_URL environment variable usage

### DIFF
--- a/docs/ENV_VARS.md
+++ b/docs/ENV_VARS.md
@@ -12,9 +12,9 @@
   export DATABASE_URL="sqlite:///./dev.db"  # swap in your Postgres URL when needed
   ```
 
-  The helpers do not read `DB_URL`; ensure automation and developer machines
-  consistently set `DATABASE_URL` so the API and migration stack point at the
-  same datastore.
+  The helpers read only `DATABASE_URL`; ensure automation and developer
+  machines consistently set that variable so the API and migration stack point
+  at the same datastore.
 
 ## Skyfield kernels
 Searched in: `./kernels`, `~/.skyfield`, `~/.astroengine/kernels`. Use helper


### PR DESCRIPTION
## Summary
- update ENV_VARS documentation to emphasize only DATABASE_URL is supported
- remove outdated mention of DB_URL to standardize environment variable guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68e2c3509d548324947696fc9d3f0d9b