### PR TITLE
Document Alembic operations for SQLite migrator

### DIFF
--- a/astroengine/infrastructure/storage/sqlite/engine.py
+++ b/astroengine/infrastructure/storage/sqlite/engine.py
@@ -40,16 +40,22 @@ class SQLiteMigrator:
         return get_sqlite_config(self.db_path)
 
     def upgrade(self, revision: str = "head") -> None:
+        """Apply migrations up to ``revision`` using Alembic's upgrade command."""
+
         from alembic import command
 
         command.upgrade(self._config(), revision)
 
     def downgrade(self, revision: str = "base") -> None:
+        """Revert migrations down to ``revision`` using Alembic's downgrade command."""
+
         from alembic import command
 
         command.downgrade(self._config(), revision)
 
     def current(self) -> str | None:
+        """Return the current Alembic revision recorded in the SQLite database."""
+
         from sqlalchemy import create_engine
         from sqlalchemy.pool import NullPool
         from alembic.runtime.migration import MigrationContext


### PR DESCRIPTION
## Summary
- add targeted docstrings to the SQLite migrator methods to clarify how Alembic commands are invoked

## Testing
- pytest tests/test_migration_tables.py *(fails: ValueError: No such constraint: 'uq_ruleset_versions_scope_key_version' in existing migration downgrade)*

------
https://chatgpt.com/codex/tasks/task_e_68e2c34c05e48324a0282a63100ed1c1