### PR TITLE
Add dark-themed Streamlit portal with ChatGPT panel

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,10 @@
+[theme]
+base = "dark"
+primaryColor = "#7C5CFF"
+backgroundColor = "#0E1117"
+secondaryBackgroundColor = "#161A23"
+textColor = "#E6E6E6"
+font = "Inter"
+
+[browser]
+gatherUsageStats = false

--- a/ui/streamlit/components/chatgpt_panel.py
+++ b/ui/streamlit/components/chatgpt_panel.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+import streamlit as st
+
+SYSTEM_PROMPT = (
+    "You are AstroEngine Copilot — an astrology assistant. "
+    "Be concise, accurate, and cite internal findings by referring to data returned by local endpoints when available. "
+    "If the user asks about charts, techniques, or diagnostics, you may suggest hitting local endpoints like /v1/settings or /healthz if the user consents. "
+    "Never fabricate data; if unsure, ask to run a local check (e.g., /healthz)."
+)
+
+DEFAULT_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
+DEFAULT_API_BASE = os.environ.get("OPENAI_BASE_URL", None)
+
+
+def _ensure_state() -> None:
+    if "chat_messages" not in st.session_state:
+        st.session_state.chat_messages = [
+            {"role": "system", "content": SYSTEM_PROMPT}
+        ]
+    if "openai_model" not in st.session_state:
+        st.session_state.openai_model = DEFAULT_MODEL
+
+
+def _call_openai(messages: List[Dict[str, Any]], model: str, stream: bool = True):
+    """Lightweight wrapper that supports both new and legacy openai clients."""
+    api_key = os.environ.get("OPENAI_API_KEY") or st.session_state.get("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY not set. Set it in env or the field above.")
+
+    try:
+        # New SDK style
+        from openai import OpenAI
+
+        client = OpenAI(api_key=api_key, base_url=DEFAULT_API_BASE)
+        return client.chat.completions.create(model=model, messages=messages, stream=stream)
+    except Exception:
+        # Legacy fallback
+        import openai  # type: ignore
+
+        openai.api_key = api_key
+        if DEFAULT_API_BASE:
+            openai.base_url = DEFAULT_API_BASE
+        return openai.ChatCompletion.create(model=model, messages=messages, stream=stream)
+
+
+def _render_stream(stream_obj):
+    """Render a streaming response into the last assistant message container."""
+    full = []
+    for chunk in stream_obj:
+        try:
+            # New SDK delta
+            delta = chunk.choices[0].delta.get("content")
+        except Exception:
+            # Legacy SDK delta
+            delta = chunk["choices"][0]["delta"].get("content") if isinstance(chunk, dict) else None
+        if delta:
+            full.append(delta)
+            yield delta
+    return "".join(full)
+
+
+def _do_local_action(cmd: str, base_url: str) -> str:
+    import requests
+
+    cmd = cmd.strip().lower()
+    if cmd == "/health":
+        url = base_url.rstrip("/") + "/healthz"
+        r = requests.get(url, timeout=5)
+        return f"GET {url}\nStatus: {r.status_code}\n\n{r.text[:4000]}"
+    if cmd == "/settings":
+        url = base_url.rstrip("/") + "/v1/settings"
+        r = requests.get(url, timeout=5)
+        return f"GET {url}\nStatus: {r.status_code}\n\n{r.text[:4000]}"
+    if cmd == "/metrics":
+        url = base_url.rstrip("/") + "/metrics"
+        r = requests.get(url, timeout=5)
+        return f"GET {url}\nStatus: {r.status_code}\n\n{r.text[:2000]}\n..."
+    return "Unknown command. Try /health, /settings, or /metrics."
+
+
+def chatgpt_panel() -> None:
+    _ensure_state()
+
+    with st.container(border=True):
+        st.markdown("### 🤖 ChatGPT Copilot")
+        # API key & model controls (local-only; not persisted to disk)
+        with st.expander("Model & Connection", expanded=False):
+            st.session_state.OPENAI_API_KEY = st.text_input(
+                "OpenAI API Key",
+                type="password",
+                value=os.environ.get("OPENAI_API_KEY", ""),
+                help="Only stored in-memory during this session.",
+            )
+            st.session_state.openai_model = st.text_input(
+                "Model",
+                value=st.session_state.openai_model,
+                help="e.g., gpt-4o-mini, gpt-4.1-mini",
+            )
+            api_base = st.text_input("(Optional) API Base URL", value=DEFAULT_API_BASE or "")
+            if api_base:
+                os.environ["OPENAI_BASE_URL"] = api_base
+
+        # Local API base for slash-commands
+        api_local = st.text_input(
+            "Local API Base",
+            value=os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000"),
+            help="Used for /health, /settings, /metrics",
+        )
+
+        # Render prior conversation
+        for msg in st.session_state.chat_messages:
+            if msg["role"] == "system":
+                continue
+            with st.chat_message(msg["role"]):
+                st.markdown(msg["content"])
+
+        # Composer
+        prompt = st.chat_input(placeholder="Ask about a chart, run /health, or say hi…")
+        if prompt:
+            # Slash-commands (no call to OpenAI)
+            if prompt.strip().startswith("/"):
+                st.session_state.chat_messages.append({"role": "user", "content": prompt})
+                result = _do_local_action(prompt.strip(), api_local)
+                st.session_state.chat_messages.append({"role": "assistant", "content": f"````text\n{result}\n````"})
+                st.rerun()
+
+            st.session_state.chat_messages.append({"role": "user", "content": prompt})
+            with st.chat_message("assistant"):
+                # Stream tokens
+                try:
+                    stream = _call_openai(
+                        messages=st.session_state.chat_messages,
+                        model=st.session_state.openai_model,
+                        stream=True,
+                    )
+                    placeholder = st.empty()
+                    acc = ""
+                    for token in _render_stream(stream):
+                        acc += token
+                        placeholder.markdown(acc)
+                    st.session_state.chat_messages.append({"role": "assistant", "content": acc})
+                except Exception as e:
+                    st.warning(f"Chat error: {e}")

