### PR TITLE
Gate Swiss-dependent tests on swisseph availability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 setup:
 	python -m pip install --upgrade pip
 	@if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
-	@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e . || true; fi
+	@if [ -f pyproject.toml ] || [ -f setup.py ]; then pip install -e ".[api,providers,ui]" || pip install -e .; fi
 	python -m astroengine.diagnostics --strict || true
 
 install-optional:

--- a/tests/test_ephemeris_adapter.py
+++ b/tests/test_ephemeris_adapter.py
@@ -2,10 +2,9 @@ from datetime import UTC, datetime
 
 import pytest
 
-try:  # pragma: no cover - exercised via runtime availability
-    import swisseph as swe
-except Exception:  # pragma: no cover - fallback when pyswisseph missing
-    swe = None  # type: ignore[assignment]
+swe = pytest.importorskip(
+    "swisseph", reason="Install with `.[providers]` or set SE_EPHE_PATH"
+)
 
 from astroengine.core.angles import DeltaLambdaTracker
 from astroengine.core.time import to_tt
@@ -46,7 +45,6 @@ def test_topocentric_longitude_delta_within_bounds() -> None:
     assert abs(topocentric.declination - geocentric.declination) < 1.0
 
 
-@pytest.mark.skipif(swe is None, reason="pyswisseph unavailable")
 def test_sidereal_mode_configures_swiss_backend() -> None:
     moment = datetime(2000, 4, 13, 11, 52, 10, 808741, tzinfo=UTC)
     adapter = EphemerisAdapter(

--- a/tests/test_perf_smoke.py
+++ b/tests/test_perf_smoke.py
@@ -4,16 +4,15 @@ import os
 
 import pytest
 
+pytest.importorskip(
+    "swisseph", reason="Install with `.[providers]` or set SE_EPHE_PATH"
+)
+
 pytestmark = [pytest.mark.perf, pytest.mark.swiss]
 
 
-def _have_swiss():
-    try:
-        import swisseph as _  # noqa
-
-        return bool(os.getenv("SE_EPHE_PATH"))
-    except Exception:
-        return False
+def _have_swiss() -> bool:
+    return bool(os.getenv("SE_EPHE_PATH") or os.getenv("SWE_EPH_PATH"))
 
 
 @pytest.mark.skipif(not _have_swiss(), reason="Swiss unavailable")

--- a/tests/test_stations_impl.py
+++ b/tests/test_stations_impl.py
@@ -8,17 +8,15 @@ import pytest
 from astroengine.detectors.common import iso_to_jd
 from astroengine.detectors.stations import find_shadow_periods, find_stations
 
-try:  # pragma: no cover - optional dependency guard
-    import swisseph as swe  # type: ignore
-
-    HAVE_SWISS = True
-except Exception:  # pragma: no cover - defensive fallback
-    HAVE_SWISS = False
+swe = pytest.importorskip(
+    "swisseph", reason="Install with `.[providers]` or set SE_EPHE_PATH"
+)
 
 SE_OK = bool(os.environ.get("SE_EPHE_PATH") or os.environ.get("SWE_EPH_PATH"))
 
 pytestmark = pytest.mark.skipif(
-    not (HAVE_SWISS and SE_OK), reason="Swiss ephemeris not available"
+    not SE_OK,
+    reason="Swiss ephemeris path not configured (set SE_EPHE_PATH or SWE_EPH_PATH)",
 )
 
 


### PR DESCRIPTION
## Summary
- guard Swiss ephemeris dependent tests with `pytest.importorskip` so they skip cleanly when pyswisseph or SE ephemeris data is missing
- keep station and performance smoke tests gated on ephemeris path configuration to avoid flaky failures
- install the `api,providers,ui` extras by default in the Makefile setup target so uvicorn's standard extras are available in dev/prod workflows

## Testing
- pytest tests/test_ephemeris_adapter.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2cf28449c83249f1d25a0257327ee