### PR TITLE
Add Chart Integration Index metric documentation

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,24 @@
+# Metrics
+
+## Chart Integration Index
+
+- **Integration Index (0–1):** Weighted connectivity of the natal aspect web.
+- **Dense (>0.66):** Highly interlinked, fate-heavy feedback loops.
+- **Balanced (0.33–0.66):** Cohesive but adaptable.
+- **Loose (<0.33):** Compartmentalized, offering more freedom and less systemic reactivity.
+
+**Inputs**
+
+- Longitudes per body
+- Orb policy
+- Include/exclude minor aspects
+
+**Outputs**
+
+- `density_weighted`
+- `largest_component_ratio`
+- `exactness_mean`
+- `anti_isolates`
+- `tight_count`
+- `edges`
+- `avg_degree`


### PR DESCRIPTION
## Summary
- add documentation for the Chart Integration Index metric in docs/metrics.md
- outline classification bands, required inputs, and derived outputs for the integration index

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e2d835aa48832489e6deedf5336004