### PR TITLE
Add ephemeris regression checks and migration CI guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -31,10 +31,29 @@ jobs:
           isort --check-only --profile black .
       - name: Type check
         run: |
-          pip install mypy pydantic
-          mypy .
-  tests:
+          mypy --config-file mypy.ini --cache-dir=.mypy_cache .
+  db-migration-roundtrip:
     needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+      - name: Validate migration round-trip
+        env:
+          TESTCONTAINERS_RYUK_DISABLED: true
+        run: python scripts/ci/run_migration_roundtrip.py
+  tests:
+    needs:
+      - lint
+      - db-migration-roundtrip
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,6 +12,12 @@ repos:
     hooks:
       - id: black
         language_version: python3
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+        args: ["--profile", "black"]
   - repo: https://github.com/pycqa/ruff-pre-commit
     rev: v0.6.9
     hooks:
@@ -42,4 +48,14 @@ repos:
         entry: python scripts/validators/validate_registry.py
         language: system
         files: '^registry/'
+      - id: mypy
+        name: mypy (strict subset)
+        entry: mypy --cache-dir=.mypy_cache --config-file mypy.ini
+        language: system
+        pass_filenames: false
+      - id: pytest-quick
+        name: pytest quick checks
+        entry: pytest -q -m quick
+        language: system
+        pass_filenames: false
 # >>> AUTO-GEN END: Pre-commit Hooks v1.0

--- a/mypy.ini
+++ b/mypy.ini
@@ -13,3 +13,5 @@ exclude = (?x)(
   | ^astroengine/mundane/
   | ^astroengine/narrative/
 )
+warn_redundant_casts = True
+disallow_any_generics = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,4 +5,5 @@ markers =
     swiss: Requires Swiss Ephemeris data (auto-skipped when unavailable).
     perf: Performance smoke scenarios.
     smoke: Lightweight smoke coverage.
+    quick: Fast-running regression and integrity checks.
 # >>> AUTO-GEN END: pytest path v1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,6 +10,7 @@ pytest>=8.0.0  # ENSURE-LINE
 hypothesis>=6.92.0  # ENSURE-LINE
 ruff>=0.6.5
 mypy>=1.10
+isort>=5.13
 pytest-benchmark>=4.0  # ENSURE-LINE
 
 pypdf>=4.2
@@ -22,3 +23,5 @@ streamlit>=1.35
 pytest-cov>=4.1.0  # ENSURE-LINE
 
 genbadge[coverage]>=1.1.1  # ENSURE-LINE
+psycopg[binary]>=3.1
+testcontainers[postgres]>=3.7

