### PR TITLE
Document AstroJSON exports and Solar Fire dataset stub

### DIFF
--- a/datasets/solarfire/README.md
+++ b/datasets/solarfire/README.md
@@ -1,0 +1,6 @@
+# Solar Fire Export Archive Stub
+
+This directory stores native Solar Fire export files (`*.sf`, `*.txt`) referenced by AstroEngine interoperability specs. Populate
+it with signed copies of the datasets cited in `docs/module/interop.md` and record SHA256 checksums in
+`docs/governance/data_revision_policy.md` before running validation. Do not commit proprietary files to Git; use this folder as a
+mount point during development.


### PR DESCRIPTION
## Summary
- expand the exports and interoperability specification to cover AstroJSON, tabular, SQLite, and ICS contracts with provenance guidance
- add a Solar Fire dataset staging directory README referenced by the interoperability spec

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e2c36be0dc8324ba5f66b3267e42f1