### PR TITLE
Add timeline analysis API and Streamlit finder

### DIFF
--- a/astroengine/analysis/__init__.py
+++ b/astroengine/analysis/__init__.py
@@ -1,0 +1,17 @@
+"""Analysis helpers for generating astrology timelines."""
+
+from .timeline import (
+    VoidOfCourseEvent,
+    find_eclipses,
+    find_lunations,
+    find_stations,
+    void_of_course_moon,
+)
+
+__all__ = [
+    "find_lunations",
+    "find_eclipses",
+    "find_stations",
+    "void_of_course_moon",
+    "VoidOfCourseEvent",
+]

--- a/astroengine/analysis/timeline.py
+++ b/astroengine/analysis/timeline.py
@@ -1,0 +1,230 @@
+"""Timeline utilities exposing lunations, eclipses, stations, and void-of-course data."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from ..detectors.common import delta_deg, moon_lon, solve_zero_crossing, body_lon
+from ..detectors.eclipses import find_eclipses as _detector_eclipses
+from ..detectors.ingresses import sign_index, sign_name
+from ..detectors.lunations import find_lunations as _detector_lunations
+from ..detectors.stations import find_stations as _detector_stations
+from ..ephemeris.swisseph_adapter import SwissEphemerisAdapter
+from ..events import EclipseEvent, LunationEvent, StationEvent
+
+__all__ = [
+    "find_lunations",
+    "find_eclipses",
+    "find_stations",
+    "void_of_course_moon",
+    "VoidOfCourseEvent",
+]
+
+_VOC_ASPECTS: Mapping[str, float] = {
+    "conjunction": 0.0,
+    "sextile": 60.0,
+    "square": 90.0,
+    "trine": 120.0,
+    "opposition": 180.0,
+}
+_VOC_BODIES: Sequence[str] = (
+    "Sun",
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+    "Uranus",
+    "Neptune",
+    "Pluto",
+)
+
+
+@dataclass(frozen=True)
+class VoidOfCourseEvent:
+    """Represents a void-of-course Moon interval."""
+
+    ts: str
+    jd: float
+    end_ts: str
+    end_jd: float
+    is_void: bool
+    moon_sign: str
+    next_sign: str
+    end_reason: str
+    terminating_body: str | None = None
+    terminating_aspect: str | None = None
+
+
+def _ensure_utc(moment: dt.datetime) -> dt.datetime:
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        raise ValueError("datetime must be timezone-aware in UTC")
+    return moment.astimezone(dt.UTC)
+
+
+def _to_julian(moment: dt.datetime) -> float:
+    adapter = SwissEphemerisAdapter.get_default_adapter()
+    return adapter.julian_day(_ensure_utc(moment))
+
+
+def _from_julian(jd: float) -> dt.datetime:
+    adapter = SwissEphemerisAdapter.get_default_adapter()
+    return adapter.from_julian_day(jd)
+
+
+def find_lunations(
+    start: dt.datetime,
+    end: dt.datetime,
+    *,
+    step_hours: float = 3.0,
+) -> list[LunationEvent]:
+    """Return lunations between ``start`` and ``end`` using Swiss ephemeris."""
+
+    start_jd = _to_julian(start)
+    end_jd = _to_julian(end)
+    return _detector_lunations(start_jd, end_jd, step_hours=step_hours)
+
+
+def find_eclipses(start: dt.datetime, end: dt.datetime) -> list[EclipseEvent]:
+    """Return eclipses between ``start`` and ``end`` when Swiss ephemeris is available."""
+
+    start_jd = _to_julian(start)
+    end_jd = _to_julian(end)
+    return _detector_eclipses(start_jd, end_jd)
+
+
+def find_stations(
+    body: str,
+    start: dt.datetime,
+    end: dt.datetime,
+    *,
+    step_days: float = 0.5,
+) -> list[StationEvent]:
+    """Return station events for ``body`` within ``start`` and ``end``."""
+
+    start_jd = _to_julian(start)
+    end_jd = _to_julian(end)
+    events = _detector_stations(start_jd, end_jd, bodies=[body], step_days=step_days)
+    return events
+
+
+def _moon_sign_boundary(longitude: float, *, sign_orb: float) -> float:
+    idx = sign_index(longitude)
+    boundary = (idx + 1) * 30.0
+    return boundary + float(sign_orb)
+
+
+def _refine_moon_ingress(start_jd: float, *, sign_orb: float) -> float:
+    start_lon = moon_lon(start_jd) % 360.0
+    target = _moon_sign_boundary(start_lon, sign_orb=sign_orb)
+    prev_jd = start_jd
+    prev_delta = delta_deg(moon_lon(prev_jd), target)
+    step = 1.0 / 24.0  # 1 hour steps
+    jd = prev_jd + step
+    limit = start_jd + 3.0
+    while jd <= limit:
+        curr_delta = delta_deg(moon_lon(jd), target)
+        root: float | None = None
+        if prev_delta == 0.0:
+            root = prev_jd
+        elif prev_delta * curr_delta <= 0.0:
+            try:
+                root = solve_zero_crossing(
+                    lambda value, tgt=target: delta_deg(moon_lon(value), tgt),
+                    prev_jd,
+                    jd,
+                    tol=5e-6,
+                    value_tol=5e-5,
+                )
+            except ValueError:
+                root = None
+        if root is not None and root > start_jd:
+            return root
+        prev_jd = jd
+        prev_delta = curr_delta
+        jd += step
+    return limit
+
+
+def _aspect_delta(jd: float, body: str, target: float) -> float:
+    moon = moon_lon(jd)
+    other = body_lon(jd, body)
+    separation = (moon - other) % 360.0
+    return delta_deg(separation, target)
+
+
+def _next_moon_aspect(start_jd: float, end_jd: float) -> tuple[float, str, str] | None:
+    if end_jd <= start_jd:
+        return None
+    step = 1.0 / 24.0
+    prev_jd = start_jd
+    prev = {
+        body: {name: _aspect_delta(prev_jd, body, angle) for name, angle in _VOC_ASPECTS.items()}
+        for body in _VOC_BODIES
+    }
+    jd = start_jd + step
+    while jd <= end_jd:
+        curr = {
+            body: {name: _aspect_delta(jd, body, angle) for name, angle in _VOC_ASPECTS.items()}
+            for body in _VOC_BODIES
+        }
+        candidate: tuple[float, str, str] | None = None
+        for body in _VOC_BODIES:
+            for aspect_name, target in _VOC_ASPECTS.items():
+                prev_delta = prev[body][aspect_name]
+                curr_delta = curr[body][aspect_name]
+                root: float | None = None
+                if prev_delta == 0.0:
+                    root = prev_jd
+                elif prev_delta * curr_delta <= 0.0:
+                    try:
+                        root = solve_zero_crossing(
+                            lambda value, b=body, t=target: _aspect_delta(value, b, t),
+                            prev_jd,
+                            min(jd, end_jd),
+                            tol=5e-6,
+                            value_tol=5e-5,
+                        )
+                    except ValueError:
+                        root = None
+                if root is None or not (start_jd <= root <= end_jd):
+                    continue
+                if candidate is None or root < candidate[0]:
+                    candidate = (root, body, aspect_name)
+        if candidate is not None:
+            return candidate
+        prev_jd = jd
+        prev = curr
+        jd += step
+    return None
+
+
+def void_of_course_moon(
+    moment: dt.datetime,
+    *,
+    sign_orb: float = 0.0,
+) -> VoidOfCourseEvent:
+    """Return a naive void-of-course Moon interval beginning at ``moment``."""
+
+    start_dt = _ensure_utc(moment)
+    start_jd = _to_julian(start_dt)
+    start_lon = moon_lon(start_jd) % 360.0
+    ingress_jd = _refine_moon_ingress(start_jd, sign_orb=sign_orb)
+    aspect = _next_moon_aspect(start_jd, ingress_jd)
+    is_void = aspect is None
+    end_jd = ingress_jd if is_void else aspect[0]
+    end_dt = _from_julian(end_jd)
+    return VoidOfCourseEvent(
+        ts=start_dt.isoformat().replace("+00:00", "Z"),
+        jd=start_jd,
+        end_ts=end_dt.astimezone(dt.UTC).isoformat().replace("+00:00", "Z"),
+        end_jd=end_jd,
+        is_void=is_void,
+        moon_sign=sign_name(sign_index(start_lon)),
+        next_sign=sign_name(sign_index(start_lon) + 1),
+        end_reason="ingress" if is_void else "aspect",
+        terminating_body=None if is_void else aspect[1],
+        terminating_aspect=None if is_void else aspect[2],
+    )

--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -21,6 +21,7 @@ def create_app() -> FastAPI:
     from .routers import topocentric as topocentric_router
     from .routers import transit_overlay as transit_overlay_router
     from .routers import vedic as vedic_router
+    from .routers import timeline as timeline_router
 
     app = FastAPI(
         title="AstroEngine API",
@@ -46,6 +47,7 @@ def create_app() -> FastAPI:
     app.include_router(vedic_router.router)
     app.include_router(topocentric_router.router, prefix="/v1", tags=["topocentric"])
     app.include_router(transit_overlay_router.router)
+    app.include_router(timeline_router.router, prefix="/v1", tags=["timeline"])
 
     return app
 

--- a/astroengine/api/routers/__init__.py
+++ b/astroengine/api/routers/__init__.py
@@ -14,5 +14,6 @@ __all__ = [
     "traditional",
     "lots",
     "transit_overlay",
+    "timeline",
 ]
 

--- a/astroengine/api/routers/timeline.py
+++ b/astroengine/api/routers/timeline.py
@@ -1,0 +1,225 @@
+"""Timeline API router exposing lunations, eclipses, stations, and void-of-course data."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from functools import lru_cache
+from typing import Any, Iterable, Literal
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ...analysis import (
+    VoidOfCourseEvent,
+    find_eclipses,
+    find_lunations,
+    find_stations,
+    void_of_course_moon,
+)
+from ...config import default_settings, load_settings
+from ...events import EclipseEvent, LunationEvent, StationEvent
+from .._time import ensure_utc_datetime
+
+router = APIRouter()
+
+_ALLOWED_TYPES: dict[str, str] = {
+    "lunations": "lunations",
+    "lunation": "lunations",
+    "eclipses": "eclipses",
+    "eclipse": "eclipses",
+    "stations": "stations",
+    "station": "stations",
+    "void_of_course": "void_of_course",
+    "void-of-course": "void_of_course",
+    "voc": "void_of_course",
+}
+_DEFAULT_STATION_BODIES: tuple[str, ...] = (
+    "Mercury",
+    "Venus",
+    "Mars",
+    "Jupiter",
+    "Saturn",
+)
+
+
+class TimelineEventModel(BaseModel):
+    type: Literal["lunations", "eclipses", "stations", "void_of_course"]
+    ts: str
+    jd: float
+    summary: str
+    end_ts: str | None = None
+    end_jd: float | None = None
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+class TimelineResponse(BaseModel):
+    events: list[TimelineEventModel]
+
+
+@lru_cache(maxsize=1)
+def _get_settings():
+    try:
+        return load_settings()
+    except Exception:
+        return default_settings()
+
+
+def _serialize_lunations(events: Iterable[LunationEvent]) -> list[TimelineEventModel]:
+    payload: list[TimelineEventModel] = []
+    for event in events:
+        phase_title = event.phase.replace("_", " ").title()
+        summary = f"{phase_title} Moon"
+        payload.append(
+            TimelineEventModel(
+                type="lunations",
+                ts=event.ts,
+                jd=event.jd,
+                summary=summary,
+                details={
+                    "phase": event.phase,
+                    "sun_longitude": event.sun_longitude,
+                    "moon_longitude": event.moon_longitude,
+                },
+            )
+        )
+    return payload
+
+
+def _serialize_eclipses(events: Iterable[EclipseEvent]) -> list[TimelineEventModel]:
+    payload: list[TimelineEventModel] = []
+    for event in events:
+        eclipse_kind = event.eclipse_type.title()
+        phase_title = event.phase.replace("_", " ").title()
+        summary = f"{eclipse_kind} Eclipse ({phase_title})"
+        payload.append(
+            TimelineEventModel(
+                type="eclipses",
+                ts=event.ts,
+                jd=event.jd,
+                summary=summary,
+                details={
+                    "eclipse_type": event.eclipse_type,
+                    "phase": event.phase,
+                    "sun_longitude": event.sun_longitude,
+                    "moon_longitude": event.moon_longitude,
+                    "moon_latitude": event.moon_latitude,
+                    "is_visible": event.is_visible,
+                },
+            )
+        )
+    return payload
+
+
+def _serialize_stations(events: Iterable[StationEvent]) -> list[TimelineEventModel]:
+    payload: list[TimelineEventModel] = []
+    for event in events:
+        if event.station_type:
+            summary = f"{event.body} station {event.station_type}"
+        else:
+            summary = f"{event.body} station"
+        payload.append(
+            TimelineEventModel(
+                type="stations",
+                ts=event.ts,
+                jd=event.jd,
+                summary=summary,
+                details={
+                    "body": event.body,
+                    "motion": event.motion,
+                    "longitude": event.longitude,
+                    "speed_longitude": event.speed_longitude,
+                    "station_type": event.station_type,
+                },
+            )
+        )
+    return payload
+
+
+def _serialize_voc(event: VoidOfCourseEvent) -> TimelineEventModel:
+    details = asdict(event)
+    details.pop("ts", None)
+    details.pop("jd", None)
+    return TimelineEventModel(
+        type="void_of_course",
+        ts=event.ts,
+        jd=event.jd,
+        summary=f"Void-of-course Moon in {event.moon_sign}",
+        end_ts=event.end_ts,
+        end_jd=event.end_jd,
+        details=details,
+    )
+
+
+@router.get("/timeline", response_model=TimelineResponse)
+def timeline(
+    from_: str = Query(..., alias="from", description="Start of the search window (UTC RFC3339)"),
+    to: str = Query(..., description="End of the search window (UTC RFC3339)"),
+    types: str | None = Query(
+        None,
+        description="Comma separated list of event types: lunations,eclipses,stations,void_of_course",
+    ),
+    bodies: str | None = Query(None, description="Optional comma separated list of station bodies"),
+    sign_orb: float = Query(0.0, ge=0.0, le=5.0, description="Orb in degrees when extending void-of-course past sign ingress"),
+) -> TimelineResponse:
+    settings = _get_settings()
+    if not settings.timeline_ui:
+        raise HTTPException(status_code=404, detail="Timeline endpoint disabled by configuration")
+
+    start_dt = ensure_utc_datetime(from_)
+    end_dt = ensure_utc_datetime(to)
+    if end_dt <= start_dt:
+        raise HTTPException(status_code=400, detail="'to' must be after 'from'")
+
+    requested: set[str]
+    if types:
+        requested = set()
+        for token in types.split(","):
+            key = token.strip().lower()
+            if not key:
+                continue
+            try:
+                resolved = _ALLOWED_TYPES[key]
+            except KeyError as exc:
+                raise HTTPException(status_code=400, detail=f"Unknown timeline type '{token}'") from exc
+            requested.add(resolved)
+        if not requested:
+            requested = set(_ALLOWED_TYPES.values())
+    else:
+        requested = {"lunations", "eclipses", "stations"}
+
+    events: list[TimelineEventModel] = []
+
+    if "lunations" in requested:
+        events.extend(_serialize_lunations(find_lunations(start_dt, end_dt)))
+
+    if "eclipses" in requested:
+        if settings.eclipse_finder:
+            try:
+                events.extend(_serialize_eclipses(find_eclipses(start_dt, end_dt)))
+            except Exception as exc:  # pragma: no cover - runtime-only fallback
+                raise HTTPException(status_code=503, detail=str(exc)) from exc
+        else:
+            requested.discard("eclipses")
+
+    if "stations" in requested:
+        if not settings.stations:
+            requested.discard("stations")
+        else:
+            body_list = _DEFAULT_STATION_BODIES
+            if bodies:
+                parsed = [token.strip() for token in bodies.split(",") if token.strip()]
+                if parsed:
+                    body_list = tuple(parsed)
+            for body in body_list:
+                events.extend(_serialize_stations(find_stations(body, start_dt, end_dt)))
+
+    if "void_of_course" in requested:
+        try:
+            voc_event = void_of_course_moon(start_dt, sign_orb=sign_orb)
+        except Exception as exc:  # pragma: no cover - runtime-only fallback
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+        if voc_event.end_jd >= voc_event.jd:
+            events.append(_serialize_voc(voc_event))
+
+    events.sort(key=lambda item: (item.ts, item.type))
+    return TimelineResponse(events=events)

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -180,6 +180,9 @@ class Settings(BaseModel):
     rendering: RenderingCfg = Field(default_factory=RenderingCfg)
     ephemeris: EphemerisCfg = Field(default_factory=EphemerisCfg)
     perf: PerfCfg = Field(default_factory=PerfCfg)