--- a/scripts/ci/run_migration_roundtrip.py
+++ b/scripts/ci/run_migration_roundtrip.py
@@ -1,0 +1,73 @@
+"""CI helper to validate Alembic migrations across multiple backends."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Iterator, Sequence
+
+from alembic import command
+from alembic.config import Config
+
+
+def _run_roundtrip(database_url: str) -> None:
+    config = Config("alembic.ini")
+    config.set_main_option("sqlalchemy.url", database_url)
+    os.environ["DATABASE_URL"] = database_url
+    command.upgrade(config, "head")
+    command.downgrade(config, "base")
+    command.upgrade(config, "head")
+
+
+@contextlib.contextmanager
+def _sqlite_url() -> Iterator[str]:
+    with tempfile.TemporaryDirectory(prefix="astroengine-migrations-") as tmpdir:
+        path = Path(tmpdir) / "roundtrip.db"
+        yield f"sqlite:///{path}"
+
+
+@contextlib.contextmanager
+def _postgres_url(image: str) -> Iterator[str]:
+    from testcontainers.postgres import PostgresContainer
+
+    with PostgresContainer(image) as container:
+        yield container.get_connection_url()
+
+
+def _parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--backends",
+        nargs="*",
+        default=("sqlite", "postgres"),
+        choices=("sqlite", "postgres"),
+        help="Database backends to validate.",
+    )
+    parser.add_argument(
+        "--postgres-image",
+        default="postgres:16-alpine",
+        help="Docker image used for the Postgres test container.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    for backend in args.backends:
+        if backend == "sqlite":
+            with _sqlite_url() as url:
+                _run_roundtrip(url)
+        elif backend == "postgres":
+            with _postgres_url(args.postgres_image) as url:
+                _run_roundtrip(url)
+        else:  # pragma: no cover - defensive
+            raise ValueError(f"Unsupported backend: {backend}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/tests/fixtures/ephemeris/sun_moon_2024.json
+++ b/tests/fixtures/ephemeris/sun_moon_2024.json
@@ -1,0 +1,107 @@
+[
+  {
+    "timestamp": "2024-03-20T00:00:00Z",
+    "bodies": {
+      "sun": {
+        "jd_tt": 2460389.500800741,
+        "jd_utc": 2460389.500001209,
+        "longitude": 359.87139156858416,
+        "latitude": 0.00010697824572854129,
+        "distance": 0.9958278853627928,
+        "speed_longitude": 0.9935680448021902,
+        "speed_latitude": -9.901637324241512e-06,
+        "speed_distance": 0.00027363579098788944,
+        "right_ascension": 359.88196096101365,
+        "declination": -0.05105809474458075,
+        "speed_right_ascension": 0.9115895890459655,
+        "speed_declination": 0.39519936841594766,
+        "delta_t_seconds": 69.07956898212433
+      },
+      "moon": {
+        "jd_tt": 2460389.500800741,
+        "jd_utc": 2460389.500001209,
+        "longitude": 122.2520230984418,
+        "latitude": 5.048774381778784,
+        "distance": 0.0026795030133732285,
+        "speed_longitude": 12.115400832042807,
+        "speed_latitude": -0.31508248036943587,
+        "speed_distance": 2.1133549658404887e-05,
+        "right_ascension": 125.76810969470328,
+        "declination": 24.57177154599507,
+        "speed_right_ascension": 12.82273800081709,
+        "speed_declination": -3.123182469312947,
+        "delta_t_seconds": 69.07956898212433
+      }
+    }
+  },
+  {
+    "timestamp": "2024-06-21T10:00:00Z",
+    "bodies": {
+      "sun": {
+        "jd_tt": 2460482.9174674074,
+        "jd_utc": 2460482.916668167,
+        "longitude": 90.52267424008903,
+        "latitude": -0.0001655419712317255,
+        "distance": 1.0162297538181726,
+        "speed_longitude": 0.9538940606777072,
+        "speed_latitude": -1.4399018364098352e-05,
+        "speed_distance": 6.348057748871173e-05,
+        "right_ascension": 90.56967575602344,
+        "declination": 23.43718857190909,
+        "speed_right_ascension": 1.0396621452705732,
+        "speed_declination": -0.003786837130615764,
+        "delta_t_seconds": 69.05438303947449
+      },
+      "moon": {
+        "jd_tt": 2460482.9174674074,
+        "jd_utc": 2460482.916668167,
+        "longitude": 262.62741187398467,
+        "latitude": -4.7247123819743395,
+        "distance": 0.0025576812802715677,
+        "speed_longitude": 13.378948835022449,
+        "speed_latitude": -0.39378194742668865,
+        "speed_distance": -2.8273066980830186e-05,
+        "right_ascension": 261.67591526592895,
+        "declination": -27.950321444857575,
+        "speed_right_ascension": 15.043178379711273,
+        "speed_declination": -1.163550234813161,
+        "delta_t_seconds": 69.05438303947449
+      }
+    }
+  },
+  {
+    "timestamp": "2024-12-21T22:27:00Z",
+    "bodies": {
+      "sun": {
+        "jd_tt": 2460666.4362174077,
+        "jd_utc": 2460666.4354187655,
+        "longitude": 270.5561224213366,
+        "latitude": 8.047195707582894e-06,
+        "distance": 0.98369901212973,
+        "speed_longitude": 1.0183416738268334,
+        "speed_latitude": -3.906700208075229e-05,
+        "speed_distance": -5.7242947212962795e-05,
+        "right_ascension": 270.60613227136747,
+        "declination": -23.437252995699602,
+        "speed_right_ascension": 1.1099041177192992,
+        "speed_declination": 0.004245974456396114,
+        "delta_t_seconds": 69.00268346071243
+      },
+      "moon": {
+        "jd_tt": 2460666.4362174077,
+        "jd_utc": 2460666.4354187655,
+        "longitude": 169.73073844575345,
+        "latitude": 1.0834798499357645,
+        "distance": 0.0026791805804558732,
+        "speed_longitude": 11.994208708683825,
+        "speed_latitude": -1.0343737778070368,
+        "speed_distance": 2.0215959830352418e-05,
+        "right_ascension": 170.9889457355478,
+        "declination": 5.06278129506275,
+        "speed_right_ascension": 10.662720059521606,
+        "speed_declination": -5.663155660563764,
+        "delta_t_seconds": 69.00268346071243
+      }
+    }
+  }
+]

--- a/tests/property/test_sun_moon_invariants.py
+++ b/tests/property/test_sun_moon_invariants.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import datetime as dt
+import math
+
+import pytest
+
+from astroengine.ephemeris import EphemerisAdapter
+from astroengine.utils.angles import norm360
+
+hypothesis = pytest.importorskip("hypothesis")
+_swe = pytest.importorskip("swisseph")
+
+given = hypothesis.given
+settings = hypothesis.settings
+st = hypothesis.strategies
+
+UTC = dt.timezone.utc
+
+MOMENTS = st.datetimes(
+    min_value=dt.datetime(1950, 1, 1, tzinfo=UTC),
+    max_value=dt.datetime(2050, 12, 31, 23, 59, 59, tzinfo=UTC),
+    timezones=st.just(UTC),
+)
+
+ADAPTER = EphemerisAdapter()
+
+
+def _forward_diff(a: float, b: float) -> float:
+    """Return the forward angular difference from ``a`` to ``b`` in degrees."""
+
+    return math.fmod(b - a, 360.0) % 360.0
+
+
+@settings(deadline=None, max_examples=64)
+@given(moment=MOMENTS)
+def test_solar_lunar_longitude_latitude_ranges(moment: dt.datetime) -> None:
+    """Sun/Moon samples remain within expected ecliptic ranges."""
+
+    for body in (_swe.SUN, _swe.MOON):
+        sample = ADAPTER.sample(body, moment)
+        lon = norm360(float(sample.longitude))
+        lat = float(sample.latitude)
+        assert 0.0 <= lon < 360.0
+        assert -90.0 <= lat <= 90.0
+
+
+@settings(deadline=None, max_examples=48)
+@given(moment=MOMENTS, minutes=st.integers(min_value=1, max_value=120))
+def test_sun_monotonic_over_short_intervals(moment: dt.datetime, minutes: int) -> None:
+    """The Sun's apparent longitude increases steadily over short time spans."""
+
+    start = moment
+    end = moment + dt.timedelta(minutes=minutes)
+    base = norm360(float(ADAPTER.sample(_swe.SUN, start).longitude))
+    later = norm360(float(ADAPTER.sample(_swe.SUN, end).longitude))
+    diff = _forward_diff(base, later)
+    assert diff >= -1e-6
+    assert diff <= 1.0 + 1e-6
+
+
+@settings(deadline=None, max_examples=48)
+@given(moment=MOMENTS, minutes=st.integers(min_value=1, max_value=180))
+def test_moon_progresses_without_retrograde(moment: dt.datetime, minutes: int) -> None:
+    """The Moon's ecliptic longitude advances across small deltas."""
+
+    end = moment + dt.timedelta(minutes=minutes)
+    base = norm360(float(ADAPTER.sample(_swe.MOON, moment).longitude))
+    later = norm360(float(ADAPTER.sample(_swe.MOON, end).longitude))
+    diff = _forward_diff(base, later)
+    assert diff >= -1e-6
+    assert diff <= 2.0 + 1e-6

