### PR TITLE
Fix lot event scanning loop bounds

### DIFF
--- a/astroengine/engine/lots/events.py
+++ b/astroengine/engine/lots/events.py
@@ -97,13 +97,13 @@ def scan_lot_events(
 
     events: list[LotEvent] = []
     for body in bodies:
-        current = t0
-        body_val, body_speed = _get_longitude(ephem, body, current)
         for angle in angles:
+            current = t0
+            body_val, body_speed = _get_longitude(ephem, body, current)
             allowance = _resolve_orb(policy, body, angle)
             target = angle if abs(_angular_separation(body_val, lot_lambda) - angle) <= abs(_angular_separation(body_val, lot_lambda) + angle) else -angle
             diff_prev = _angular_separation(body_val, lot_lambda) - target
-            while current <= t1:
+            while current < t1:
                 next_time = min(current + step, t1)
                 body_next, _ = _get_longitude(ephem, body, next_time)
                 diff_next = _angular_separation(body_next, lot_lambda) - target
@@ -141,9 +141,7 @@ def scan_lot_events(
                                 metadata=_event_metadata(angle, int(round(360 / angle)) if angle else 0),
                             )
                         )
-                    diff_prev = diff_next
-                else:
-                    diff_prev = diff_next
+                diff_prev = diff_next
                 current = next_time
                 body_val = body_next
     events.sort(key=lambda event: event.timestamp)

--- a/tests/test_aspects_events.py
+++ b/tests/test_aspects_events.py
@@ -60,3 +60,21 @@ def test_event_scan_linear_motion():
     assert abs(event.angle - 0.0) < 1e-6
     assert event.timestamp >= start + timedelta(days=9)
     assert event.timestamp <= start + timedelta(days=11)
+
+
+def test_event_scan_checks_each_angle():
+    start = datetime(2023, 1, 1, tzinfo=timezone.utc)
+    ephem = LinearEphemeris(start, base=0.0, speed=30.0)
+    events = scan_lot_events(
+        ephem,
+        0.0,
+        ["Mars"],
+        start,
+        start + timedelta(days=7),
+        _policy(),
+        [1, 4],
+        step_hours=6.0,
+        lot_name="Fortune",
+    )
+    angles = {round(event.angle, 6) for event in events}
+    assert {0.0, 90.0}.issubset(angles)


### PR DESCRIPTION
## Summary
- reset the lot event scanning loop for each harmonic so the search covers the full window without hanging at the upper bound
- add a regression test ensuring multiple aspect angles are detected for linear ephemerides

## Testing
- pytest tests/test_aspects_events.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2cd728c888324b2385b80ee8513be