### PR TITLE
Add observability services to docker-compose stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,25 @@ services:
     command: uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
     environment:
       PYTHONUNBUFFERED: "1"
-    ports:
-      - "8000:8000"
+      DATABASE_URL: ${DATABASE_URL:-sqlite:///./dev.db}
+      OTEL_SERVICE_NAME: astroengine-api
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4318
+    ports: ["8000:8000"]
+    depends_on: ["otel-collector"]
     volumes:
       - .:/app
+
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.136.0
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./ops/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./ops/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports: ["9090:9090"]

--- a/ops/otel-collector-config.yaml
+++ b/ops/otel-collector-config.yaml
@@ -1,0 +1,8 @@
+receivers:
+  otlp:
+    protocols: { http: {}, grpc: {} }
+exporters:
+  logging: { loglevel: info }
+service:
+  pipelines:
+    traces: { receivers: [otlp], exporters: [logging] }

--- a/ops/prometheus.yml
+++ b/ops/prometheus.yml
@@ -1,0 +1,5 @@
+scrape_configs:
+  - job_name: astroengine
+    scrape_interval: 15s
+    static_configs: [{ targets: ["api:8000"] }]
+    metrics_path: /metrics


### PR DESCRIPTION
## Summary
- extend docker-compose to pass DATABASE_URL and wire in OTLP environment variables for the API
- add OpenTelemetry collector and Prometheus services for local observability
- provide minimal collector and Prometheus configuration files under ops/

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2dad1c748832493cca70f163e80bd