--- a/tests/test_ephemeris_golden_outputs.py
+++ b/tests/test_ephemeris_golden_outputs.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import math
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from astroengine.ephemeris import EphemerisAdapter
+
+_swe = pytest.importorskip("swisseph")
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures" / "ephemeris" / "sun_moon_2024.json"
+GOLDEN_FIXTURES: list[dict[str, Any]] = json.loads(FIXTURE_PATH.read_text())
+
+BODY_IDS = {
+    "sun": _swe.SUN,
+    "moon": _swe.MOON,
+}
+
+ADAPTER = EphemerisAdapter()
+
+_FIELD_TOLERANCE = {
+    "jd_tt": 5e-10,
+    "jd_utc": 5e-10,
+    "longitude": 5e-7,
+    "latitude": 5e-7,
+    "distance": 5e-9,
+    "speed_longitude": 5e-7,
+    "speed_latitude": 5e-7,
+    "speed_distance": 5e-9,
+    "right_ascension": 5e-7,
+    "declination": 5e-7,
+    "speed_right_ascension": 5e-7,
+    "speed_declination": 5e-7,
+    "delta_t_seconds": 5e-7,
+}
+
+
+def _parse_timestamp(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+@pytest.mark.quick
+@pytest.mark.parametrize("fixture", GOLDEN_FIXTURES, ids=lambda row: row["timestamp"])
+def test_ephemeris_samples_match_golden(fixture: dict[str, Any]) -> None:
+    """EphemerisAdapter reproduces recorded Swiss ephemeris samples."""
+
+    moment = _parse_timestamp(fixture["timestamp"])
+    for body_name, expected in fixture["bodies"].items():
+        body_id = BODY_IDS[body_name]
+        sample = ADAPTER.sample(body_id, moment)
+        for field, tolerance in _FIELD_TOLERANCE.items():
+            observed = getattr(sample, field)
+            assert math.isfinite(observed)
+            assert math.isclose(observed, expected[field], abs_tol=tolerance)


### PR DESCRIPTION
## Summary
- add Hypothesis-based solar and lunar invariants along with golden ephemeris fixtures to guard numerical regressions
- wire the golden checks into a quick pytest marker and tighten pre-commit hooks plus mypy strictness flags
- extend CI with a migration round-trip job backed by Testcontainers and scriptable SQLite/Postgres executions

## Testing
- pytest -q tests/property/test_sun_moon_invariants.py tests/test_ephemeris_golden_outputs.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cf663aa8832497436f2b6cb760ac