### PR TITLE
Add Windows desktop packaging toolkit

### DIFF
--- a/app/desktop/__init__.py
+++ b/app/desktop/__init__.py
@@ -1,0 +1,7 @@
+"""Desktop launch and packaging helpers for AstroEngine."""
+
+__all__ = [
+    "CONFIG_DEFAULT_NAME",
+]
+
+CONFIG_DEFAULT_NAME = "config.yaml"

--- a/app/desktop/config_default.yaml
+++ b/app/desktop/config_default.yaml
@@ -1,0 +1,3 @@
+# Desktop defaults
+# Point this to your Swiss Ephemeris data folder if available
+# SE_EPHE_PATH: C:/path/to/sweph

--- a/app/desktop/launch_desktop.py
+++ b/app/desktop/launch_desktop.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+
+APP_NAME = "AstroEngine"
+LOCAL_APPDATA = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / ".astroengine")))
+APP_HOME = LOCAL_APPDATA / APP_NAME
+APP_HOME.mkdir(parents=True, exist_ok=True)
+
+os.environ.setdefault("ASTROENGINE_HOME", str(APP_HOME))
+os.environ.setdefault("DATABASE_URL", f"sqlite:///{(APP_HOME / 'dev.db').as_posix()}")
+
+CONFIG_PATH = APP_HOME / "config.yaml"
+if CONFIG_PATH.exists():
+    try:
+        import yaml
+
+        cfg = yaml.safe_load(CONFIG_PATH.read_text()) or {}
+        se_path = cfg.get("SE_EPHE_PATH")
+        if se_path:
+            os.environ["SE_EPHE_PATH"] = str(se_path)
+    except Exception:  # pragma: no cover - defensive logging for desktop runtime
+        pass
+else:
+    CONFIG_PATH.write_text(
+        """# AstroEngine Desktop config\n# Set to your Swiss Ephemeris data folder if you have it\n# SE_EPHE_PATH: C:/path/to/sweph\n"""
+    )
+
+BUNDLE_BASE = Path(getattr(sys, "_MEIPASS", Path.cwd()))
+MIGRATIONS_DIR = BUNDLE_BASE / "migrations"
+ALEMBIC_INI = BUNDLE_BASE / "alembic.ini"
+UI_ENTRY = BUNDLE_BASE / "ui" / "streamlit" / "vedic_app.py"
+
+
+def run_migrations() -> None:
+    try:
+        from alembic import command
+        from alembic.config import Config
+
+        cfg = Config(str(ALEMBIC_INI))
+        cfg.set_main_option("script_location", str(MIGRATIONS_DIR))
+        cfg.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
+        command.upgrade(cfg, "head")
+    except Exception as exc:  # pragma: no cover - migrate best effort for desktop runtime
+        print(f"[WARN] Migrations failed: {exc}")
+
+
+def wait_port(host: str, port: int, timeout: float = 30.0) -> bool:
+    start = time.time()
+    while time.time() - start < timeout:
+        with socket.socket() as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect((host, port))
+                return True
+            except OSError:
+                time.sleep(0.2)
+    return False
+
+
+def start_api() -> None:
+    import uvicorn
+    from app.main import app
+
+    uvicorn.run(app, host="127.0.0.1", port=8000, log_level="info")
+
+
+def start_ui() -> subprocess.Popen[bytes]:
+    ui_path = str(UI_ENTRY)
+    cmd = [
+        sys.executable,
+        "-m",
+        "streamlit",
+        "run",
+        ui_path,
+        "--server.headless",
+        "true",
+        "--server.port",
+        "8501",
+    ]
+    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+
+if __name__ == "__main__":
+    print(f"[INFO] Home: {APP_HOME}")
+    run_migrations()
+
+    api_thread = threading.Thread(target=start_api, daemon=True)
+    api_thread.start()
+    if not wait_port("127.0.0.1", 8000, 30):
+        print("[ERROR] API did not start on 127.0.0.1:8000")
+
+    ui_proc = start_ui()
+    if wait_port("127.0.0.1", 8501, 45):
+        webbrowser.open("http://127.0.0.1:8501", new=1)
+    else:
+        print("[WARN] UI did not start on time; check logs.")
+
+    try:
+        if ui_proc and ui_proc.stdout:
+            for _ in range(500):
+                line = ui_proc.stdout.readline()
+                if not line:
+                    break
+                print(line.decode(errors="ignore"), end="")
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if ui_proc:
+            try:
+                ui_proc.terminate()
+            except Exception:
+                pass

