### PR TITLE
Ensure PyYAML dependency is listed once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,9 @@ dependencies = [
   "pandas>=2.2",
   "python-dateutil>=2.8",
   "pydantic>=2.11,<3",
+  "PyYAML>=6.0",
 
   "jsonschema>=4.21",
-  "PyYAML>=6.0",
   "requests>=2.31",
   "python-multipart>=0.0.9",
   "SQLAlchemy>=2.0",


### PR DESCRIPTION
## Summary
- group the PyYAML dependency with the other core runtime packages so it appears only once in the project requirements

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'swisseph')*

------
https://chatgpt.com/codex/tasks/task_e_68e2c33453dc832482d86f4a06809496