+    eclipse_finder: bool = True
+    stations: bool = True
+    timeline_ui: bool = True
 
 
 # -------------------- I/O Helpers --------------------

--- a/tests/analysis/test_timeline_lunations.py
+++ b/tests/analysis/test_timeline_lunations.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import os
+from datetime import UTC, datetime
+
+import pytest
+
+from astroengine.analysis import find_lunations
+
+pytest.importorskip("swisseph")
+if not (os.environ.get("SE_EPHE_PATH") or os.environ.get("SWE_EPH_PATH")):
+    pytest.skip("Swiss ephemeris not available", allow_module_level=True)
+
+
+def test_find_lunations_wrapper_orders_events() -> None:
+    start = datetime(2025, 9, 1, tzinfo=UTC)
+    end = datetime(2025, 10, 1, tzinfo=UTC)
+    events = find_lunations(start, end)
+    assert len(events) >= 3
+    timestamps = [event.ts for event in events]
+    assert timestamps == sorted(timestamps)

--- a/ui/streamlit/api.py
+++ b/ui/streamlit/api.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, Sequence
 
 import requests
 from requests import Response
@@ -137,6 +137,30 @@ class APIClient:
         data = self._post_json("/events/returns", payload, timeout=60)
         if not isinstance(data, list):  # pragma: no cover - defensive
             raise RuntimeError("Unexpected response payload from /events/returns")
