### PR TITLE
refactor(cli): defer legacy imports for lazy CLI

### DIFF
--- a/astroengine/cli/__init__.py
+++ b/astroengine/cli/__init__.py
@@ -7,19 +7,14 @@ import json as _json
 json = _json
 
 
+# Lazy import to avoid pulling heavy deps at module import time
 def build_parser():
-    """Lazily import the CLI parser builder to avoid early heavy dependencies."""
-
     from .__main__ import build_parser as _build
-
     return _build()
 
 
 def main(argv=None):
-    """Lazily import the CLI entrypoint to defer optional dependency loading."""
-
     from .__main__ import main as _main
-
     return _main(argv)
 
 

--- a/astroengine/cli/__main__.py
+++ b/astroengine/cli/__main__.py
@@ -31,15 +31,16 @@ def _add_legacy_subparser(sub: argparse._SubParsersAction[argparse.ArgumentParse
             metavar="legacy-args",
             help="Arguments passed directly to the legacy CLI",
         )
-        legacy_parser.set_defaults(func=_run_legacy, _cli_legacy=module)
+        legacy_parser.set_defaults(func=_run_legacy)
 
 
 def _run_legacy(parsed: argparse.Namespace) -> int:
-    module = getattr(parsed, "_cli_legacy")
     argv = list(parsed.legacy_args or [])
     if argv and argv[0] == "--":
         argv = argv[1:]
-    return module.main(argv if argv else None)
+    from .. import cli_legacy
+
+    return cli_legacy.main(argv if argv else None)
 
 
 def _legacy_unavailable(parsed: argparse.Namespace) -> int:


### PR DESCRIPTION
## Summary
- ensure the astroengine CLI package lazily imports its parser and main entrypoints
- defer the legacy CLI import until execution to avoid heavy dependencies during help/parse paths

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2c342ea188324adab2ab96b594071