### PR TITLE
Tune SQLite caches and scope indexes

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -393,6 +393,14 @@ class RulesetVersion(ModuleScopeMixin, TimestampMixin, Base):
             "channel",
             "subchannel",
         ),
+        Index(
+            "ix_ruleset_versions_scope_key",
+            "module",
+            "submodule",
+            "channel",
+            "subchannel",
+            "ruleset_key",
+        ),
         Index("ix_ruleset_versions_created_at", "created_at"),
     )
 

--- a/astroengine/cache/positions_cache.py
+++ b/astroengine/cache/positions_cache.py
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS positions_daily (
   speed REAL,
   PRIMARY KEY (day_jd, body)
 );
+CREATE INDEX IF NOT EXISTS ix_positions_daily_day_body
+  ON positions_daily(day_jd, body);
 """,
     "get": "SELECT lon FROM positions_daily WHERE day_jd=? AND body=?",
     "upsert": (
@@ -32,7 +34,10 @@ CREATE TABLE IF NOT EXISTS positions_daily (
 
 def _connect():
     con = sqlite3.connect(str(DB))
-    con.execute(_SQL["init"])
+    con.execute("PRAGMA journal_mode=WAL;")
+    con.execute("PRAGMA synchronous=NORMAL;")
+    con.executescript(_SQL["init"])
+    con.commit()
     return con
 
 

--- a/migrations/versions/20241118_0004_sqlite_cache_indexes.py
+++ b/migrations/versions/20241118_0004_sqlite_cache_indexes.py
@@ -1,0 +1,75 @@
+"""Add hot-path indexes for cached lookups."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Inspector
+from sqlalchemy.exc import NoSuchTableError, SQLAlchemyError
+
+revision = "20241118_0004"
+down_revision = "20241115_0003"
+branch_labels = None
+depends_on = None
+
+
+def _has_index(inspector: Inspector, table: str, name: str) -> bool:
+    try:
+        return any(index["name"] == name for index in inspector.get_indexes(table))
+    except NoSuchTableError:
+        return False
+
+
+def _table_exists(inspector: Inspector, name: str) -> bool:
+    try:
+        return name in inspector.get_table_names()
+    except SQLAlchemyError:
+        return False
+
+
+def _column_exists(inspector: Inspector, table: str, column: str) -> bool:
+    try:
+        return any(col["name"] == column for col in inspector.get_columns(table))
+    except SQLAlchemyError:
+        return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if not _has_index(inspector, "positions", "ix_positions_by_day_body") and _table_exists(
+        inspector, "positions"
+    ):
+        op.create_index(
+            "ix_positions_by_day_body",
+            "positions",
+            ["day_jd", "body"],
+            unique=False,
+        )
+
+    if not _has_index(inspector, "ruleset_versions", "ix_ruleset_versions_scope_key") and _table_exists(
+        inspector, "ruleset_versions"
+    ):
+        scope_key_column = (
+            "ruleset_key"
+            if _column_exists(inspector, "ruleset_versions", "ruleset_key")
+            else "key"
+        )
+        op.create_index(
+            "ix_ruleset_versions_scope_key",
+            "ruleset_versions",
+            ["module", "submodule", "channel", "subchannel", scope_key_column],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _has_index(inspector, "ruleset_versions", "ix_ruleset_versions_scope_key"):
+        op.drop_index("ix_ruleset_versions_scope_key", table_name="ruleset_versions")
+
+    if _has_index(inspector, "positions", "ix_positions_by_day_body"):
+        op.drop_index("ix_positions_by_day_body", table_name="positions")


### PR DESCRIPTION
## Summary
- ensure SQLite cache connections use WAL mode and `synchronous=NORMAL`, and add a daily positions composite index for faster lookups
- register scope/key indexes for ruleset versions, including an Alembic migration that guards both SQLite and renamed schemas

## Testing
- pytest tests/test_migration_tables.py tests/test_canonical_event_adapter.py

------
https://chatgpt.com/codex/tasks/task_e_68e2cf447d508324a054479016bf32d0