+        return data
+
+    # ---- Timeline ---------------------------------------------------------
+    def timeline(
+        self,
+        start_iso: str,
+        end_iso: str,
+        *,
+        types: Sequence[str] | None = None,
+        bodies: Sequence[str] | None = None,
+        sign_orb: float | None = None,
+    ) -> Dict[str, Any]:
+        params: Dict[str, Any] = {"from": start_iso, "to": end_iso}
+        if types:
+            params["types"] = ",".join(types)
+        if bodies:
+            params["bodies"] = ",".join(bodies)
+        if sign_orb is not None:
+            params["sign_orb"] = float(sign_orb)
+        r = requests.get(f"{self.base}/v1/timeline", params=params, timeout=60)
+        r.raise_for_status()
+        data = r.json()
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise RuntimeError("Unexpected response payload from /v1/timeline")
         return data
 
     def electional_search(self, payload: Dict[str, Any]) -> Dict[str, Any]:

--- a/ui/streamlit/pages/12_Timeline_Finder.py
+++ b/ui/streamlit/pages/12_Timeline_Finder.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Sequence
+
+import pandas as pd
+import streamlit as st
+
+from astroengine.config import default_settings, load_settings
+from astroengine.export.ics import to_ics
+from ui.streamlit.api import APIClient
+
+st.set_page_config(page_title="Timeline Finder", page_icon="🗓️", layout="wide")
+st.title("Timeline Finder 🗓️")
+
+try:
+    SETTINGS = load_settings()
+except Exception:  # pragma: no cover - streamlit runtime fallback
+    SETTINGS = default_settings()
+
+if not getattr(SETTINGS, "timeline_ui", True):
+    st.warning("Timeline UI is disabled in the current configuration.")
+    st.stop()
+
+api = APIClient()
+
+st.sidebar.header("Timeline Window")
+now = datetime.now(UTC)
+def_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+def_end = def_start + timedelta(days=30)
+start_dt = st.sidebar.datetime_input("Start (UTC)", value=def_start, step=timedelta(hours=1))
+end_dt = st.sidebar.datetime_input("End (UTC)", value=def_end, step=timedelta(hours=1))
+
+if end_dt <= start_dt:
+    st.sidebar.error("End must be after start.")
+
+type_labels = {
+    "Lunations": "lunations",
+    "Eclipses": "eclipses",
+    "Stations": "stations",
+    "Void-of-course Moon": "void_of_course",
+}
+selected_types = st.sidebar.multiselect(
+    "Event Types",
+    list(type_labels.keys()),
+    default=["Lunations", "Eclipses", "Stations"],
+)
+requested_types = [type_labels[label] for label in selected_types] or list(type_labels.values())
+
+station_default = ["Mercury", "Venus", "Mars", "Jupiter", "Saturn"]
+station_bodies: Sequence[str] = st.sidebar.multiselect(
+    "Station Bodies",
+    [
+        "Mercury",
+        "Venus",
+        "Mars",
+        "Jupiter",
+        "Saturn",
+        "Uranus",
+        "Neptune",
+        "Pluto",
+    ],
+    default=station_default,
+)
+
+sign_orb = st.sidebar.slider("Void-of-course sign orb (°)", 0.0, 5.0, 0.0, 0.5)
+
+with st.sidebar.expander("Options", expanded=False):
+    st.caption("Adjust filters and click **Fetch Timeline** to query the API.")
+
+trigger = st.button("Fetch Timeline", type="primary")
+
+if trigger:
+    if end_dt <= start_dt:
+        st.stop()
+
+    with st.spinner("Fetching timeline events..."):
+        payload = api.timeline(
+            start_dt.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            end_dt.astimezone(UTC).isoformat().replace("+00:00", "Z"),
+            types=requested_types,
+            bodies=station_bodies,
+            sign_orb=sign_orb,
+        )
+    events = payload.get("events", [])
+    if not events:
+        st.info("No timeline events for the selected parameters.")
+        st.stop()
+
+    df = pd.DataFrame(events)
+    if "ts" in df:
+        df["ts"] = pd.to_datetime(df["ts"], utc=True)
+    if "end_ts" in df:
+        df["end_ts"] = pd.to_datetime(df["end_ts"], utc=True, errors="coerce")
+    df.sort_values("ts", inplace=True)
+
+    st.subheader("Timeline Events")
+    display_cols = [col for col in ["type", "summary", "ts", "end_ts"] if col in df.columns]
+    st.dataframe(df[display_cols], use_container_width=True, hide_index=True)
+
+    st.subheader("Event Details")
+    detail_df = df.copy()
+    if "details" in detail_df:
+        detail_df["details"] = detail_df["details"].apply(
+            lambda value: json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2)
+        )
+    st.dataframe(detail_df, use_container_width=True, hide_index=True)
+
+    csv_bytes = df.to_csv(index=False).encode("utf-8")
+
+    def _timeline_events_to_ics(raw_events: Sequence[dict[str, object]]) -> bytes:
+        calendar_events = []
+        for idx, event in enumerate(raw_events):
+            start_iso = str(event.get("ts"))
+            end_iso = str(event.get("end_ts") or event.get("ts"))
+            calendar_events.append(
+                {
+                    "uid": f"timeline-{idx}-{start_iso}",
+                    "kind": str(event.get("type", "event")),
+                    "summary": str(event.get("summary", "Timeline Event")),
+                    "start": start_iso,
+                    "end": end_iso,
+                    "description": json.dumps(event.get("details", {}), ensure_ascii=False, sort_keys=True),
+                    "meta": event,
+                }
+            )
+        return to_ics(calendar_events, calendar_name="AstroEngine Timeline")
+
+    ics_bytes = _timeline_events_to_ics(events)
+
+    col1, col2 = st.columns(2)
+    with col1:
+        st.download_button(
+            "Download CSV",
+            csv_bytes,
+            file_name="timeline_events.csv",
+            mime="text/csv",
+        )
+    with col2:
+        st.download_button(
+            "Download ICS",
+            ics_bytes,
+            file_name="timeline_events.ics",
+            mime="text/calendar",
+        )
+else:
+    st.caption("Configure filters and click **Fetch Timeline** to populate the results.")


### PR DESCRIPTION
## Summary
- add an `astroengine.analysis` module with timeline helpers for lunations, eclipses, stations, and void-of-course periods
- expose a `/v1/timeline` API backed by configuration toggles and extend the Streamlit client/UI with a timeline finder page and exports
- cover the new lunation wrapper with a basic Swiss-ephemeris-aware test

## Testing
- pytest tests/analysis/test_timeline_lunations.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e2cfb6808324bfb17f1db43da602