### PR TITLE
Add Windows desktop shell with config editor and copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,38 @@ The containers mount `./data` at `/app/data`, so database migrations and
 ephemeris files persist between restarts and remain available to both services.
 # >>> AUTO-GEN END: README Quick Start v1.1
 
+### Windows desktop shell
+
+The packaged Windows experience wraps the FastAPI service, Streamlit UI, and
+diagnostics inside a WebView2-powered desktop window. Launch it locally with:
+
+```bash
+python -m app.desktop.launch_desktop
+```
+
+Key behaviour:
+
+* **Native menus & tray.** Start/stop the API, reopen the embedded UI, tail
+  logs, or quit directly from the title bar menu or system tray icon.
+* **Settings editor.** Configuration lives at
+  `%LOCALAPPDATA%/AstroEngine/config.yaml` and includes database connection
+  details, Swiss Ephemeris path validation, API/Streamlit port overrides,
+  caching knobs (`AE_QCACHE_*`), logging level, theme, and auto-start toggles.
+  Updates are validated (including a live database connectivity check) before
+  being applied.
+* **Observability helpers.** Diagnostics, `/healthz`, `/metrics`, and log
+  viewers are available from the menus, and a one-click issue report bundles an
+  anonymised diagnostics snapshot for support.
+* **ChatGPT copilot.** The dockable copilot panel can tail logs, run
+  diagnostics, summarise API errors, and explain endpoints. Provide an OpenAI
+  API key and model in Settings to enable remote completions; otherwise the
+  panel falls back to deterministic tool output. Token usage is tracked with a
+  daily guardrail sourced from the desktop config.
+
+All values surfaced by the desktop shell originate from the same data-backed
+modules shipped with AstroEngine—no synthetic astrology data or guessed
+ephemerides are injected into the workflow.
+
 ### First transit sanity check
 
 Once the virtual environment is ready, confirm that the bundled CLI can

--- a/app/desktop/config_default.yaml
+++ b/app/desktop/config_default.yaml
@@ -1,3 +1,17 @@
-# Desktop defaults
-# Point this to your Swiss Ephemeris data folder if available
-# SE_EPHE_PATH: C:/path/to/sweph
+# AstroEngine desktop defaults
+schema_version: 1
+database_url: sqlite:///astroengine-desktop.db
+se_ephe_path: ""
+api_host: 127.0.0.1
+api_port: 8000
+streamlit_port: 8501
+qcache_sec: 1.0
+qcache_size: 4096
+logging_level: INFO
+theme: system
+openai_api_key: ""
+openai_model: gpt-4o-mini
+openai_base_url: null
+copilot_daily_limit: 50000
+copilot_session_limit: 8000
+autostart: false

--- a/app/desktop/launch_desktop.py
+++ b/app/desktop/launch_desktop.py
@@ -1,122 +1,21 @@
+"""Launch the AstroEngine desktop shell."""
+
 from __future__ import annotations
 
-import os
-import socket
-import subprocess
-import sys
-import threading
-import time
-import webbrowser
-from pathlib import Path
+from astroengine.ux.desktop import AstroEngineDesktopApp, DesktopConfigManager
 
-APP_NAME = "AstroEngine"
-LOCAL_APPDATA = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / ".astroengine")))
-APP_HOME = LOCAL_APPDATA / APP_NAME
-APP_HOME.mkdir(parents=True, exist_ok=True)
 
-os.environ.setdefault("ASTROENGINE_HOME", str(APP_HOME))
-os.environ.setdefault("DATABASE_URL", f"sqlite:///{(APP_HOME / 'dev.db').as_posix()}")
-
-CONFIG_PATH = APP_HOME / "config.yaml"
-if CONFIG_PATH.exists():
+def main() -> None:
+    manager = DesktopConfigManager()
+    config = manager.load()
+    if not manager.config_path.exists():
+        manager.save(config)
+    app = AstroEngineDesktopApp(config_manager=manager)
     try:
-        import yaml
-
-        cfg = yaml.safe_load(CONFIG_PATH.read_text()) or {}
-        se_path = cfg.get("SE_EPHE_PATH")
-        if se_path:
-            os.environ["SE_EPHE_PATH"] = str(se_path)
-    except Exception:  # pragma: no cover - defensive logging for desktop runtime
-        pass
-else:
-    CONFIG_PATH.write_text(
-        """# AstroEngine Desktop config\n# Set to your Swiss Ephemeris data folder if you have it\n# SE_EPHE_PATH: C:/path/to/sweph\n"""
-    )
-
-BUNDLE_BASE = Path(getattr(sys, "_MEIPASS", Path.cwd()))
-MIGRATIONS_DIR = BUNDLE_BASE / "migrations"
-ALEMBIC_INI = BUNDLE_BASE / "alembic.ini"
-UI_ENTRY = BUNDLE_BASE / "ui" / "streamlit" / "vedic_app.py"
-
-
-def run_migrations() -> None:
-    try:
-        from alembic import command
-        from alembic.config import Config
-
-        cfg = Config(str(ALEMBIC_INI))
-        cfg.set_main_option("script_location", str(MIGRATIONS_DIR))
-        cfg.set_main_option("sqlalchemy.url", os.environ["DATABASE_URL"])
-        command.upgrade(cfg, "head")
-    except Exception as exc:  # pragma: no cover - migrate best effort for desktop runtime
-        print(f"[WARN] Migrations failed: {exc}")
-
-
-def wait_port(host: str, port: int, timeout: float = 30.0) -> bool:
-    start = time.time()
-    while time.time() - start < timeout:
-        with socket.socket() as sock:
-            sock.settimeout(0.5)
-            try:
-                sock.connect((host, port))
-                return True
-            except OSError:
-                time.sleep(0.2)
-    return False
-
-
-def start_api() -> None:
-    import uvicorn
-    from app.main import app
-
-    uvicorn.run(app, host="127.0.0.1", port=8000, log_level="info")
-
-
-def start_ui() -> subprocess.Popen[bytes]:
-    ui_path = str(UI_ENTRY)
-    cmd = [
-        sys.executable,
-        "-m",
-        "streamlit",
-        "run",
-        ui_path,
-        "--server.headless",
-        "true",
-        "--server.port",
-        "8501",
-    ]
-    return subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        app.run()
+    except KeyboardInterrupt:
+        app.shutdown()
 
 
 if __name__ == "__main__":
-    print(f"[INFO] Home: {APP_HOME}")
-    run_migrations()
-
-    api_thread = threading.Thread(target=start_api, daemon=True)
-    api_thread.start()
-    if not wait_port("127.0.0.1", 8000, 30):
-        print("[ERROR] API did not start on 127.0.0.1:8000")
-
-    ui_proc = start_ui()
-    if wait_port("127.0.0.1", 8501, 45):
-        webbrowser.open("http://127.0.0.1:8501", new=1)
-    else:
-        print("[WARN] UI did not start on time; check logs.")
-
-    try:
-        if ui_proc and ui_proc.stdout:
-            for _ in range(500):
-                line = ui_proc.stdout.readline()
-                if not line:
-                    break
-                print(line.decode(errors="ignore"), end="")
-        while True:
-            time.sleep(1)
-    except KeyboardInterrupt:
-        pass
-    finally:
-        if ui_proc:
-            try:
-                ui_proc.terminate()
-            except Exception:
-                pass
+    main()

--- a/astroengine/ux/desktop/__init__.py
+++ b/astroengine/ux/desktop/__init__.py
@@ -1,0 +1,12 @@
+"""Desktop shell integration for AstroEngine."""
+
+from .app import AstroEngineDesktopApp
+from .config import DesktopConfigManager, DesktopConfigModel
+from .copilot import DesktopCopilot
+
+__all__ = [
+    "AstroEngineDesktopApp",
+    "DesktopConfigManager",
+    "DesktopConfigModel",
+    "DesktopCopilot",
+]

