### PR TITLE
Ensure bootstrap installs extras by default

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -15,6 +15,7 @@ fi
 
 if [[ -f "${PROJECT_ROOT}/pyproject.toml" ]] || [[ -f "${PROJECT_ROOT}/setup.py" ]]; then
   pushd "${PROJECT_ROOT}" >/dev/null
+  # API + providers + UI in one go (fallback to core only if extras unavailable)
   pip install -e ".[api,providers,ui]" || pip install -e .
   popd >/dev/null
 fi


### PR DESCRIPTION
## Summary
- document that the bootstrap script installs the API, provider, and UI extras together, falling back to the core package if extras are unavailable

## Testing
- ./scripts/bootstrap.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2dac4f4fc8324b975c816afee9c5e