### PR TITLE
Fix Dockerfile env var name for database URL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN set -eux; \
     fi
 
 # Runtime env
-ENV DB_URL="sqlite:///./dev.db" \
+ENV DATABASE_URL="sqlite:///./dev.db" \
     ASTROENGINE_HOME="/app/.astroengine" \
     AE_QCACHE_SIZE=4096 AE_QCACHE_SEC=1.0
 


### PR DESCRIPTION
## Summary
- align the Dockerfile database environment variable with the application expectation by renaming DB_URL to DATABASE_URL

## Testing
- not run (non-code change)


------
https://chatgpt.com/codex/tasks/task_e_68e2ce04e6408324980af39ec7580287