--- a/installer/AstroEngine.iss
+++ b/installer/AstroEngine.iss
@@ -1,0 +1,32 @@
+; Build with Inno Setup (iscc.exe)
+#define AppName "AstroEngine"
+#define AppVersion "1.0.0"
+#define Publisher "Your Company"
+#define InstallDirName "{localappdata}\AstroEngine"
+#define ExeSrcDir "..\dist\AstroEngine"
+
+[Setup]
+AppName={#AppName}
+AppVersion={#AppVersion}
+DefaultDirName={#InstallDirName}
+DisableProgramGroupPage=yes
+OutputDir=..\dist
+OutputBaseFilename=AstroEngine-Setup
+Compression=lzma
+SolidCompression=yes
+ArchitecturesInstallIn64BitMode=x64
+
+[Files]
+Source: "{#ExeSrcDir}\AstroEngine.exe"; DestDir: "{app}"; Flags: ignoreversion
+; Optional: ship CLI too
+Source: "..\dist\astroengine-cli\astroengine-cli.exe"; DestDir: "{app}"; Flags: ignoreversion
+
+[Icons]
+Name: "{group}\AstroEngine"; Filename: "{app}\AstroEngine.exe"
+Name: "{userdesktop}\AstroEngine"; Filename: "{app}\AstroEngine.exe"; Tasks: desktopicon
+
+[Tasks]
+Name: "desktopicon"; Description: "Create a desktop icon"; GroupDescription: "Additional icons:"; Flags: unchecked
+
+[Run]
+Filename: "{app}\AstroEngine.exe"; Description: "Launch {#AppName}"; Flags: nowait postinstall skipifsilent

--- a/packaging/astroengine_cli.spec
+++ b/packaging/astroengine_cli.spec
@@ -1,0 +1,46 @@
+# Builds a console CLI EXE: astroengine-cli.exe
+block_cipher = None
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+hiddenimports = []
+hiddenimports += collect_submodules("pydantic")
+hiddenimports += collect_submodules("sqlalchemy")
+hiddenimports += collect_submodules("alembic")
+hiddenimports += collect_submodules("uvicorn")
+hiddenimports += collect_submodules("fastapi")
+hiddenimports += collect_submodules("pyswisseph")
+
+
+datas = []
+datas += collect_data_files("alembic")
+datas += [("alembic.ini", "alembic.ini", "DATA")]
+datas += [("migrations", "migrations")]
+datas += [("ui/streamlit", "ui/streamlit")]
+
+
+a = Analysis(
+    [
+        "astroengine/__main__.py",
+    ],
+    pathex=["."],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name="astroengine-cli",
+    console=True,
+)

--- a/packaging/astroengine_gui.spec
+++ b/packaging/astroengine_gui.spec
@@ -1,0 +1,46 @@
+# Builds a windowed EXE that launches API + Streamlit UI
+block_cipher = None
+
+from PyInstaller.utils.hooks import collect_data_files, collect_submodules
+
+hiddenimports = []
+hiddenimports += collect_submodules("pydantic")
+hiddenimports += collect_submodules("sqlalchemy")
+hiddenimports += collect_submodules("alembic")
+hiddenimports += collect_submodules("uvicorn")
+hiddenimports += collect_submodules("fastapi")
+hiddenimports += collect_submodules("pyswisseph")
+
+
+datas = []
+datas += [("alembic.ini", "alembic.ini", "DATA")]
+datas += [("migrations", "migrations")]
+datas += [("ui/streamlit", "ui/streamlit")]
+
+
+a = Analysis(
+    [
+        "app/desktop/launch_desktop.py",
+    ],
+    pathex=["."],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name="AstroEngine",
+    console=False,
+    icon=None,
+)

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -1,0 +1,24 @@
+param(
+  [switch]$WithObs
+)
+$ErrorActionPreference = "Stop"
+
+# 1) Fresh venv with Python 3.11
+python -V
+python -m venv .venv
+. .\.venv\Scripts\Activate.ps1
+python -m pip install -U pip wheel setuptools
+
+# 2) Install project + extras (API, providers, UI)
+$extras = "api,providers,ui"
+if ($WithObs) { $extras = "$extras,obs" }
+pip install -e ".[${extras}]"
+
+# 3) PyInstaller
+pip install pyinstaller
+
+# 4) Build EXEs
+pyinstaller packaging/astroengine_cli.spec --noconfirm
+pyinstaller packaging/astroengine_gui.spec --noconfirm
+
+Write-Host "Build complete. Artifacts in .\\dist\\"


### PR DESCRIPTION
## Summary
- add a desktop launcher that provisions local storage, runs migrations, starts the API, and launches the Streamlit UI for packaged builds
- add PyInstaller specifications, Windows build script, and Inno Setup installer recipe to generate CLI and GUI executables
- include default desktop configuration guidance for locating Swiss Ephemeris data

## Testing
- pytest *(fails: requires pyswisseph/Swiss ephemeris assets in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2dd3b402c8324bfbc14ef9ab8ac23