--- a/ui/streamlit/main_portal.py
+++ b/ui/streamlit/main_portal.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import os
+
+import requests
+import streamlit as st
+
+from astroengine.config import load_settings
+from ui.streamlit.components.chatgpt_panel import chatgpt_panel
+
+st.set_page_config(page_title="AstroEngine Portal", layout="wide")
+
+# --- Header / style ---------------------------------------------------------
+st.markdown(
+    """
+    <style>
+      .stMetric, .element-container { padding-top: 2px !important; }
+      .gallery-card { border-radius: 16px; padding: 12px; background: var(--secondary-background-color); }
+      .muted { color: #9aa0a6; font-size: 12px; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+st.title("🌌 AstroEngine — Main Portal")
+settings = load_settings()
+
+left, right = st.columns([7, 5], gap="large")
+
+# --- Left: Multi-graphic gallery -------------------------------------------
+with left:
+    st.subheader("Visuals")
+    tab1, tab2, tab3, tab4, tab5 = st.tabs(["Chart", "Aspects", "Timeline", "Map", "Custom"])
+
+    with tab1:
+        st.markdown("**Chart Wheel**")
+        # If your API exposes an image, render it. Otherwise, placeholder.
+        url = os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000").rstrip("/") + "/v1/plots/wheel"
+        try:
+            r = requests.get(url, timeout=3)
+            if r.status_code == 200 and r.headers.get("content-type", "").startswith("image/"):
+                st.image(r.content, caption="Current Chart")
+            else:
+                st.info("Chart image endpoint not available yet. Add /v1/plots/wheel to the API to enable.")
+        except Exception:
+            st.info("Chart endpoint unreachable.")
+
+    with tab2:
+        st.markdown("**Aspect Grid**")
+        url = os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000").rstrip("/") + "/v1/plots/aspects"
+        try:
+            r = requests.get(url, timeout=3)
+            if r.status_code == 200 and r.headers.get("content-type", "").startswith("image/"):
+                st.image(r.content, caption="Aspect Grid")
+            else:
+                st.info("Aspect grid not available yet. Add /v1/plots/aspects.")
+        except Exception:
+            st.info("Aspect endpoint unreachable.")
+
+    with tab3:
+        st.markdown("**Timeline**")
+        url = os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000").rstrip("/") + "/v1/timeline?from=now-30d&to=now+30d"
+        try:
+            r = requests.get(url, timeout=4)
+            if r.ok:
+                data = r.json()
+                st.json(data[:25] if isinstance(data, list) else data)
+            else:
+                st.info("Timeline endpoint not ready. See Task 7/10.")
+        except Exception:
+            st.info("Timeline endpoint unreachable.")
+
+    with tab4:
+        st.markdown("**Astrocartography Map**")
+        try:
+            import pydeck as pdk
+
+            # Expect GeoJSON FeatureCollection from /v1/astrocartography
+            url = os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000").rstrip("/") + "/v1/astrocartography"
+            r = requests.get(url, timeout=5)
+            if r.ok:
+                geo = r.json()
+                layer = pdk.Layer("GeoJsonLayer", geo, pickable=True)
+                view_state = pdk.ViewState(latitude=0, longitude=0, zoom=0.8)
+                st.pydeck_chart(pdk.Deck(layers=[layer], initial_view_state=view_state))
+            else:
+                st.info("Map endpoint not ready. See Task 12.")
+        except Exception:
+            st.info("pydeck not installed or map endpoint unreachable.")
+
+    with tab5:
+        st.markdown("**Custom**")
+        st.caption("Bring your own graphic here — embed images, tables, or KPIs.")
+        st.write("")
+
+# --- Right: ChatGPT ---------------------------------------------------------
+with right:
+    chatgpt_panel()

--- a/ui/streamlit/main_portal.py
+++ b/ui/streamlit/main_portal.py
@@ -4,10 +4,11 @@ import os
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List
+from typing import Callable, Dict, List, Optional
 
 import requests
 import streamlit as st
+from streamlit.delta_generator import DeltaGenerator
 
 ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
@@ -24,6 +25,10 @@ st.markdown(
       .stMetric, .element-container { padding-top: 2px !important; }
       .gallery-card { border-radius: 16px; padding: 12px; background: var(--secondary-background-color); }
       .muted { color: #9aa0a6; font-size: 12px; }
+      .dashboard-toolbar { background: rgba(22, 26, 35, 0.85); border-radius: 14px; padding: 12px 18px; margin-bottom: 1.2rem; }
+      .dashboard-toolbar .stSelectbox div[data-baseweb="select"] { min-height: 34px; }
+      .dashboard-toolbar .stSlider { padding-top: 0; }
+      .dashboard-slot > div:first-child { padding: 0.75rem; border-radius: 16px; background: var(--secondary-background-color); border: 1px solid rgba(255,255,255,0.08); }
     </style>
     """,
     unsafe_allow_html=True,
@@ -36,48 +41,52 @@ def _api_base() -> str:
     return os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000").rstrip("/")
 
 
-def _render_chart() -> None:
-    st.markdown("**Chart Wheel**")
+def _render_chart(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Chart Wheel**")
     url = f"{_api_base()}/v1/plots/wheel"
     try:
         r = requests.get(url, timeout=3)
         if r.status_code == 200 and r.headers.get("content-type", "").startswith("image/"):
-            st.image(r.content, caption="Current Chart")
+            target.image(r.content, caption="Current Chart")
         else:
-            st.info("Chart image endpoint not available yet. Add /v1/plots/wheel to the API to enable.")
+            target.info("Chart image endpoint not available yet. Add /v1/plots/wheel to the API to enable.")
     except Exception:
-        st.info("Chart endpoint unreachable.")
+        target.info("Chart endpoint unreachable.")
 
 
-def _render_aspects() -> None:
-    st.markdown("**Aspect Grid**")
+def _render_aspects(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Aspect Grid**")
     url = f"{_api_base()}/v1/plots/aspects"
     try:
         r = requests.get(url, timeout=3)
         if r.status_code == 200 and r.headers.get("content-type", "").startswith("image/"):
-            st.image(r.content, caption="Aspect Grid")
+            target.image(r.content, caption="Aspect Grid")
         else:
-            st.info("Aspect grid not available yet. Add /v1/plots/aspects.")
+            target.info("Aspect grid not available yet. Add /v1/plots/aspects.")
     except Exception:
-        st.info("Aspect endpoint unreachable.")
+        target.info("Aspect endpoint unreachable.")
 
 
-def _render_timeline() -> None:
-    st.markdown("**Timeline**")
+def _render_timeline(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Timeline**")
     url = f"{_api_base()}/v1/timeline?from=now-30d&to=now+30d"
     try:
         r = requests.get(url, timeout=4)
         if r.ok:
             data = r.json()
-            st.json(data[:25] if isinstance(data, list) else data)
+            target.json(data[:25] if isinstance(data, list) else data)
         else:
-            st.info("Timeline endpoint not ready. See Task 7/10.")
+            target.info("Timeline endpoint not ready. See Task 7/10.")
     except Exception:
-        st.info("Timeline endpoint unreachable.")
+        target.info("Timeline endpoint unreachable.")
 
 
-def _render_map() -> None:
-    st.markdown("**Astrocartography Map**")
+def _render_map(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Astrocartography Map**")
     try:
         import pydeck as pdk
 
@@ -87,65 +96,69 @@ def _render_map() -> None:
             geo = r.json()
             layer = pdk.Layer("GeoJsonLayer", geo, pickable=True)
             view_state = pdk.ViewState(latitude=0, longitude=0, zoom=0.8)
-            st.pydeck_chart(pdk.Deck(layers=[layer], initial_view_state=view_state))
+            target.pydeck_chart(pdk.Deck(layers=[layer], initial_view_state=view_state))
         else:
-            st.info("Map endpoint not ready. See Task 12.")
+            target.info("Map endpoint not ready. See Task 12.")
     except Exception:
-        st.info("pydeck not installed or map endpoint unreachable.")
+        target.info("pydeck not installed or map endpoint unreachable.")
 
 
-def _render_custom() -> None:
-    st.markdown("**Custom Panel**")
-    st.caption("Bring your own graphic here — embed images, tables, or KPIs.")
-    st.write("")
+def _render_custom(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Custom Panel**")
+    target.caption("Bring your own graphic here — embed images, tables, or KPIs.")
+    target.write("")
 
 
-def _render_health() -> None:
-    st.markdown("**Service Health**")
+def _render_health(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Service Health**")
     url = f"{_api_base()}/healthz"
     try:
         r = requests.get(url, timeout=3)
-        st.markdown(f"`GET {url}` → **{r.status_code}**")
+        target.markdown(f"`GET {url}` → **{r.status_code}**")
         content_type = r.headers.get("content-type", "")
         if content_type.startswith("application/json"):
-            st.json(r.json())
+            target.json(r.json())
         else:
-            st.code(r.text[:2000])
+            target.code(r.text[:2000])
     except Exception as exc:
-        st.warning(f"Health endpoint unreachable: {exc}")
+        target.warning(f"Health endpoint unreachable: {exc}")
 
 
-def _render_settings_snapshot() -> None:
-    st.markdown("**Configuration Snapshot**")
+def _render_settings_snapshot(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Configuration Snapshot**")
     url = f"{_api_base()}/v1/settings"
     try:
         r = requests.get(url, timeout=4)
         if r.ok:
-            st.json(r.json())
+            target.json(r.json())
         else:
-            st.info("Settings endpoint responded without data. Ensure /v1/settings is implemented.")
+            target.info("Settings endpoint responded without data. Ensure /v1/settings is implemented.")
     except Exception as exc:
-        st.warning(f"Settings endpoint unreachable: {exc}")
+        target.warning(f"Settings endpoint unreachable: {exc}")
 
 
-def _render_metrics() -> None:
-    st.markdown("**Prometheus Metrics**")
+def _render_metrics(target: Optional[DeltaGenerator] = None) -> None:
+    target = target or st
+    target.markdown("**Prometheus Metrics**")
     url = f"{_api_base()}/metrics"
     try:
         r = requests.get(url, timeout=4)
         if r.ok:
-            st.code(r.text[:4000] + ("\n…" if len(r.text) > 4000 else ""), language="text")
+            target.code(r.text[:4000] + ("\n…" if len(r.text) > 4000 else ""), language="text")
         else:
-            st.info("Metrics endpoint responded without data. Ensure Prometheus middleware is enabled.")
+            target.info("Metrics endpoint responded without data. Ensure Prometheus middleware is enabled.")
     except Exception as exc:
-        st.warning(f"Metrics endpoint unreachable: {exc}")
+        target.warning(f"Metrics endpoint unreachable: {exc}")
 
 
 @dataclass(frozen=True)
 class PaneDefinition:
     label: str
     category: str
-    renderer: Callable[[], None]
+    renderer: Callable[[DeltaGenerator], None]
 
 
 PANE_LIBRARY: Dict[str, PaneDefinition] = {
@@ -171,88 +184,169 @@ DEFAULT_LAYOUT = {
 def _init_dashboard_state() -> None:
     if "dashboard_slots" not in st.session_state:
         st.session_state.dashboard_slots = DEFAULT_LAYOUT.copy()
+    st.session_state.setdefault("dashboard_column_ratio", 0.65)
+    st.session_state.setdefault("dashboard_top_split", 0.5)
+    st.session_state.setdefault("dashboard_bottom_split", 0.5)
+    st.session_state.setdefault("dashboard_slot_height", 420)
 
 
-def _layout_controls() -> None:
-    with st.expander("Dashboard Layout", expanded=False):
-        st.markdown(
-            "Select which insight appears in each quadrant. Choose a category to filter the available panels."
-        )
-        categories: List[str] = sorted({pane.category for pane in PANE_LIBRARY.values()})
-        for slot in DEFAULT_LAYOUT:
-            current = st.session_state.dashboard_slots.get(slot, "Empty")
-            slot_key = slot.replace(" ", "_").lower()
+def _slot_selector(slot: str, categories: List[str]) -> None:
+    current = st.session_state.dashboard_slots.get(slot, "Empty")
+    slot_key = slot.replace(" ", "_").lower()
 
-            if current == "Empty":
-                current_category = "Empty"
-            else:
-                pane_meta = PANE_LIBRARY.get(current)
-                current_category = pane_meta.category if pane_meta else "Empty"
+    if current == "Empty":
+        current_category = "Empty"
+    else:
+        pane_meta = PANE_LIBRARY.get(current)
+        current_category = pane_meta.category if pane_meta else "Empty"
 
-            category_options = ["Empty", *categories]
-            selected_category = st.selectbox(
-                f"{slot} Category",
-                options=category_options,
-                index=category_options.index(current_category)
-                if current_category in category_options
-                else 0,
-                key=f"dashboard_slot_{slot_key}_category",
-            )
+    st.caption(slot)
+    category_options = ["Empty", *categories]
+    selected_category = st.selectbox(
+        f"{slot} Category",
+        options=category_options,
+        index=category_options.index(current_category)
+        if current_category in category_options
+        else 0,
+        key=f"dashboard_slot_{slot_key}_category",
+        label_visibility="collapsed",
+    )
+    st.write("")
 
-            if selected_category == "Empty":
-                st.session_state.dashboard_slots[slot] = "Empty"
-                st.session_state[f"dashboard_slot_{slot_key}_pane"] = "Empty"
-                continue
+    if selected_category == "Empty":
+        st.session_state.dashboard_slots[slot] = "Empty"
+        st.session_state[f"dashboard_slot_{slot_key}_pane"] = "Empty"
+        return
 
-            panes_in_category = [
-                key
-                for key, pane in PANE_LIBRARY.items()
-                if pane.category == selected_category
-            ]
-            if not panes_in_category:
-                st.session_state.dashboard_slots[slot] = "Empty"
-                st.warning(f"No panels available for category {selected_category}.")
-                continue
+    panes_in_category = [
+        key
+        for key, pane in PANE_LIBRARY.items()
+        if pane.category == selected_category
+    ]
+    if not panes_in_category:
+        st.session_state.dashboard_slots[slot] = "Empty"
+        st.warning(f"No panels available for category {selected_category}.")
+        return
 
-            default_pane = current if current in panes_in_category else panes_in_category[0]
-            selected_pane = st.selectbox(
-                slot,
-                options=panes_in_category,
-                index=panes_in_category.index(default_pane),
-                format_func=lambda key: PANE_LIBRARY[key].label,
-                key=f"dashboard_slot_{slot_key}_pane",
-            )
-            st.session_state.dashboard_slots[slot] = selected_pane
+    default_pane = current if current in panes_in_category else panes_in_category[0]
+    selected_pane = st.selectbox(
+        f"{slot} Pane",
+        options=panes_in_category,
+        index=panes_in_category.index(default_pane),
+        format_func=lambda key: PANE_LIBRARY[key].label,
+        key=f"dashboard_slot_{slot_key}_pane",
+        label_visibility="collapsed",
+    )
+    st.caption(PANE_LIBRARY[selected_pane].label)
+    st.session_state.dashboard_slots[slot] = selected_pane
+
+
+def _layout_toolbar() -> None:
+    categories: List[str] = sorted({pane.category for pane in PANE_LIBRARY.values()})
+    st.markdown("#### Dashboard Menu")
+    with st.container():
+        toolbar = st.container()
+        with toolbar:
+            st.markdown('<div class="dashboard-toolbar">', unsafe_allow_html=True)
+            ratio_col, height_col = st.columns([3, 2])
+            with ratio_col:
+                st.slider(
+                    "Dashboard / Copilot Width",
+                    min_value=0.45,
+                    max_value=0.8,
+                    step=0.05,
+                    value=float(st.session_state.dashboard_column_ratio),
+                    key="dashboard_column_ratio",
+                    help="Adjust the horizontal space dedicated to the dashboard versus the Copilot panel.",
+                )
+                st.slider(
+                    "Top Row Split",
+                    min_value=0.35,
+                    max_value=0.65,
+                    step=0.05,
+                    value=float(st.session_state.dashboard_top_split),
+                    key="dashboard_top_split",
+                    help="Widen or narrow the top row panes without allowing them to collapse.",
+                )
+                st.slider(
+                    "Bottom Row Split",
+                    min_value=0.35,
+                    max_value=0.65,
+                    step=0.05,
+                    value=float(st.session_state.dashboard_bottom_split),
+                    key="dashboard_bottom_split",
+                    help="Adjust the proportions for the lower panes.",
+                )
+            with height_col:
+                st.slider(
+                    "Panel Minimum Height",
+                    min_value=260,
+                    max_value=640,
+                    step=20,
+                    value=int(st.session_state.dashboard_slot_height),
+                    key="dashboard_slot_height",
+                    help="Increase height for richer visuals or shrink for quick-glance metrics.",
+                )
+
+                st.caption(
+                    "Pane controls stay constrained so the layout remains legible even when resized."
+                )
+
+            st.markdown("<hr style='margin: 0.8rem 0 1rem 0; border-color: rgba(255,255,255,0.08);'>", unsafe_allow_html=True)
+
+            selector_cols = st.columns(4)
+            for slot, column in zip(DEFAULT_LAYOUT.keys(), selector_cols):
+                with column:
+                    _slot_selector(slot, categories)
+
+            st.markdown("</div>", unsafe_allow_html=True)
 
 
 def _render_slot(slot: str, pane_key: str) -> None:
-    with st.container(border=True):
-        if pane_key == "Empty":
-            st.info("Select a panel from the layout controls to populate this slot.")
-            return
+    min_height = int(st.session_state.get("dashboard_slot_height", 420))
+    slot_container = st.container()
+    slot_container.markdown(
+        f"<div class='dashboard-slot' style='min-height: {min_height}px'>",
+        unsafe_allow_html=True,
+    )
+    slot_body = slot_container.container()
+    if pane_key == "Empty":
+        slot_body.info("Select a panel from the menu above to populate this slot.")
+    else:
         pane = PANE_LIBRARY.get(pane_key)
         if not pane:
-            st.warning(f"Unknown panel: {pane_key}")
-            return
-        pane.renderer()
+            slot_body.warning(f"Unknown panel: {pane_key}")
+        else:
+            pane.renderer(slot_body)
+    slot_container.markdown("</div>", unsafe_allow_html=True)
 
 
 _init_dashboard_state()
 
-left, right = st.columns([7, 5], gap="large")
+dashboard_weight = max(min(st.session_state.dashboard_column_ratio, 0.8), 0.45)
+copilot_weight = max(1.0 - dashboard_weight, 0.2)
+left_weight = max(int(round(dashboard_weight * 100)), 1)
+right_weight = max(int(round(copilot_weight * 100)), 1)
+left, right = st.columns([left_weight, right_weight], gap="large")
 
 # --- Left: Configurable dashboard ------------------------------------------
 with left:
     st.subheader("Visuals")
-    _layout_controls()
+    _layout_toolbar()
 
-    top = st.columns(2)
+    top_split = max(min(st.session_state.dashboard_top_split, 0.65), 0.35)
+    top_left = max(int(round(top_split * 100)), 1)
+    top_right = max(int(round((1 - top_split) * 100)), 1)
+    top = st.columns([top_left, top_right], gap="small")
     with top[0]:
         _render_slot("Top Left", st.session_state.dashboard_slots.get("Top Left", "Empty"))
     with top[1]:
         _render_slot("Top Right", st.session_state.dashboard_slots.get("Top Right", "Empty"))
 
-    bottom = st.columns(2)
+    bottom_split = max(min(st.session_state.dashboard_bottom_split, 0.65), 0.35)
+    bottom_left = max(int(round(bottom_split * 100)), 1)
+    bottom_right = max(int(round((1 - bottom_split) * 100)), 1)
+    bottom = st.columns([bottom_left, bottom_right], gap="small")
     with bottom[0]:
         _render_slot("Bottom Left", st.session_state.dashboard_slots.get("Bottom Left", "Empty"))
     with bottom[1]:


### PR DESCRIPTION
## Summary
- add a dark Streamlit theme configuration for the AstroEngine portal
- introduce a reusable ChatGPT Copilot component with OpenAI streaming and local slash-commands
- build a two-column main portal layout combining visual placeholders with the chat assistant

## Testing
- pytest *(fails: ImportError: cannot import name 'AstrocartographyCfg' from 'astroengine.config.settings')*


------
https://chatgpt.com/codex/tasks/task_e_68e2eb9c99ec83249412d2f43bbbe53d