### PR TITLE
Disable pytest plugin autoload for faster startup

### DIFF
--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
+import os
 from datetime import datetime
 from typing import Any, Callable
+
+
+# Pytest auto-loads entry point based plugins by default which introduces
+# substantial import overhead in this repository.  Disable the implicit scan
+# unless a developer explicitly opts back in.
+if not os.getenv("ASTROENGINE_ENABLE_PYTEST_AUTOLOAD"):
+    os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")
+
 
 def _install_hypothesis_patch(module: Any) -> None:
     """Install a timezone-aware `datetimes` helper on the provided module."""


### PR DESCRIPTION
## Summary
- disable implicit pytest plugin auto-discovery during interpreter bootstrap to reduce startup overhead
- provide ASTROENGINE_ENABLE_PYTEST_AUTOLOAD escape hatch for developers who still need plugin autoloading

## Testing
- pytest tests/test_sanity.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cca0d4b88324a6daa34758f4b8a4