### PR TITLE
Optimize cache tuning and batch timeline sampling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,18 +42,7 @@ migrate:
 -$(ALEMBIC) upgrade head || true
 
 cache-warm:
-$(PY) - <<PY
-from os import getenv
-bodies=getenv("AE_WARM_BODIES","sun,moon").split(",")
-start=getenv("AE_WARM_START","2000-01-01")
-end=getenv("AE_WARM_END","2030-12-31")
-try:
-    from astroengine.legacy.cache import warm as warm_cache
-    warm_cache(bodies=bodies, start=start, end=end)
-    print("Cache warmed", bodies)
-except Exception as e:
-    print("Cache warm skipped:", e)
-PY
+	@:
 
 doctor:
 $(PY) - <<PY
@@ -96,4 +85,6 @@ migrate:
 	.venv/bin/alembic upgrade head
 
 cache-warm:
+	AE_WARM_START=$${AE_WARM_START:-1900-01-01} \
+	AE_WARM_END=$${AE_WARM_END:-2100-12-31} \
 	python -m astroengine.pipeline.cache_warm

--- a/README.md
+++ b/README.md
@@ -206,11 +206,19 @@ High-frequency refinement loops now consult a tiny process-local LRU that
 quantizes Terrestrial Time (TT) into short bins so repeat calls within the same
 window reuse identical Swiss Ephemeris samples. Control the cache via env vars:
 
-- `AE_QCACHE_SEC` – quantization window in seconds (default `0.25`). Lower values
+- `AE_QCACHE_SEC` – quantization window in seconds (default `1.0`). Lower values
   tighten the window; increase to broaden cache hits when input jitter exceeds
-  a quarter second.
-- `AE_QCACHE_SIZE` – maximum cached entries (default `16384`). Raise this if
+  a second.
+- `AE_QCACHE_SIZE` – maximum cached entries (default `4096`). Raise this if
   long-running transit scans churn through the default footprint.
+
+Heavy relationship or mundane timeline scans benefit from a denser cache. For
+those workloads export `AE_QCACHE_SEC=0.25 AE_QCACHE_SIZE=16384` to mirror the
+container tuned defaults.
+
+Daily Swiss-ephemeris lookups can be precomputed on disk across the 1900‑2100
+span via `make cache-warm`. Override the range with `AE_WARM_START` and
+`AE_WARM_END` when you need narrower warms (e.g. CI disk quotas).
 
 Both knobs act locally per process and can be tuned without code changes when
 profiling heavy refinement workloads.

--- a/astroengine/core/qcache.py
+++ b/astroengine/core/qcache.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from math import floor
 from typing import Any, Hashable, Optional, Tuple
 
-# Quantization size in seconds (default 0.25s). Tune via env if needed.
-DEFAULT_QSEC = float(os.getenv("AE_QCACHE_SEC", "0.25"))
+# Quantization size in seconds (default 1s). Tune via env if needed.
+DEFAULT_QSEC = float(os.getenv("AE_QCACHE_SEC", "1.0"))
 
 
 def qbin(jd_tt: float, qsec: float = DEFAULT_QSEC) -> int:
@@ -51,4 +51,4 @@ class QCache:
 
 
 # Module-global cache (per process)
-qcache = QCache(maxsize=int(os.getenv("AE_QCACHE_SIZE", "16384")))
+qcache = QCache(maxsize=int(os.getenv("AE_QCACHE_SIZE", "4096")))

--- a/astroengine/relation_timeline/engine.py
+++ b/astroengine/relation_timeline/engine.py
@@ -4,9 +4,15 @@ from __future__ import annotations
 
 import datetime as dt
 import math
+import os
 from dataclasses import dataclass, field
 from typing import Iterable, Mapping, Sequence
 
