### PR TITLE
Add OpenTelemetry tracing helper and fix interpret router import

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -12,7 +12,9 @@ from starlette.responses import Response
 
 from astroengine.ephemeris.adapter import EphemerisAdapter, EphemerisConfig
 
+from app.db.session import engine
 from app.observability import configure_observability
+from app.telemetry import setup_tracing
 
 from app.routers import (
     aspects_router,
@@ -33,6 +35,7 @@ from app.routers.aspects import (  # re-exported for convenience
 
 app = FastAPI(title="AstroEngine Plus API")
 configure_observability(app)
+setup_tracing(app, sqlalchemy_engine=engine)
 app.include_router(aspects_router)
 app.include_router(electional_router)
 app.include_router(events_router)

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,0 +1,70 @@
+"""OpenTelemetry tracing helpers for the AstroEngine API."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from fastapi import FastAPI
+
+_LOGGER = logging.getLogger("astroengine.telemetry")
+
+
+def setup_tracing(
+    app: FastAPI,
+    sqlalchemy_engine: Optional[object] = None,
+    service_name: str = "astroengine-api",
+) -> None:
+    """Configure OpenTelemetry tracing instrumentation if available."""
+
+    sql_configured_flag = "_otel_sqlalchemy_instrumented"
+    tracing_configured_flag = "_otel_tracing_configured"
+
+    if (
+        getattr(app.state, tracing_configured_flag, False)
+        and (
+            not sqlalchemy_engine
+            or getattr(app.state, sql_configured_flag, False)
+        )
+    ):
+        return
+
+    try:  # pragma: no cover - optional dependency plumbing
+        from opentelemetry import trace
+        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
+            OTLPSpanExporter,
+        )
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        from opentelemetry.instrumentation.requests import RequestsInstrumentor
+        from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import BatchSpanProcessor
+    except ImportError:
+        _LOGGER.warning(
+            "telemetry.opentelemetry_missing",
+            extra={"err_code": "OTEL_DEPENDENCY_MISSING"},
+        )
+        setattr(app.state, tracing_configured_flag, True)
+        if sqlalchemy_engine is not None:
+            setattr(app.state, sql_configured_flag, True)
+        return
+
+    if not getattr(app.state, tracing_configured_flag, False):
+        resource = Resource.create({"service.name": service_name})
+        provider = TracerProvider(resource=resource)
+        trace.set_tracer_provider(provider)
+        provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+        FastAPIInstrumentor.instrument_app(
+            app,
+            excluded_urls=r"/(metrics|healthz|readyz)",
+        )
+        RequestsInstrumentor().instrument()
+        setattr(app.state, tracing_configured_flag, True)
+
+    if (
+        sqlalchemy_engine is not None
+        and not getattr(app.state, sql_configured_flag, False)
+    ):
+        SQLAlchemyInstrumentor().instrument(engine=sqlalchemy_engine)
+        setattr(app.state, sql_configured_flag, True)

--- a/astroengine/api/routers/interpret.py
+++ b/astroengine/api/routers/interpret.py
@@ -9,6 +9,7 @@ from typing import Any, Type
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, UploadFile
 from pydantic import BaseModel, ConfigDict, ValidationError
 
+from ..errors import ErrorEnvelope
 from ...interpret.loader import RulepackValidationError, lint_rulepack
 from ...interpret.models import InterpretRequest, InterpretResponse, RulepackLintResult, RulepackMeta, RulepackVersionPayload
 from ...interpret.service import InterpretationError, evaluate_relationship

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,15 @@ ui = [
   "plotly>=5.20",
 ]
 
+# Observability helpers
+obs = [
+  "opentelemetry-sdk>=1.26",
+  "opentelemetry-exporter-otlp>=1.26",
+  "opentelemetry-instrumentation-fastapi>=0.48b0",
+  "opentelemetry-instrumentation-requests>=0.48b0",
+  "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
+]
+
 # Release bundles
 api = [
   "fastapi[all]>=0.117,<0.118",
@@ -133,6 +142,11 @@ dev = [
   "ruff",
   "mypy",
   "pytest-benchmark>=4.0",
+  "opentelemetry-sdk>=1.26",
+  "opentelemetry-exporter-otlp>=1.26",
+  "opentelemetry-instrumentation-fastapi>=0.48b0",
+  "opentelemetry-instrumentation-requests>=0.48b0",
+  "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
 ]
 
 all = [
@@ -167,6 +181,11 @@ all = [
   "ruff",
   "mypy",
   "pytest-benchmark>=4.0",
+  "opentelemetry-sdk>=1.26",
+  "opentelemetry-exporter-otlp>=1.26",
+  "opentelemetry-instrumentation-fastapi>=0.48b0",
+  "opentelemetry-instrumentation-requests>=0.48b0",
+  "opentelemetry-instrumentation-sqlalchemy>=0.48b0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary
- add a reusable `setup_tracing` helper that configures FastAPI, Requests, and SQLAlchemy OpenTelemetry spans when the optional deps are present
- integrate the tracing helper with the existing observability bootstrap and API startup so SQLAlchemy spans are captured once the engine is available
- expose the OpenTelemetry packages through a new `obs` extra and include them in the dev/all bundles for easy installation
- ensure the interpret router imports `ErrorEnvelope` so documented error responses resolve correctly

## Testing
- pytest *(fails: environment lacks Swiss Ephemeris/pyswisseph and related astrology datasets, causing numerous known failures)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dadf288083249dc373b6529cbe1c