--- a/astroengine/ux/desktop/app.py
+++ b/astroengine/ux/desktop/app.py
@@ -1,0 +1,745 @@
+"""Native desktop entrypoint for the AstroEngine Windows shell."""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import socket
+import subprocess
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+from typing import Any
+
+from .config import DesktopConfigManager, DesktopConfigModel
+from .copilot import DesktopCopilot
+
+LOG = logging.getLogger(__name__)
+
+
+class APIServerController:
+    """Manage the bundled uvicorn server lifecycle."""
+
+    def __init__(self, config: DesktopConfigModel) -> None:
+        self.host = config.api_host
+        self.port = config.api_port
+        self.log_level = config.logging_level.lower()
+        self._thread: threading.Thread | None = None
+        self._server: Any | None = None
+        self._lock = threading.Lock()
+
+    def configure(self, config: DesktopConfigModel) -> None:
+        restart_needed = (
+            self.is_running()
+            and (self.host != config.api_host or self.port != config.api_port)
+        )
+        self.host = config.api_host
+        self.port = config.api_port
+        self.log_level = config.logging_level.lower()
+        if restart_needed:
+            self.restart()
+
+    def start(self) -> None:
+        with self._lock:
+            if self._thread and self._thread.is_alive():
+                return
+            self._thread = threading.Thread(target=self._run_server, daemon=True)
+            self._thread.start()
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._server is not None:
+                setattr(self._server, "should_exit", True)
+                setattr(self._server, "force_exit", True)
+            thread = self._thread
+        if thread:
+            thread.join(timeout=5)
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def is_running(self) -> bool:
+        thread = self._thread
+        return bool(thread and thread.is_alive())
+
+    def _run_server(self) -> None:
+        try:
+            import uvicorn
+            from app.main import app as fastapi_app
+        except Exception as exc:  # pragma: no cover - runtime import errors
+            LOG.exception("Unable to launch API server: %s", exc)
+            return
+
+        config = uvicorn.Config(
+            fastapi_app,
+            host=self.host,
+            port=self.port,
+            log_level=self.log_level,
+            access_log=False,
+        )
+        server = uvicorn.Server(config)
+        self._server = server
+        try:
+            server.run()
+        except Exception as exc:  # pragma: no cover - uvicorn runtime error
+            LOG.exception("uvicorn exited unexpectedly: %s", exc)
+        finally:
+            self._server = None
+
+
+class StreamlitController:
+    """Launch and monitor the embedded Streamlit UI."""
+
+    def __init__(self, config: DesktopConfigModel, base_dir: Path) -> None:
+        self.port = config.streamlit_port
+        self.host = "127.0.0.1"
+        self.process: subprocess.Popen[bytes] | None = None
+        self._lock = threading.Lock()
+        self._log_path = base_dir / "logs" / "streamlit.log"
+        self._log_path.parent.mkdir(parents=True, exist_ok=True)
+        self._log_handle: Any | None = None
+        self._entry = self._resolve_entry()
+
+    def configure(self, config: DesktopConfigModel) -> None:
+        restart_needed = self.is_running() and self.port != config.streamlit_port
+        self.port = config.streamlit_port
+        if restart_needed:
+            self.restart()
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    def start(self) -> None:
+        with self._lock:
+            if self.process and self.process.poll() is None:
+                return
+            command = [
+                sys.executable,
+                "-m",
+                "streamlit",
+                "run",
+                str(self._entry),
+                "--server.headless",
+                "true",
+                "--server.port",
+                str(self.port),
+            ]
+            self._log_handle = self._log_path.open("a", encoding="utf-8")
+            self.process = subprocess.Popen(
+                command,
+                stdout=self._log_handle,
+                stderr=subprocess.STDOUT,
+            )
+        self._wait_port(self.host, self.port)
+
+    def stop(self) -> None:
+        with self._lock:
+            proc = self.process
+            self.process = None
+        if proc and proc.poll() is None:
+            proc.terminate()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:  # pragma: no cover - fallback cleanup
+                proc.kill()
+        if self._log_handle is not None:
+            try:
+                self._log_handle.close()
+            except Exception:  # pragma: no cover - defensive cleanup
+                pass
+            self._log_handle = None
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def is_running(self) -> bool:
+        proc = self.process
+        return bool(proc and proc.poll() is None)
+
+    def open_in_browser(self) -> None:
+        self.start()
+        webbrowser.open(self.url, new=1)
+
+    def _wait_port(self, host: str, port: int, timeout: float = 45.0) -> bool:
+        start = time.time()
+        while time.time() - start < timeout:
+            with socket.socket() as sock:
+                sock.settimeout(0.5)
+                try:
+                    sock.connect((host, port))
+                    return True
+                except OSError:
+                    time.sleep(0.2)
+        return False
+
+    def _resolve_entry(self) -> Path:
+        bundle_base = Path(getattr(sys, "_MEIPASS", Path.cwd()))
+        candidates = [
+            bundle_base / "ui" / "streamlit" / "vedic_app.py",
+            Path(__file__).resolve().parents[3] / "ui" / "streamlit" / "vedic_app.py",
+        ]
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+        raise FileNotFoundError("Unable to locate Streamlit entry point")
+
+
+class DesktopBridge:
+    """Expose desktop automation to pywebview JavaScript bindings."""
+
+    def __init__(self, app: "AstroEngineDesktopApp") -> None:
+        self.app = app
+
+    # Settings ---------------------------------------------------------
+    def get_config(self) -> dict[str, Any]:
+        return self.app.config_manager.redact(self.app.config)
+
+    def save_config(self, payload: dict[str, Any]) -> dict[str, Any]:
+        try:
+            updated = self.app.config_manager.update(**payload)
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+        self.app.on_config_updated(updated)
+        return {"ok": True, "config": self.app.config_manager.redact(updated)}
+
+    def validate_database(self, url: str) -> dict[str, Any]:
+        error = self.app.config_manager.probe_database(url)
+        return {"ok": error is None, "error": error}
+
+    def check_ephemeris(self, path: str) -> dict[str, Any]:
+        ok = self.app.config_manager.check_ephemeris_path(path)
+        return {"ok": ok}
+
+    # Copilot ----------------------------------------------------------
+    def copilot_status(self) -> dict[str, Any]:
+        return self.app.copilot.status()
+
+    def copilot_send(self, message: str) -> dict[str, Any]:
+        result = self.app.copilot.send(message)
+        return {
+            "response": result.response,
+            "tokens": result.tokens_consumed,
+            "total": result.total_tokens,
+            "tools": result.tool_invocations,
+        }
+
+    def copilot_tool(self, name: str) -> dict[str, Any]:
+        try:
+            output = self.app.copilot.invoke_tool(name)
+            return {"ok": True, "output": output}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+    # Desktop convenience ----------------------------------------------
+    def open_logs(self) -> dict[str, Any]:
+        try:
+            self.app.open_logs()
+            return {"ok": True}
+        except Exception as exc:  # pragma: no cover - platform specific
+            return {"ok": False, "error": str(exc)}
+
+    def issue_bundle(self) -> dict[str, Any]:
+        try:
+            bundle = self.app.create_issue_bundle()
+            return {"ok": True, "path": str(bundle)}
+        except Exception as exc:
+            return {"ok": False, "error": str(exc)}
+
+
+class AstroEngineDesktopApp:
+    """Top-level orchestrator for the Windows desktop experience."""
+
+    SETTINGS_HTML = (Path(__file__).with_name("settings.html"))
+    CHAT_HTML = (Path(__file__).with_name("chat.html"))
+
+    def __init__(self, *, config_manager: DesktopConfigManager | None = None) -> None:
+        self.config_manager = config_manager or DesktopConfigManager()
+        self.config = self.config_manager.load()
+        self.config_manager.apply_environment(self.config)
+        self._configure_logging(self.config)
+        self.api_controller = APIServerController(self.config)
+        self.ui_controller = StreamlitController(self.config, self.config_manager.base_dir)
+        self.copilot = DesktopCopilot(self.config_manager)
+        self._tray_icon = None
+        self._webview_window = None
+        self._settings_window = None
+        self._chat_window = None
+        self._windows: list[Any] = []
+        self._shutdown = threading.Event()
+        self._health_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def run(self) -> None:
+        self.api_controller.start()
+        self.ui_controller.start()
+        self._start_tray()
+        self._launch_webview()
+
+    def shutdown(self) -> None:
+        self._shutdown.set()
+        if self._tray_icon is not None:
+            try:
+                self._tray_icon.stop()
+            except Exception:  # pragma: no cover
+                pass
+        self.ui_controller.stop()
+        self.api_controller.stop()
+
+    def on_config_updated(self, config: DesktopConfigModel) -> None:
+        self.config = config
+        self.config_manager.apply_environment(config)
+        self.api_controller.configure(config)
+        self.ui_controller.configure(config)
+        self.copilot.refresh_config()
+
+    def open_logs(self) -> None:
+        path = self.config_manager.log_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.touch(exist_ok=True)
+        if platform.system() == "Windows":  # pragma: no cover - requires Windows
+            os.startfile(path)  # type: ignore[attr-defined]
+        else:
+            try:
+                subprocess.Popen(["xdg-open", str(path)])
+            except FileNotFoundError:
+                subprocess.Popen(["open", str(path)])
+
+    def create_issue_bundle(self) -> Path:
+        return self.copilot.create_issue_bundle()
+
+    def open_metrics(self) -> None:
+        url = f"http://{self.config.api_host}:{self.config.api_port}/metrics"
+        webbrowser.open(url, new=1)
+
+    def open_collector_logs(self) -> None:
+        path = self.config_manager.logs_dir / "collector.log"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            path.write_text("No collector logs captured yet.\n", encoding="utf-8")
+        if platform.system() == "Windows":  # pragma: no cover - requires Windows
+            os.startfile(path)  # type: ignore[attr-defined]
+        else:
+            try:
+                subprocess.Popen(["xdg-open", str(path)])
+            except FileNotFoundError:
+                subprocess.Popen(["open", str(path)])
+
+    def _open_text_document(self, title: str, content: str) -> None:
+        safe_title = title.lower().replace(" ", "-")
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
+        path = self.config_manager.issue_dir / f"{safe_title}-{timestamp}.txt"
+        path.write_text(content, encoding="utf-8")
+        if platform.system() == "Windows":  # pragma: no cover - requires Windows
+            os.startfile(path)  # type: ignore[attr-defined]
+        else:
+            try:
+                subprocess.Popen(["xdg-open", str(path)])
+            except FileNotFoundError:
+                subprocess.Popen(["open", str(path)])
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _configure_logging(self, config: DesktopConfigModel) -> None:
+        log_level = getattr(logging, config.logging_level, logging.INFO)
+        root_logger = logging.getLogger()
+        root_logger.setLevel(log_level)
+        if not any(isinstance(handler, logging.FileHandler) for handler in root_logger.handlers):
+            file_handler = logging.FileHandler(self.config_manager.log_path, encoding="utf-8")
+            file_handler.setFormatter(
+                logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+            )
+            root_logger.addHandler(file_handler)
+
+    def _launch_webview(self) -> None:
+        try:
+            import webview
+        except Exception as exc:  # pragma: no cover - dependency missing
+            LOG.warning("pywebview unavailable (%s); falling back to browser", exc)
+            self.ui_controller.open_in_browser()
+            self._wait_forever()
+            return
+
+        bridge = DesktopBridge(self)
+        menu = self._build_menu(webview)
+        window = webview.create_window(
+            "AstroEngine",
+            url=self.ui_controller.url,
+            width=1280,
+            height=800,
+            resizable=True,
+            text_select=True,
+            js_api=bridge,
+            menu=menu,
+        )
+        self._settings_window = webview.create_window(
+            "Settings",
+            html=DEFAULT_SETTINGS_HTML,
+            width=720,
+            height=780,
+            js_api=bridge,
+            hidden=True,
+            resizable=True,
+        )
+        self._chat_window = webview.create_window(
+            "AstroEngine Copilot",
+            html=DEFAULT_CHAT_HTML,
+            width=520,
+            height=720,
+            js_api=bridge,
+            hidden=True,
+            resizable=True,
+        )
+        self._webview_window = window
+        for w in (window, self._settings_window, self._chat_window):
+            if w is not None:
+                self._windows.append(w)
+        gui = "edgechromium" if platform.system() == "Windows" else None
+        try:
+            webview.start(self._on_webview_ready, window=window, gui=gui)
+        finally:
+            self.shutdown()
+
+    def _build_menu(self, webview: Any) -> Any:
+        try:
+            from webview import menu as menu_module
+        except Exception:
+            return None
+
+        def item(title: str, callback: Any) -> Any:
+            return menu_module.MenuItem(title, callback)
+
+        return menu_module.Menu(
+            menu_module.MenuItem(
+                "AstroEngine",
+                [
+                    item("Start API", lambda: self.api_controller.start()),
+                    item("Stop API", lambda: self.api_controller.stop()),
+                    item("Open UI in browser", lambda: self.ui_controller.open_in_browser()),
+                    item("Diagnostics", lambda: self._open_text_document("Diagnostics", self.copilot.invoke_tool("diagnostics"))),
+                    item("Open Logs", lambda: self.open_logs()),
+                    item("Open Metrics", lambda: self.open_metrics()),
+                    item("Collector Logs", lambda: self.open_collector_logs()),
+                    item("Settings", lambda: self._open_settings()),
+                    item("Chat Copilot", lambda: self._open_chat()),
+                    item("Quit", lambda: self.shutdown()),
+                ],
+            )
+        )
+
+    def _on_webview_ready(self) -> None:
+        self._start_health_monitor()
+
+    def _start_tray(self) -> None:
+        try:
+            import pystray
+            from PIL import Image, ImageDraw
+        except Exception as exc:  # pragma: no cover - optional dependency missing
+            LOG.info("System tray unavailable: %s", exc)
+            return
+
+        image = Image.new("RGB", (64, 64), color="#1b2352")
+        draw = ImageDraw.Draw(image)
+        draw.ellipse((12, 12, 52, 52), fill="#c9973b")
+        menu = pystray.Menu(
+            pystray.MenuItem("Start API", lambda: self.api_controller.start()),
+            pystray.MenuItem("Stop API", lambda: self.api_controller.stop()),
+            pystray.MenuItem("Open UI", lambda: self.ui_controller.open_in_browser()),
+            pystray.MenuItem("Diagnostics", lambda: self._open_text_document("Diagnostics", self.copilot.invoke_tool("diagnostics"))),
+            pystray.MenuItem("Open Logs", lambda: self.open_logs()),
+            pystray.MenuItem("Open Metrics", lambda: self.open_metrics()),
+            pystray.MenuItem("Collector Logs", lambda: self.open_collector_logs()),
+            pystray.MenuItem("Settings", lambda: self._open_settings()),
+            pystray.MenuItem("Chat Copilot", lambda: self._open_chat()),
+            pystray.MenuItem("Quit", lambda: self.shutdown()),
+        )
+        self._tray_icon = pystray.Icon("astroengine", image, "AstroEngine", menu)
+        threading.Thread(target=self._tray_icon.run, daemon=True).start()
+
+    def _start_health_monitor(self) -> None:
+        if self._health_thread and self._health_thread.is_alive():
+            return
+
+        def poll() -> None:
+            last_status: bool | None = None
+            while not self._shutdown.is_set():
+                status = self._check_api_health()
+                if status != last_status:
+                    for window in list(self._windows):
+                        if window is None:
+                            continue
+                        try:
+                            window.evaluate_js(
+                                "window.AstroEngine?.setApiStatus?.(" + ("true" if status else "false") + ")"
+                            )
+                        except Exception:  # pragma: no cover - JS errors ignored
+                            LOG.debug("Failed to push health status to webview", exc_info=True)
+                last_status = status
+                time.sleep(5)
+
+        self._health_thread = threading.Thread(target=poll, daemon=True)
+        self._health_thread.start()
+
+    def _check_api_health(self) -> bool:
+        try:
+            import httpx
+
+            url = f"http://{self.config.api_host}:{self.config.api_port}/healthz"
+            with httpx.Client(timeout=3.0) as client:
+                response = client.get(url)
+                response.raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    def _open_settings(self) -> None:
+        if self._settings_window is not None:
+            self._settings_window.show()
+            try:
+                self._settings_window.focus()
+            except Exception:  # pragma: no cover - GUI dependent
+                pass
+
+    def _open_chat(self) -> None:
+        if self._chat_window is not None:
+            self._chat_window.show()
+            try:
+                self._chat_window.focus()
+            except Exception:  # pragma: no cover - GUI dependent
+                pass
+
+    def _wait_forever(self) -> None:
+        try:
+            while not self._shutdown.is_set():
+                time.sleep(1)
+        except KeyboardInterrupt:
+            self.shutdown()
+
+
+DEFAULT_SETTINGS_HTML = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\" />
+<title>AstroEngine Settings</title>
+<style>
+body { font-family: 'Segoe UI', sans-serif; margin: 0; padding: 1.5rem; background: #101321; color: #f5f6fa; }
+form { max-width: 720px; margin: 0 auto; }
+label { display: block; margin-top: 1rem; font-weight: 600; }
+input, select { width: 100%; padding: 0.5rem; border-radius: 6px; border: 1px solid #2d3256; background: #1b2040; color: #f5f6fa; }
+button { margin-top: 1.5rem; padding: 0.6rem 1.2rem; border: none; border-radius: 6px; background: #c9973b; color: #101321; font-weight: 600; cursor: pointer; }
+button.secondary { background: transparent; border: 1px solid #c9973b; color: #c9973b; margin-left: 0.5rem; }
+#status { margin-top: 1rem; min-height: 1.5rem; }
+</style>
+</head>
+<body>
+<h1>AstroEngine Settings</h1>
+<form id=\"settingsForm\" onsubmit=\"return false;\">
+  <label>Database URL <input name=\"database_url\" required /></label>
+  <label>Swiss Ephemeris Path <input name=\"se_ephe_path\" placeholder=\"C:/SwissEphemeris\" /></label>
+  <label>API Host <input name=\"api_host\" required /></label>
+  <label>API Port <input name=\"api_port\" type=\"number\" min=\"1\" max=\"65535\" required /></label>
+  <label>Streamlit Port <input name=\"streamlit_port\" type=\"number\" min=\"1\" max=\"65535\" required /></label>
+  <label>AE_QCACHE_SEC <input name=\"qcache_sec\" type=\"number\" step=\"0.1\" min=\"0.01\" /></label>
+  <label>AE_QCACHE_SIZE <input name=\"qcache_size\" type=\"number\" min=\"128\" /></label>
+  <label>Logging Level
+    <select name=\"logging_level\">
+      <option>DEBUG</option>
+      <option>INFO</option>
+      <option>WARNING</option>
+      <option>ERROR</option>
+      <option>CRITICAL</option>
+    </select>
+  </label>
+  <label>Theme
+    <select name=\"theme\">
+      <option value=\"system\">System</option>
+      <option value=\"light\">Light</option>
+      <option value=\"dark\">Dark</option>
+    </select>
+  </label>
+  <label>OpenAI API Key <input name=\"openai_api_key\" type=\"password\" autocomplete=\"off\" /></label>
+  <label>OpenAI Model <input name=\"openai_model\" /></label>
+  <label>OpenAI Base URL <input name=\"openai_base_url\" /></label>
+  <label>Copilot Daily Limit <input name=\"copilot_daily_limit\" type=\"number\" min=\"0\" /></label>
+  <label>Copilot Session Limit <input name=\"copilot_session_limit\" type=\"number\" min=\"0\" /></label>
+  <label><input type=\"checkbox\" name=\"autostart\" /> Start AstroEngine when I sign in</label>
+  <div style=\"display:flex; gap:0.5rem; flex-wrap:wrap;\">
+    <button id=\"saveButton\">Save Settings</button>
+    <button class=\"secondary\" id=\"testDb\">Test Database</button>
+    <button class=\"secondary\" id=\"checkEphe\">Check Ephemeris Path</button>
+    <button class=\"secondary\" id=\"makeBundle\">Create Issue Bundle</button>
+  </div>
+</form>
+<div id=\"status\"></div>
+<script>
+const form = document.getElementById('settingsForm');
+const statusEl = document.getElementById('status');
+const dbBtn = document.getElementById('testDb');
+const epheBtn = document.getElementById('checkEphe');
+const bundleBtn = document.getElementById('makeBundle');
+
+function showStatus(message, ok=true) {
+  statusEl.textContent = message;
+  statusEl.style.color = ok ? '#7fffd4' : '#ff6b6b';
+}
+
+function formData() {
+  const data = new FormData(form);
+  const payload = {};
+  for (const [key, value] of data.entries()) {
+    if (key === 'autostart') {
+      payload[key] = form.autostart.checked;
+    } else if (['api_port', 'streamlit_port', 'qcache_size', 'copilot_daily_limit', 'copilot_session_limit'].includes(key)) {
+      payload[key] = value ? Number(value) : 0;
+    } else if (key === 'qcache_sec') {
+      payload[key] = Number(value);
+    } else {
+      payload[key] = value;
+    }
+  }
+  return payload;
+}
+
+async function load() {
+  const cfg = await window.pywebview.api.get_config();
+  for (const [key, value] of Object.entries(cfg)) {
+    if (form[key] === undefined) continue;
+    if (typeof form[key].type === 'string' && form[key].type === 'checkbox') {
+      form[key].checked = Boolean(value);
+    } else {
+      form[key].value = value ?? '';
+    }
+  }
+  showStatus('Configuration loaded', true);
+}
+
+form.addEventListener('submit', async () => {
+  const payload = formData();
+  const result = await window.pywebview.api.save_config(payload);
+  if (result.ok) {
+    showStatus('Saved. Services restarting with new configuration.');
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+dbBtn.addEventListener('click', async () => {
+  const payload = formData();
+  const result = await window.pywebview.api.validate_database(payload.database_url);
+  if (result.ok) {
+    showStatus('Database connection succeeded.');
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+epheBtn.addEventListener('click', async () => {
+  const payload = formData();
+  const result = await window.pywebview.api.check_ephemeris(payload.se_ephe_path);
+  if (result.ok) {
+    showStatus('Swiss Ephemeris path verified.');
+  } else {
+    showStatus('Swiss Ephemeris path not found.', false);
+  }
+});
+
+bundleBtn.addEventListener('click', async () => {
+  const result = await window.pywebview.api.issue_bundle();
+  if (result.ok) {
+    showStatus('Issue bundle created at ' + result.path);
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+window.AstroEngine = window.AstroEngine || {};
+window.AstroEngine.setApiStatus = function(online) {
+  document.body.style.borderTop = online ? '4px solid #0f9960' : '4px solid #ff6b6b';
+};
+
+load();
+</script>
+</body>
+</html>
+"""
+
+
+DEFAULT_CHAT_HTML = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+<meta charset=\"utf-8\" />
+<title>AstroEngine Copilot</title>
+<style>
+body { font-family: 'Segoe UI', sans-serif; margin: 0; padding: 1rem; background: #0f1224; color: #f5f6fa; }
+#messages { max-height: 520px; overflow-y: auto; padding: 0.5rem; border: 1px solid #272a4b; border-radius: 8px; background: #141836; }
+.message { margin-bottom: 1rem; padding: 0.6rem 0.75rem; border-radius: 6px; }
+.message.user { background: #1e2344; border-left: 3px solid #c9973b; }
+.message.assistant { background: #16294f; border-left: 3px solid #0f9960; }
+#composer { display: flex; gap: 0.5rem; margin-top: 1rem; }
+#composer textarea { flex: 1; min-height: 60px; border-radius: 6px; border: 1px solid #2d3256; background: #1b2040; color: #f5f6fa; padding: 0.5rem; }
+#composer button { padding: 0.6rem 1rem; border: none; border-radius: 6px; background: #c9973b; color: #101321; font-weight: 600; cursor: pointer; }
+#status { margin-top: 0.5rem; font-size: 0.85rem; color: #9aa5ff; }
+</style>
+</head>
+<body>
+<h1>AstroEngine Copilot</h1>
+<div id=\"messages\"></div>
+<div id=\"status\"></div>
+<form id=\"composer\">
+  <textarea id=\"prompt\" placeholder=\"Ask the copilot to run diagnostics, tail logs, or explain an endpoint...\"></textarea>
+  <button>Send</button>
+</form>
+<script>
+const messagesEl = document.getElementById('messages');
+const statusEl = document.getElementById('status');
+const composer = document.getElementById('composer');
+const promptEl = document.getElementById('prompt');
+
+function append(role, text) {
+  const div = document.createElement('div');
+  div.className = 'message ' + role;
+  div.innerHTML = '<strong>' + role + '</strong><br />' + text.replace(/\n/g, '<br />');
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+async function refreshStatus() {
+  const stats = await window.pywebview.api.copilot_status();
+  statusEl.textContent = `Tokens today: ${stats.tokens_used_today}/${stats.daily_limit} · API ${stats.client_available ? 'ready' : 'not configured'}`;
+}
+
+composer.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const text = promptEl.value.trim();
+  if (!text) return;
+  append('user', text);
+  promptEl.value = '';
+  append('assistant', '… running tools / awaiting response …');
+  const nodes = messagesEl.querySelectorAll('.message.assistant');
+  const placeholder = nodes[nodes.length - 1];
+  const result = await window.pywebview.api.copilot_send(text);
+  placeholder.innerHTML = '<strong>assistant</strong><br />' + result.response.replace(/\n/g, '<br />');
+  refreshStatus();
+});
+
+window.AstroEngine = window.AstroEngine || {};
+window.AstroEngine.setApiStatus = function(online) {
+  statusEl.style.borderBottom = online ? '3px solid #0f9960' : '3px solid #ff6b6b';
+};
+
+refreshStatus();
+</script>
+</body>
+</html>
+"""
+
+
+__all__ = ["AstroEngineDesktopApp", "APIServerController", "StreamlitController"]

--- a/astroengine/ux/desktop/config.py
+++ b/astroengine/ux/desktop/config.py
@@ -1,0 +1,299 @@
+"""Configuration helpers for the AstroEngine desktop shell."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+LOG = logging.getLogger(__name__)
+
+APP_NAME = "AstroEngine"
+CONFIG_FILENAME = "config.yaml"
+STREAMLIT_DIRNAME = ".streamlit"
+STREAMLIT_CONFIG = "config.toml"
+DEFAULT_DB_NAME = "astroengine-desktop.db"
+DEFAULT_LOG_NAME = "astroengine.log"
+
+_VALID_LOG_LEVELS = {"CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"}
+_VALID_THEMES = {"system", "light", "dark"}
+
+
+class DesktopConfigModel(BaseModel):
+    """Pydantic model describing persisted desktop settings."""
+
+    schema_version: int = Field(default=1, ge=1)
+    database_url: str
+    se_ephe_path: str = ""
+    api_host: str = Field(default="127.0.0.1")
+    api_port: int = Field(default=8000, ge=1, le=65535)
+    streamlit_port: int = Field(default=8501, ge=1, le=65535)
+    qcache_sec: float = Field(default=1.0, gt=0.0)
+    qcache_size: int = Field(default=4096, ge=128)
+    logging_level: str = Field(default="INFO")
+    theme: str = Field(default="system")
+    openai_api_key: str = ""
+    openai_model: str = Field(default="gpt-4o-mini")
+    openai_base_url: str | None = None
+    copilot_daily_limit: int = Field(default=50000, ge=0)
+    copilot_session_limit: int = Field(default=8000, ge=0)
+    autostart: bool = False
+    issue_report_dir: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+    @field_validator("logging_level")
+    @classmethod
+    def _validate_logging_level(cls, value: str) -> str:
+        level = value.upper().strip()
+        if level not in _VALID_LOG_LEVELS:
+            raise ValueError(
+                f"Unsupported logging level '{value}'. Valid levels: {sorted(_VALID_LOG_LEVELS)}"
+            )
+        return level
+
+    @field_validator("theme")
+    @classmethod
+    def _validate_theme(cls, value: str) -> str:
+        theme = value.lower().strip()
+        if theme not in _VALID_THEMES:
+            raise ValueError(
+                f"Unsupported theme '{value}'. Valid themes: {sorted(_VALID_THEMES)}"
+            )
+        return theme
+
+
+class DesktopConfigManager:
+    """Manage the desktop configuration lifecycle with validation and migrations."""
+
+    CURRENT_SCHEMA_VERSION = 1
+
+    def __init__(self, app_name: str = APP_NAME, base_dir: Path | None = None) -> None:
+        self.app_name = app_name
+        self.base_dir = base_dir or self._resolve_app_dir(app_name)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self.config_path = self.base_dir / CONFIG_FILENAME
+        self.logs_dir = self.base_dir / "logs"
+        self.logs_dir.mkdir(exist_ok=True)
+        self.log_path = self.logs_dir / DEFAULT_LOG_NAME
+        self.issue_dir = self.base_dir / "issues"
+        self.issue_dir.mkdir(exist_ok=True)
+        self.streamlit_dir = self.base_dir / STREAMLIT_DIRNAME
+        self.streamlit_dir.mkdir(exist_ok=True)
+        self.streamlit_config_path = self.streamlit_dir / STREAMLIT_CONFIG
+
+    # ------------------------------------------------------------------
+    # public helpers
+    # ------------------------------------------------------------------
+    def load(self) -> DesktopConfigModel:
+        """Return the effective configuration, applying defaults as needed."""
+
+        payload = self._default_payload()
+        if self.config_path.exists():
+            try:
+                raw = yaml.safe_load(self.config_path.read_text(encoding="utf-8")) or {}
+                if isinstance(raw, dict):
+                    payload.update(raw)
+            except Exception as exc:  # pragma: no cover - defensive read
+                LOG.warning("Failed to read %s: %s", self.config_path, exc)
+        payload.setdefault("schema_version", self.CURRENT_SCHEMA_VERSION)
+        try:
+            model = DesktopConfigModel.model_validate(payload)
+        except ValidationError as exc:
+            raise ValueError(f"Invalid desktop configuration: {exc}") from exc
+        self._write_streamlit_theme(model.theme)
+        return model
+
+    def save(self, config: DesktopConfigModel) -> None:
+        """Persist ``config`` to disk and apply shell side-effects."""
+
+        data = self._redacted_dict(config, redact_secrets=False)
+        data["schema_version"] = self.CURRENT_SCHEMA_VERSION
+        yaml.safe_dump(data, self.config_path.open("w", encoding="utf-8"), sort_keys=True)
+        self._write_streamlit_theme(config.theme)
+        self.apply_environment(config)
+        self._apply_autostart(config.autostart)
+
+    def update(self, **changes: Any) -> DesktopConfigModel:
+        """Apply ``changes`` and return the resulting model after validation."""
+
+        config = self.load()
+        payload = config.model_dump()
+        payload.update(changes)
+        try:
+            model = DesktopConfigModel.model_validate(payload)
+        except ValidationError as exc:
+            raise ValueError(f"Invalid configuration update: {exc}") from exc
+        errors = self.validate_external(model)
+        if errors:
+            raise ValueError("; ".join(errors))
+        self.save(model)
+        return model
+
+    def validate_external(self, config: DesktopConfigModel) -> list[str]:
+        """Perform IO-heavy validation checks (database, filesystem)."""
+
+        errors: list[str] = []
+        se_path = config.se_ephe_path.strip()
+        if se_path and not Path(se_path).expanduser().exists():
+            errors.append(f"Swiss ephemeris path does not exist: {se_path}")
+        db_error = self._probe_database(config.database_url)
+        if db_error:
+            errors.append(db_error)
+        return errors
+
+    def probe_database(self, url: str) -> str | None:
+        """Public entrypoint to validate a database URL."""
+
+        return self._probe_database(url)
+
+    def check_ephemeris_path(self, path: str) -> bool:
+        """Return ``True`` if ``path`` exists or is left blank."""
+
+        if not path:
+            return True
+        return Path(path).expanduser().exists()
+
+    def apply_environment(self, config: DesktopConfigModel | None = None) -> None:
+        """Set process environment variables for the active configuration."""
+
+        config = config or self.load()
+        os.environ["ASTROENGINE_HOME"] = str(self.base_dir)
+        os.environ["DATABASE_URL"] = config.database_url
+        os.environ["AE_QCACHE_SEC"] = str(config.qcache_sec)
+        os.environ["AE_QCACHE_SIZE"] = str(config.qcache_size)
+        os.environ["ASTROENGINE_LOG_LEVEL"] = config.logging_level
+        if config.openai_api_key:
+            os.environ["ASTROENGINE_OPENAI_KEY"] = config.openai_api_key
+            os.environ["OPENAI_API_KEY"] = config.openai_api_key
+        else:
+            for key in ("ASTROENGINE_OPENAI_KEY", "OPENAI_API_KEY"):
+                os.environ.pop(key, None)
+        if config.openai_model:
+            os.environ["ASTROENGINE_OPENAI_MODEL"] = config.openai_model
+        if config.openai_base_url:
+            os.environ["ASTROENGINE_OPENAI_BASE_URL"] = config.openai_base_url
+        else:
+            os.environ.pop("ASTROENGINE_OPENAI_BASE_URL", None)
+        if config.se_ephe_path:
+            os.environ["SE_EPHE_PATH"] = str(Path(config.se_ephe_path).expanduser())
+        else:
+            os.environ.pop("SE_EPHE_PATH", None)
+        self._write_streamlit_theme(config.theme)
+        self._apply_autostart(config.autostart)
+
+    def redact(self, config: DesktopConfigModel | None = None) -> dict[str, Any]:
+        """Return a JSON-serialisable dictionary with secrets removed."""
+
+        config = config or self.load()
+        return self._redacted_dict(config, redact_secrets=True)
+
+    def ensure_issue_bundle(self, name: str, payload: dict[str, Any]) -> Path:
+        """Persist ``payload`` as a JSON diagnostics artifact for support bundles."""
+
+        safe_name = name.replace("/", "-").replace("\\", "-")
+        target = self.issue_dir / f"{safe_name}.json"
+        target.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+        return target
+
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _resolve_app_dir(app_name: str) -> Path:
+        if platform.system() == "Windows":
+            root = Path(os.environ.get("LOCALAPPDATA", Path.home()))
+        else:
+            root = Path(os.environ.get("ASTROENGINE_HOME", Path.home() / ".astroengine"))
+        return Path(root) / app_name
+
+    def _default_payload(self) -> dict[str, Any]:
+        db_path = (self.base_dir / DEFAULT_DB_NAME).as_posix()
+        return {
+            "schema_version": self.CURRENT_SCHEMA_VERSION,
+            "database_url": f"sqlite:///{db_path}",
+            "se_ephe_path": "",
+            "api_host": "127.0.0.1",
+            "api_port": 8000,
+            "streamlit_port": 8501,
+            "qcache_sec": 1.0,
+            "qcache_size": 4096,
+            "logging_level": "INFO",
+            "theme": "system",
+            "openai_api_key": "",
+            "openai_model": "gpt-4o-mini",
+            "openai_base_url": None,
+            "copilot_daily_limit": 50000,
+            "copilot_session_limit": 8000,
+            "autostart": False,
+            "issue_report_dir": str(self.issue_dir),
+        }
+
+    def _probe_database(self, url: str) -> str | None:
+        try:
+            from sqlalchemy import create_engine, text
+
+            engine = create_engine(url, pool_pre_ping=True)
+            with engine.connect() as conn:
+                conn.execute(text("SELECT 1"))
+        except Exception as exc:  # pragma: no cover - depends on drivers
+            return f"Database connection failed: {exc}"
+        return None
+
+    def _redacted_dict(self, config: DesktopConfigModel, *, redact_secrets: bool) -> dict[str, Any]:
+        data = config.model_dump()
+        if redact_secrets:
+            if data.get("openai_api_key"):
+                data["openai_api_key"] = "*** configured ***"
+        return data
+
+    def _write_streamlit_theme(self, theme: str) -> None:
+        if theme == "system":
+            if self.streamlit_config_path.exists():
+                try:
+                    self.streamlit_config_path.unlink()
+                except OSError:  # pragma: no cover - defensive cleanup
+                    LOG.debug("Unable to remove %s", self.streamlit_config_path)
+            return
+        theme_value = "dark" if theme == "dark" else "light"
+        config_text = "[theme]\nbase = \"{value}\"\n".format(value=theme_value)
+        self.streamlit_config_path.write_text(config_text, encoding="utf-8")
+
+    def _apply_autostart(self, enabled: bool) -> None:
+        if platform.system() != "Windows":  # pragma: no cover - requires Windows
+            return
+        try:
+            import winreg  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - module missing on non-Windows
+            return
+        key_path = r"Software\Microsoft\Windows\CurrentVersion\Run"
+        try:
+            with winreg.OpenKey(winreg.HKEY_CURRENT_USER, key_path, 0, winreg.KEY_SET_VALUE) as key:
+                if enabled:
+                    command = self._autostart_command()
+                    winreg.SetValueEx(key, self.app_name, 0, winreg.REG_SZ, command)
+                else:
+                    try:
+                        winreg.DeleteValue(key, self.app_name)
+                    except FileNotFoundError:
+                        pass
+        except OSError as exc:  # pragma: no cover - depends on permissions
+            LOG.warning("Unable to update autostart flag: %s", exc)
+
+    def _autostart_command(self) -> str:
+        executable = Path(getattr(sys, "frozen", False) and sys.executable or sys.executable)
+        if getattr(sys, "frozen", False):
+            return str(executable)
+        project_root = Path(__file__).resolve().parents[3]
+        module_path = project_root / "app" / "desktop" / "launch_desktop.py"
+        return f'"{sys.executable}" "{module_path}"'
+
+
+__all__ = ["DesktopConfigManager", "DesktopConfigModel"]

--- a/astroengine/ux/desktop/copilot.py
+++ b/astroengine/ux/desktop/copilot.py
@@ -1,0 +1,353 @@
+"""ChatGPT copilot integration for the AstroEngine desktop shell."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import logging
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import httpx
+
+from astroengine import diagnostics
+from astroengine.narrative.gpt_api import GPTNarrativeClient
+
+from .config import DesktopConfigManager
+
+LOG = logging.getLogger(__name__)
+
+_TOOL_HINTS = {
+    "diagnostics": ("diagnostic", "doctor", "health check"),
+    "healthz": ("healthz", "health", "status"),
+    "tail_logs": ("tail log", "recent log", "show log"),
+    "summarize_errors": ("error summary", "explain error"),
+    "explain_endpoints": ("explain endpoint", "api list", "help endpoint"),
+}
+
+_SECRET_PATTERN = re.compile(r"(?<=://)([^:@]+):([^@]+)@")
+
+
+@dataclass
+class CopilotMessage:
+    role: str
+    content: str
+
+
+@dataclass
+class CopilotResult:
+    response: str
+    tokens_consumed: int
+    total_tokens: int
+    tool_invocations: list[str]
+
+
+class DesktopCopilot:
+    """Simple assistant wrapper that routes tool requests and GPT completions."""
+
+    def __init__(
+        self,
+        config_manager: DesktopConfigManager,
+        *,
+        http_client: httpx.Client | None = None,
+    ) -> None:
+        self.config_manager = config_manager
+        self.http_client = http_client or httpx.Client(timeout=10.0)
+        self.state_path = self.config_manager.base_dir / "copilot_state.json"
+        self.messages: list[CopilotMessage] = []
+        self._state_lock = threading.Lock()
+        self._daily_tokens, self._state_date = self._load_token_state()
+        self.config = self.config_manager.load()
+        self.client = GPTNarrativeClient(
+            api_key=self.config.openai_api_key or None,
+            model=self.config.openai_model,
+            base_url=self.config.openai_base_url or None,
+            allow_stub=True,
+        )
+
+    # ------------------------------------------------------------------
+    # High level conversation API
+    # ------------------------------------------------------------------
+    def refresh_config(self) -> None:
+        """Reload configuration (e.g., after settings change)."""
+
+        with self._state_lock:
+            self.config = self.config_manager.load()
+            self.client = GPTNarrativeClient(
+                api_key=self.config.openai_api_key or None,
+                model=self.config.openai_model,
+                base_url=self.config.openai_base_url or None,
+                allow_stub=True,
+            )
+
+    def send(self, user_text: str) -> CopilotResult:
+        """Process ``user_text`` and return a response."""
+
+        user_text = user_text.strip()
+        if not user_text:
+            return CopilotResult("I need a question to help with.", 0, self._daily_tokens, [])
+
+        today = _dt.date.today()
+        with self._state_lock:
+            if today != self._state_date:
+                self._daily_tokens = 0
+                self._state_date = today
+            if (
+                self.config.copilot_daily_limit
+                and self._daily_tokens >= self.config.copilot_daily_limit
+            ):
+                return CopilotResult(
+                    "The daily copilot token budget has been reached. Try again tomorrow or raise the limit in Settings.",
+                    0,
+                    self._daily_tokens,
+                    [],
+                )
+
+        self.messages.append(CopilotMessage("user", user_text))
+        tools = self._detect_tools(user_text)
+        tool_outputs: list[str] = []
+        tool_names: list[str] = []
+        for tool_name in tools:
+            try:
+                output = self._invoke_tool(tool_name)
+            except Exception as exc:  # pragma: no cover - runtime safety
+                LOG.exception("Tool %s failed", tool_name)
+                output = f"{tool_name} failed: {exc}"
+            sanitized = self._sanitize(output)
+            tool_outputs.append(f"[{tool_name}]\n{sanitized}")
+            tool_names.append(tool_name)
+
+        prompt = self._build_prompt(user_text, tool_outputs)
+        if not self.client.available:
+            response_text = self._fallback_response(user_text, tool_outputs)
+            tokens = self._estimate_tokens(response_text)
+            self._record_tokens(tokens)
+            self.messages.append(CopilotMessage("assistant", response_text))
+            return CopilotResult(response_text, tokens, self._daily_tokens, tool_names)
+
+        try:
+            response_text = self.client.summarize(prompt)
+        except Exception as exc:  # pragma: no cover - network error
+            LOG.warning("OpenAI request failed: %s", exc)
+            response_text = self._fallback_response(user_text, tool_outputs)
+        tokens = self._estimate_tokens(response_text)
+        self._record_tokens(tokens)
+        response_text = self._sanitize(response_text)
+        self.messages.append(CopilotMessage("assistant", response_text))
+        return CopilotResult(response_text, tokens, self._daily_tokens, tool_names)
+
+    def status(self) -> dict[str, Any]:
+        """Return telemetry for UI bindings (tokens and key availability)."""
+
+        return {
+            "tokens_used_today": self._daily_tokens,
+            "daily_limit": self.config.copilot_daily_limit,
+            "session_limit": self.config.copilot_session_limit,
+            "client_available": self.client.available,
+        }
+
+    def invoke_tool(self, name: str) -> str:
+        """Expose tool invocation for the settings UI (with sanitisation)."""
+
+        output = self._invoke_tool(name)
+        return self._sanitize(output)
+
+    def create_issue_bundle(self) -> Path:
+        """Create a support bundle and return the resulting archive path."""
+
+        return self._create_issue_bundle()
+
+    # ------------------------------------------------------------------
+    # Tool routing
+    # ------------------------------------------------------------------
+    def _detect_tools(self, message: str) -> list[str]:
+        message_lower = message.lower()
+        matches: list[str] = []
+        for name, keywords in _TOOL_HINTS.items():
+            if any(keyword in message_lower for keyword in keywords):
+                matches.append(name)
+        if "issue" in message_lower and "report" in message_lower:
+            matches.append("issue_bundle")
+        return matches
+
+    def _invoke_tool(self, name: str) -> str:
+        if name == "diagnostics":
+            return self._run_diagnostics()
+        if name == "healthz":
+            return self._fetch_healthz()
+        if name == "tail_logs":
+            return self._tail_logs()
+        if name == "summarize_errors":
+            return self._summarize_errors()
+        if name == "explain_endpoints":
+            return self._explain_endpoints()
+        if name == "issue_bundle":
+            bundle = self._create_issue_bundle()
+            return f"Issue bundle prepared at: {bundle}"
+        raise ValueError(f"Unknown tool '{name}'")
+
+    def _run_diagnostics(self) -> str:
+        checks = [diagnostics.check_python()]
+        for func in (
+            diagnostics.check_core_imports,
+            diagnostics.check_optional_deps,
+            diagnostics.check_timezone_libs,
+            diagnostics.check_swisseph,
+        ):
+            results = func()
+            if isinstance(results, diagnostics.Check):
+                checks.append(results)
+            else:
+                checks.extend(results)
+        ordered = sorted(checks, key=lambda chk: diagnostics._status_order(chk.status))
+        lines = ["AstroEngine diagnostics:"]
+        for chk in ordered:
+            detail = chk.detail.strip()
+            lines.append(f"- [{chk.status}] {chk.name}: {detail}")
+        return "\n".join(lines)
+
+    def _fetch_healthz(self) -> str:
+        url = f"http://{self.config.api_host}:{self.config.api_port}/healthz"
+        try:
+            response = self.http_client.get(url)
+            response.raise_for_status()
+            data = response.json()
+        except httpx.HTTPError as exc:
+            return f"Failed to reach {url}: {exc}"
+        return json.dumps(data, indent=2, sort_keys=True)
+
+    def _tail_logs(self, limit: int = 200) -> str:
+        path = self.config_manager.log_path
+        if not path.exists():
+            return "No log file has been written yet."
+        from collections import deque
+
+        tail = deque(maxlen=limit)
+        with path.open("r", encoding="utf-8", errors="ignore") as handle:
+            for line in handle:
+                tail.append(line.rstrip("\n"))
+        sanitized = [self._sanitize(line) for line in tail]
+        return "\n".join(sanitized)
+
+    def _summarize_errors(self) -> str:
+        text = self._tail_logs(limit=400)
+        errors = [line for line in text.splitlines() if "ERROR" in line]
+        if not errors:
+            return "No recent ERROR lines captured in the log tail."
+        summary = ["Recent error lines:"]
+        summary.extend(errors[-25:])
+        return "\n".join(summary)
+
+    def _explain_endpoints(self) -> str:
+        url = f"http://{self.config.api_host}:{self.config.api_port}/openapi.json"
+        try:
+            response = self.http_client.get(url)
+            response.raise_for_status()
+            data = response.json()
+        except httpx.HTTPError as exc:
+            return f"Failed to query {url}: {exc}"
+        paths = data.get("paths", {}) if isinstance(data, dict) else {}
+        lines = ["Available API endpoints:"]
+        for path, methods in sorted(paths.items()):
+            if not isinstance(methods, dict):
+                continue
+            verbs = ", ".join(sorted(methods))
+            lines.append(f"- {path} ({verbs})")
+        return "\n".join(lines)
+
+    def _create_issue_bundle(self) -> Path:
+        timestamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        diagnostics_text = self._run_diagnostics()
+        logs_text = self._tail_logs(limit=500)
+        payload = {
+            "generated_at": _dt.datetime.now().isoformat(),
+            "diagnostics": diagnostics_text,
+            "log_tail": logs_text,
+        }
+        metadata_path = self.config_manager.ensure_issue_bundle(f"bundle-{timestamp}", payload)
+        archive_path = self.config_manager.issue_dir / f"astroengine-support-{timestamp}.zip"
+        from zipfile import ZIP_DEFLATED, ZipFile
+
+        with ZipFile(archive_path, "w", ZIP_DEFLATED) as archive:
+            archive.writestr("diagnostics.txt", diagnostics_text)
+            archive.writestr("logs.txt", logs_text)
+            archive.write(metadata_path, metadata_path.name)
+        return archive_path
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def _build_prompt(self, user_text: str, tool_outputs: Iterable[str]) -> str:
+        parts = [
+            "You are AstroEngine's desktop copilot. Always cite actual diagnostics data.",
+            "User question:",
+            user_text,
+        ]
+        for output in tool_outputs:
+            parts.append("Tool output:")
+            parts.append(output)
+        parts.append(
+            "Explain the findings with concrete references. If you lack data, ask the user to run a relevant tool."
+        )
+        return "\n\n".join(parts)
+
+    def _fallback_response(self, user_text: str, tool_outputs: list[str]) -> str:
+        if tool_outputs:
+            joined = "\n\n".join(tool_outputs)
+            return (
+                "I summarised the requested tools locally because the OpenAI client is not configured.\n"
+                f"Here is the raw output:\n{joined}"
+            )
+        return (
+            "The OpenAI client is not configured. Add an API key under Settings to enable natural language responses."
+        )
+
+    def _sanitize(self, text: str) -> str:
+        secrets: list[str] = []
+        if self.config.openai_api_key:
+            secrets.append(self.config.openai_api_key)
+        secrets.append(self.config.database_url)
+        for secret in secrets:
+            if secret:
+                text = text.replace(secret, "[redacted]")
+        text = _SECRET_PATTERN.sub(lambda m: f"{m.group(1)}:[redacted]@", text)
+        return text
+
+    def _estimate_tokens(self, text: str) -> int:
+        words = len(text.split())
+        return max(1, int(words * 1.3))
+
+    def _record_tokens(self, tokens: int) -> None:
+        with self._state_lock:
+            session_limit = self.config.copilot_session_limit
+            if session_limit and tokens > session_limit:
+                tokens = session_limit
+            self._daily_tokens += tokens
+            self._save_token_state()
+
+    def _load_token_state(self) -> tuple[int, _dt.date]:
+        if not self.state_path.exists():
+            return 0, _dt.date.today()
+        try:
+            data = json.loads(self.state_path.read_text(encoding="utf-8"))
+            stored_date = _dt.date.fromisoformat(data.get("date", ""))
+            tokens = int(data.get("tokens", 0))
+            today = _dt.date.today()
+            if stored_date == today:
+                return tokens, stored_date
+        except Exception as exc:  # pragma: no cover - best effort load
+            LOG.debug("Unable to load copilot state: %s", exc)
+        return 0, _dt.date.today()
+
+    def _save_token_state(self) -> None:
+        payload = {"date": self._state_date.isoformat(), "tokens": self._daily_tokens}
+        try:
+            self.state_path.write_text(json.dumps(payload), encoding="utf-8")
+        except Exception as exc:  # pragma: no cover - filesystem errors
+            LOG.debug("Unable to persist copilot state: %s", exc)
+
+
+__all__ = ["DesktopCopilot", "CopilotResult", "CopilotMessage"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,12 @@ ui = [
   "plotly>=5.20",
 ]
 
+desktop = [
+  "pywebview>=4.4",
+  "pystray>=0.19",
+  "openai>=1.0",
+]
+
 # Observability helpers
 obs = [
   "opentelemetry-sdk>=1.26",
@@ -176,6 +182,9 @@ all = [
   "python-docx>=1.1",
   "playwright>=1.45",
   "pypandoc>=1.12",
+  "pywebview>=4.4",
+  "pystray>=0.19",
+  "openai>=1.0",
   "pytest",
   "hypothesis",
   "ruff",

--- a/tests/desktop/test_config.py
+++ b/tests/desktop/test_config.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from astroengine.ux.desktop.config import DesktopConfigManager, DesktopConfigModel
+from astroengine.ux.desktop.copilot import DesktopCopilot
+
+
+class DummyResponse:
+    def __init__(self, data: dict[str, object]) -> None:
+        self._data = data
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no failure in tests
+        return None
+
+    def json(self) -> dict[str, object]:
+        return self._data
+
+
+class DummyHttpClient:
+    def __init__(self, payload: dict[str, object] | None = None) -> None:
+        self.payload = payload or {"status": "ok"}
+        self.requests: list[str] = []
+
+    def get(self, url: str) -> DummyResponse:
+        self.requests.append(url)
+        return DummyResponse(self.payload)
+
+
+@pytest.fixture()
+def manager(tmp_path: Path) -> DesktopConfigManager:
+    return DesktopConfigManager(base_dir=tmp_path)
+
+
+def test_load_defaults(manager: DesktopConfigManager) -> None:
+    config = manager.load()
+    assert config.schema_version == DesktopConfigManager.CURRENT_SCHEMA_VERSION
+    assert config.database_url.endswith("astroengine-desktop.db")
+    assert manager.redact(config)["openai_api_key"] == ""
+
+
+def test_save_roundtrip(manager: DesktopConfigManager, tmp_path: Path) -> None:
+    config = manager.load()
+    updated = manager.update(database_url="sqlite:///{}".format((tmp_path / "db.sqlite").as_posix()))
+    assert updated.database_url.endswith("db.sqlite")
+    reloaded = manager.load()
+    assert reloaded.database_url.endswith("db.sqlite")
+
+
+def test_probe_database_failure(manager: DesktopConfigManager) -> None:
+    error = manager.probe_database("sqlite:///nonexistent/dir/foo.db")
+    assert error is not None
+
+
+def test_check_ephemeris(manager: DesktopConfigManager, tmp_path: Path) -> None:
+    assert manager.check_ephemeris_path("")
+    assert not manager.check_ephemeris_path(str(tmp_path / "missing"))
+    existing = tmp_path / "ephe"
+    existing.mkdir()
+    assert manager.check_ephemeris_path(str(existing))
+
+
+def test_copilot_diagnostics(tmp_path: Path) -> None:
+    manager = DesktopConfigManager(base_dir=tmp_path)
+    config = manager.load()
+    manager.save(config)
+    http_client = DummyHttpClient({"status": "pass"})
+    copilot = DesktopCopilot(manager, http_client=http_client)
+    log_path = manager.log_path
+    log_path.write_text("INFO ready\nERROR failed\n", encoding="utf-8")
+
+    result = copilot.send("please run diagnostics and tail logs")
+    assert "AstroEngine diagnostics" in result.response
+    assert "ERROR failed" in copilot.invoke_tool("summarize_errors")
+    bundle_path = copilot.create_issue_bundle()
+    assert bundle_path.exists()
+    with bundle_path.open("rb") as fh:
+        header = fh.read(2)
+    assert header == b"PK"  # zip header
+
+
+def test_copilot_token_guardrail(tmp_path: Path) -> None:
+    manager = DesktopConfigManager(base_dir=tmp_path)
+    config = manager.load()
+    manager.save(config)
+    http_client = DummyHttpClient()
+    copilot = DesktopCopilot(manager, http_client=http_client)
+    copilot.config = DesktopConfigModel.model_validate({
+        **config.model_dump(),
+        "copilot_daily_limit": 1,
+    })
+    result = copilot.send("hello")
+    assert "OpenAI client" in result.response
+    blocked = copilot.send("hello again")
+    assert "daily copilot token budget" in blocked.response


### PR DESCRIPTION
## Summary
- add astroengine.ux.desktop package with pywebview shell, tray menus, metrics links, and copilot integration
- persist desktop settings to %LOCALAPPDATA%/AstroEngine/config.yaml with validation, autostart updates, and Streamlit theme sync
- wire launch_desktop entry point to new shell, document the workflow, and cover config/copilot helpers with regression tests

## Testing
- pytest tests/desktop -q

------
https://chatgpt.com/codex/tasks/task_e_68e2de23b9c08324b4087e82dbc6e4ab