+import numpy as np
+
+from ..cache.positions_cache import get_daily_entry, supported_body
+from ..core.qcache import DEFAULT_QSEC
+from ..core.time import to_tt
 from ..ephemeris.adapter import EphemerisAdapter, EphemerisSample
 from ..utils.angles import delta_angle, norm360
 from .policy import (
@@ -42,6 +48,40 @@ try:  # pragma: no cover - import fallback mirrors other packages
     import swisseph as swe
 except Exception:  # pragma: no cover - tests rely on dependency stub
     swe = None
+
+
+_AE_JIT_ENABLED = os.getenv("AE_JIT", "").strip().lower() in {"1", "true", "yes"}
+if _AE_JIT_ENABLED:
+    try:  # pragma: no cover - optional acceleration
+        from numba import njit
+    except Exception:  # pragma: no cover - numba not available
+        njit = None  # type: ignore[assignment]
+        _AE_JIT_ENABLED = False
+else:  # pragma: no cover - JIT disabled
+    njit = None  # type: ignore[assignment]
+
+if _AE_JIT_ENABLED and njit is not None:  # pragma: no cover - depends on numba availability
+
+    @njit(cache=True)
+    def _jit_interpolate(base: np.ndarray, speeds: np.ndarray, offsets: np.ndarray) -> np.ndarray:
+        n = base.shape[0]
+        out = np.empty(n, dtype=np.float64)
+        for i in range(n):
+            value = base[i] + speeds[i] * offsets[i]
+            value %= 360.0
+            if value < 0.0:
+                value += 360.0
+            out[i] = value
+        return out
+
+else:
+
+    def _jit_interpolate(base: np.ndarray, speeds: np.ndarray, offsets: np.ndarray) -> np.ndarray:
+        values = (base + speeds * offsets) % 360.0
+        mask = values < 0.0
+        if np.any(mask):
+            values[mask] += 360.0
+        return values
 
 
 _DEFAULT_BODY_IDS = {
@@ -214,17 +254,74 @@ class _TimelineEngine:
             code = self._resolve_body(name)
             step_hours = self._STEP_HOURS.get(name, 12)
             step = dt.timedelta(hours=step_hours)
+            moments: list[dt.datetime] = []
             current = request.range_start
-            entries: list[tuple[dt.datetime, float]] = []
             while current <= request.range_end:
-                lon = self._longitude(code, current)
-                entries.append((current, lon))
+                moments.append(current)
                 current += step
-            if entries[-1][0] < request.range_end:
-                lon = self._longitude(code, request.range_end)
-                entries.append((request.range_end, lon))
+            if not moments or moments[-1] < request.range_end:
+                moments.append(request.range_end)
+
+            longitudes = self._batched_longitudes(name, code, moments)
+            entries = [
+                (moment, float(lon)) for moment, lon in zip(moments, longitudes)
+            ]
             samples[name] = entries
         return samples
+
+    def _batched_longitudes(
+        self, name: str, code: int, moments: Sequence[dt.datetime]
+    ) -> list[float]:
+        if not moments:
+            return []
+        if not supported_body(name):
+            return [self._longitude(code, moment) for moment in moments]
+
+        try:
+            jd_utc = np.array([to_tt(moment).jd_utc for moment in moments], dtype=np.float64)
+            day_bins = np.floor(jd_utc).astype(np.int64)
+            offsets = jd_utc - day_bins.astype(np.float64)
+
+            quant = float(DEFAULT_QSEC)
+            if quant > 0.0:
+                offset_seconds = offsets * 86400.0
+                offset_seconds = np.round(offset_seconds / quant) * quant
+                offsets = offset_seconds / 86400.0
+
+            unique_days, inverse = np.unique(day_bins, return_inverse=True)
+            base = np.empty(unique_days.shape[0], dtype=np.float64)
+            speeds = np.empty(unique_days.shape[0], dtype=np.float64)
+            missing_speed = np.zeros(unique_days.shape[0], dtype=bool)
+
+            for idx, day in enumerate(unique_days):
+                lon, _, speed = get_daily_entry(float(day), name)
+                base[idx] = float(lon)
+                if speed is None:
+                    speeds[idx] = 0.0
+                    missing_speed[idx] = True
+                else:
+                    speeds[idx] = float(speed)
+
+            base_full = base[inverse]
+            speed_full = speeds[inverse]
+            interpolated = _jit_interpolate(base_full, speed_full, offsets.astype(np.float64))
+
+            if missing_speed.any():
+                missing_mask = missing_speed[inverse]
+                if np.any(missing_mask):
+                    for idx in np.nonzero(missing_mask)[0]:
+                        sample = self._adapter.sample(code, moments[idx])
+                        interpolated[idx] = norm360(float(sample.longitude))
+
+            edge_indices = {0, len(moments) - 1}
+            for idx in edge_indices:
+                sample = self._adapter.sample(code, moments[idx])
+                interpolated[idx] = norm360(float(sample.longitude))
+
+            return [float(value) for value in interpolated]
+
+        except RuntimeError:
+            return [self._longitude(code, moment) for moment in moments]
 
     def _longitude(self, code: int, moment: dt.datetime) -> float:
         sample: EphemerisSample = self._adapter.sample(code, moment)


### PR DESCRIPTION
## Summary
- adjust the quantized in-process cache defaults and refresh the README guidance for operators
- expand the daily positions cache helper and make the cache-warm pipeline span 1900–2100 by default
- vectorize relationship timeline sampling with numpy/optional numba and fall back cleanly when Swiss data is unavailable

## Testing
- pytest tests/relation_timeline -q

------
https://chatgpt.com/codex/tasks/task_e_68e2cf3448a883249c94e6ba40a4fa3c