### PR TITLE
Add codex registry explorer CLI and helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,12 @@ astroengine scan --start-utc 2024-01-01T00:00:00Z --end-utc 2024-01-02T00:00:00Z
   --moving Sun Moon --targets natal:Sun natal:Moon --target-frame natal --detector lunations
 ```
 
+Use `astroengine codex tree` to render the module → submodule → channel →
+subchannel hierarchy directly in the terminal, or `astroengine codex show` to
+inspect metadata for specific entries. The command is backed by the same
+`astroengine.codex` helpers that power developer tooling, so every path it
+reports corresponds to real documentation or dataset files in the repository.
+
 > **Licensing note:** Swiss Ephemeris is AGPL/commercial for distribution. Keep data files outside the wheel; users should provide `SWE_EPH_PATH/SE_EPHE_PATH`.
 
 `pyswisseph==2.10.3.2` now ships with the core package, ensuring Swiss

--- a/astroengine/analysis/__init__.py
+++ b/astroengine/analysis/__init__.py
@@ -2,6 +2,14 @@
 
 from __future__ import annotations
 
+from .dignities import condition_report, score_accidental, score_essential
 from .midpoints import compute_midpoints, get_midpoint_settings, midpoint_longitude
 
-__all__ = ["compute_midpoints", "get_midpoint_settings", "midpoint_longitude"]
+__all__ = [
+    "compute_midpoints",
+    "get_midpoint_settings",
+    "midpoint_longitude",
+    "condition_report",
+    "score_accidental",
+    "score_essential",
+]

--- a/astroengine/cli/__main__.py
+++ b/astroengine/cli/__main__.py
@@ -6,7 +6,7 @@ import argparse
 import sys
 from typing import Sequence
 
-from . import diagnose, export, scan
+from . import codex, diagnose, export, scan
 from ._compat import cli_legacy_missing_reason, try_import_cli_legacy
 
 
@@ -54,6 +54,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="astroengine", description="AstroEngine CLI")
     sub = parser.add_subparsers(dest="command", required=True)
 
+    codex.add_subparser(sub)
     scan.add_subparser(sub)
     export.add_subparser(sub)
     diagnose.add_subparser(sub)

--- a/astroengine/cli/codex.py
+++ b/astroengine/cli/codex.py
@@ -1,0 +1,207 @@
+"""CLI integration for exploring the AstroEngine codex."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterable, Mapping, Sequence
+
+from ..codex import (
+    UnknownCodexPath,
+    describe_path,
+    get_registry,
+    registry_snapshot,
+    resolved_files,
+)
+from ..modules import AstroRegistry
+
+__all__ = ["add_subparser"]
+
+
+def add_subparser(sub: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``codex`` CLI command."""
+
+    parser = sub.add_parser(
+        "codex",
+        help="Explore module/submodule metadata registered with the codex",
+        description=(
+            "Inspect the module → submodule → channel → subchannel registry"
+            " hierarchy used by the AstroEngine developer codex."
+        ),
+    )
+    codex_sub = parser.add_subparsers(dest="codex_command", required=True)
+
+    tree_parser = codex_sub.add_parser(
+        "tree",
+        help="Render the codex hierarchy as text or JSON",
+        description=(
+            "Display the full registry tree so developers can discover which"
+            " modules, channels, and subchannels are available."
+        ),
+    )
+    tree_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the hierarchy as JSON instead of a formatted tree",
+    )
+    tree_parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Rebuild the registry snapshot before rendering the tree",
+    )
+    tree_parser.set_defaults(handler=_render_tree)
+
+    show_parser = codex_sub.add_parser(
+        "show",
+        help="Describe metadata for a specific registry path",
+        description=(
+            "Look up metadata and payload references for a module,"
+            " submodule, channel, or subchannel."
+        ),
+    )
+    show_parser.add_argument(
+        "path",
+        nargs="*",
+        help="Path expressed as module[/submodule[/channel[/subchannel]]] or dot separated",
+    )
+    show_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit metadata as JSON",
+    )
+    show_parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Rebuild the registry snapshot before resolving the path",
+    )
+    show_parser.set_defaults(handler=_show_node)
+
+    files_parser = codex_sub.add_parser(
+        "files",
+        help="List filesystem assets referenced by codex metadata",
+        description=(
+            "Resolve metadata and payload entries to concrete files so"
+            " that they can be opened in the editor."
+        ),
+    )
+    files_parser.add_argument(
+        "path",
+        nargs="*",
+        help="Path expressed as module[/submodule[/channel[/subchannel]]] or dot separated",
+    )
+    files_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the resolved paths as JSON",
+    )
+    files_parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="Rebuild the registry snapshot before resolving the path",
+    )
+    files_parser.set_defaults(handler=_list_files)
+
+    parser.set_defaults(func=_dispatch)
+
+
+def _dispatch(args: argparse.Namespace) -> int:
+    try:
+        handler = getattr(args, "handler")
+    except AttributeError:  # pragma: no cover - argparse guards this
+        parser = args.__dict__.get("_parser")
+        if parser is not None:
+            parser.print_help()
+        return 2
+
+    try:
+        return handler(args)
+    except UnknownCodexPath as exc:
+        path = " / ".join(_normalise_segments(getattr(args, "path", [])))
+        print(f"Unknown codex path: {path or exc.args}", file=sys.stderr)
+        return 2
+
+
+def _normalise_segments(values: Sequence[str]) -> list[str]:
+    segments: list[str] = []
+    for value in values:
+        if not value:
+            continue
+        chunk = value.replace("/", ".")
+        segments.extend([part for part in chunk.split(".") if part])
+    return segments
+
+
+def _render_tree(args: argparse.Namespace) -> int:
+    snapshot = registry_snapshot(refresh=args.refresh)
+    if args.json:
+        print(json.dumps(snapshot, indent=2, sort_keys=True))
+        return 0
+
+    for line in _format_tree(snapshot):
+        print(line)
+    return 0
+
+
+def _format_tree(snapshot: Mapping[str, Mapping[str, object]]) -> Iterable[str]:
+    modules = sorted(snapshot.items())
+    for module_name, module_payload in modules:
+        yield module_name
+        submodules = module_payload.get("submodules", {})
+        for submodule_name, sub_payload in sorted(submodules.items()):
+            yield f"  {submodule_name}"
+            channels = sub_payload.get("channels", {})
+            for channel_name, channel_payload in sorted(channels.items()):
+                yield f"    {channel_name}"
+                subchannels = channel_payload.get("subchannels", {})
+                for subchannel_name in sorted(subchannels):
+                    yield f"      {subchannel_name}"
+
+
+def _registry_for(args: argparse.Namespace) -> AstroRegistry:
+    return get_registry(refresh=args.refresh)
+
+
+def _show_node(args: argparse.Namespace) -> int:
+    registry = _registry_for(args)
+    segments = _normalise_segments(args.path)
+    node = describe_path(segments, registry=registry)
+    if args.json:
+        print(json.dumps(node.as_dict(), indent=2, sort_keys=True))
+    else:
+        _print_node(node)
+    return 0
+
+
+def _print_node(node) -> None:
+    header = node.name if node.name is not None else "<registry>"
+    print(f"{node.kind}: {header}")
+
+    if node.metadata:
+        print("Metadata:")
+        for key in sorted(node.metadata):
+            value = node.metadata[key]
+            print(f"  {key}: {value}")
+
+    if node.payload:
+        print("Payload:")
+        for key in sorted(node.payload):
+            value = node.payload[key]
+            print(f"  {key}: {value}")
+
+    if node.children:
+        print("Children:")
+        for child in node.children:
+            print(f"  - {child}")
+
+
+def _list_files(args: argparse.Namespace) -> int:
+    registry = _registry_for(args)
+    segments = _normalise_segments(args.path)
+    paths = [str(p) for p in resolved_files(segments, registry=registry)]
+    if args.json:
+        print(json.dumps(paths, indent=2))
+    else:
+        for path in paths:
+            print(path)
+    return 0

--- a/astroengine/codex/__init__.py
+++ b/astroengine/codex/__init__.py
@@ -1,0 +1,205 @@
+"""Codex helpers for exploring the AstroEngine module registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Mapping, Sequence
+
+from ..infrastructure.paths import get_paths
+from ..modules import DEFAULT_REGISTRY, AstroRegistry, bootstrap_default_registry
+
+__all__ = [
+    "CodexNode",
+    "UnknownCodexPath",
+    "describe_path",
+    "get_registry",
+    "registry_snapshot",
+    "resolved_files",
+]
+
+
+@dataclass(frozen=True)
+class CodexNode:
+    """Resolved element within the registry hierarchy."""
+
+    kind: str
+    name: str | None
+    metadata: Mapping[str, object]
+    payload: Mapping[str, object] | None = None
+    children: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serialisable representation of the node."""
+
+        data: dict[str, object] = {
+            "kind": self.kind,
+            "name": self.name,
+            "metadata": dict(self.metadata),
+        }
+        if self.payload is not None:
+            data["payload"] = dict(self.payload)
+        if self.children:
+            data["children"] = list(self.children)
+        return data
+
+
+class UnknownCodexPath(KeyError):
+    """Raised when a path cannot be resolved within the registry."""
+
+
+def get_registry(*, refresh: bool = False) -> AstroRegistry:
+    """Return the registry used by the codex helpers.
+
+    Parameters
+    ----------
+    refresh:
+        When ``True`` a fresh registry is constructed via
+        :func:`bootstrap_default_registry`. Otherwise the cached
+        :data:`~astroengine.modules.DEFAULT_REGISTRY` snapshot is reused.
+    """
+
+    if refresh:
+        return bootstrap_default_registry()
+    return DEFAULT_REGISTRY
+
+
+def registry_snapshot(*, refresh: bool = False) -> dict[str, Mapping[str, object]]:
+    """Return a serialisable snapshot of the registry hierarchy."""
+
+    return get_registry(refresh=refresh).as_dict()
+
+
+def describe_path(
+    path: Sequence[str] | None = None,
+    *,
+    registry: AstroRegistry | None = None,
+) -> CodexNode:
+    """Resolve ``path`` to a registry element.
+
+    The ``path`` is expressed as a sequence of up to four identifiers:
+    ``module / submodule / channel / subchannel``. Omitting segments
+    returns higher level nodes.
+    """
+
+    registry = registry or get_registry()
+    segments = list(path or [])
+    if not segments:
+        return CodexNode(
+            kind="registry",
+            name=None,
+            metadata={"modules": sorted(m.name for m in registry.iter_modules())},
+            children=sorted(m.name for m in registry.iter_modules()),
+        )
+
+    try:
+        module = registry.get_module(segments[0])
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise UnknownCodexPath(segments) from exc
+
+    if len(segments) == 1:
+        return CodexNode(
+            kind="module",
+            name=module.name,
+            metadata=module.metadata,
+            children=sorted(module.submodules.keys()),
+        )
+
+    try:
+        submodule = module.get_submodule(segments[1])
+    except KeyError as exc:
+        raise UnknownCodexPath(segments) from exc
+
+    if len(segments) == 2:
+        return CodexNode(
+            kind="submodule",
+            name=submodule.name,
+            metadata=submodule.metadata,
+            children=sorted(submodule.channels.keys()),
+        )
+
+    try:
+        channel = submodule.get_channel(segments[2])
+    except KeyError as exc:
+        raise UnknownCodexPath(segments) from exc
+
+    if len(segments) == 3:
+        return CodexNode(
+            kind="channel",
+            name=channel.name,
+            metadata=channel.metadata,
+            children=sorted(channel.subchannels.keys()),
+        )
+
+    try:
+        subchannel = channel.get_subchannel(segments[3])
+    except KeyError as exc:
+        raise UnknownCodexPath(segments) from exc
+
+    data = subchannel.describe()
+    payload = data.get("payload") if isinstance(data, dict) else None
+    metadata = data if payload is None else {k: v for k, v in data.items() if k != "payload"}
+    return CodexNode(
+        kind="subchannel",
+        name=subchannel.name,
+        metadata=metadata,
+        payload=payload if isinstance(payload, Mapping) else None,
+        children=[],
+    )
+
+
+def _candidate_paths(value: object) -> Iterable[Path]:
+    if isinstance(value, str):
+        text = value.strip()
+        if not text or "://" in text:
+            return []
+        fragment, _, _ = text.partition("#")
+        if not fragment:
+            return []
+        candidate = Path(fragment)
+        paths = get_paths()
+        bases = [paths.project_root, paths.package_root]
+        # Skip obvious commands like "astroengine scan" which contain spaces
+        if " " in fragment and "/" not in fragment:
+            return []
+        candidates: list[Path] = []
+        if candidate.is_absolute() and candidate.exists():
+            candidates.append(candidate)
+        else:
+            for base in bases:
+                potential = base / fragment
+                if potential.exists():
+                    candidates.append(potential)
+        return candidates
+    if isinstance(value, Mapping):
+        results: list[Path] = []
+        for nested in value.values():
+            results.extend(_candidate_paths(nested))
+        return results
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, str)):
+        results: list[Path] = []
+        for nested in value:
+            results.extend(_candidate_paths(nested))
+        return results
+    return []
+
+
+def resolved_files(
+    path: Sequence[str] | None = None,
+    *,
+    registry: AstroRegistry | None = None,
+) -> list[Path]:
+    """Return filesystem paths referenced by the metadata for ``path``."""
+
+    node = describe_path(path or [], registry=registry)
+    data: dict[str, object] = dict(node.metadata)
+    if node.payload is not None:
+        data.setdefault("payload", node.payload)
+
+    seen: set[Path] = set()
+    resolved: list[Path] = []
+    for candidate in _candidate_paths(data):
+        if candidate not in seen:
+            resolved.append(candidate)
+            seen.add(candidate)
+    return resolved

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -196,6 +196,10 @@ class AstroCartoCfg(BaseModel):
     show_parans: bool = False
 
 
+class AstrocartographyCfg(AstroCartoCfg):
+    """Backward-compatible alias for :class:`AstroCartoCfg`."""
+
+
 class MidpointTreeCfg(BaseModel):
     """Tree settings for midpoint expansion."""
 
@@ -326,6 +330,13 @@ class ElectionalCfg(BaseModel):
     constraints: List[Dict[str, object]] = Field(default_factory=list)
 
 
+class PluginCfg(BaseModel):
+    """Plugin enablement state segregated by capability."""
+
+    aspects: Optional[Dict[str, bool]] = None
+    lots: Optional[Dict[str, bool]] = None
+
+
 class ReturnsIngressCfg(BaseModel):
     """Return and ingress toggles."""
 
@@ -396,6 +407,7 @@ class Settings(BaseModel):
     timeline_ui: TimelineUICfg = Field(default_factory=TimelineUICfg)
     reports: ReportsCfg = Field(default_factory=ReportsCfg)
     atlas: AtlasCfg = Field(default_factory=AtlasCfg)
+    plugins: PluginCfg = Field(default_factory=PluginCfg)
 
 
 # -------------------- I/O Helpers --------------------

--- a/astroengine/modules/developer_platform/__init__.py
+++ b/astroengine/modules/developer_platform/__init__.py
@@ -78,6 +78,47 @@ def register_developer_platform_module(registry: AstroRegistry) -> None:
         },
     )
 
+    codex = module.register_submodule(
+        "codex",
+        metadata={
+            "description": "Developer codex surfaces for inspecting registry assets.",
+            "docs": ["docs/module/developer_platform/codex.md"],
+            "status": "beta",
+        },
+    )
+    access = codex.register_channel(
+        "access",
+        metadata={
+            "description": "Entry points that expose the registry hierarchy to developers.",
+        },
+    )
+    access.register_subchannel(
+        "cli",
+        metadata={
+            "description": "Command line interface for browsing codex metadata.",
+            "status": "available",
+        },
+        payload={
+            "command": "astroengine codex",
+            "documentation": "docs/module/developer_platform/codex.md#cli",
+        },
+    )
+    access.register_subchannel(
+        "python",
+        metadata={
+            "description": "Python helpers for programmatic codex exploration.",
+            "status": "available",
+        },
+        payload={
+            "module": "astroengine.codex",
+            "functions": [
+                "astroengine.codex.describe_path",
+                "astroengine.codex.resolved_files",
+            ],
+            "documentation": "docs/module/developer_platform/codex.md#python",
+        },
+    )
+
     devportal = module.register_submodule(
         "devportal",
         metadata={

--- a/docs/module/developer_platform/codex.md
+++ b/docs/module/developer_platform/codex.md
@@ -1,0 +1,60 @@
+# Developer Platform Codex
+
+The codex surfaces the module → submodule → channel → subchannel registry
+used throughout AstroEngine. It exists to help developers discover the
+available datasets, rulepacks, and workflows without needing to read every
+Python file manually.
+
+## Capabilities
+
+* Provides a structured API (`astroengine.codex`) for programmatic access to
+  the registry tree.
+* Ships a terminal command (`astroengine codex`) so engineers can browse the
+  hierarchy, inspect metadata, and jump to the underlying documentation.
+* Resolves metadata references to concrete files, ensuring that every run is
+  backed by the real sources in the repository.
+
+## CLI {#cli}
+
+The CLI exposes three primary actions:
+
+* `astroengine codex tree` renders the full hierarchy. Add `--json` to obtain
+  the raw snapshot emitted by `AstroRegistry.as_dict()`.
+* `astroengine codex show MODULE[/SUBMODULE[/CHANNEL[/SUBCHANNEL]]]` prints
+  metadata for a specific node. Use `--json` to emit the underlying payload as
+  JSON for scripting.
+* `astroengine codex files MODULE/...` resolves documentation or dataset
+  references to absolute filesystem paths, allowing you to open the referenced
+  material in your editor.
+
+Examples:
+
+```bash
+# Summarise the developer platform module
+astroengine codex show developer_platform --json
+
+# Locate all documentation files linked from the codex CLI entries
+astroengine codex files developer_platform codex cli
+```
+
+## Python helpers {#python}
+
+The `astroengine.codex` package mirrors the CLI functionality for use inside
+Python:
+
+```python
+from astroengine import codex
+
+node = codex.describe_path(["developer_platform", "codex", "access", "cli"])
+print(node.metadata["description"])  # -> Command line interface for browsing codex metadata.
+
+paths = codex.resolved_files(["developer_platform", "codex", "access", "python"])
+for path in paths:
+    print(path)
+```
+
+Calling `codex.registry_snapshot()` returns the same structure that powers the
+`tree` command, while `codex.get_registry(refresh=True)` rebuilds the registry
+for integration tests. All metadata returned by these functions originates
+from the SolarFire-aligned registry definitions shipped in the repository—no
+synthetic values are introduced.

--- a/tests/test_cli_codex.py
+++ b/tests/test_cli_codex.py
@@ -1,0 +1,42 @@
+"""Smoke tests for the ``astroengine codex`` CLI command."""
+
+from __future__ import annotations
+
+from astroengine import cli
+
+
+def test_codex_tree_lists_developer_platform(capsys) -> None:
+    exit_code = cli.main(["codex", "tree"])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "developer_platform" in output
+    assert "codex" in output
+
+
+def test_codex_show_json_emits_payload(capsys) -> None:
+    exit_code = cli.main([
+        "codex",
+        "show",
+        "developer_platform",
+        "codex",
+        "access",
+        "cli",
+        "--json",
+    ])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "astroengine codex" in output
+
+
+def test_codex_files_returns_documentation_path(capsys) -> None:
+    exit_code = cli.main([
+        "codex",
+        "files",
+        "developer_platform",
+        "codex",
+        "access",
+        "python",
+    ])
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "codex.md" in output

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -1,0 +1,28 @@
+"""Tests for the astroengine.codex helper module."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from astroengine import codex
+
+
+def test_describe_root_contains_developer_platform() -> None:
+    node = codex.describe_path()
+    assert node.kind == "registry"
+    assert "developer_platform" in node.children
+
+
+def test_codex_cli_entry_metadata_and_payload() -> None:
+    node = codex.describe_path(["developer_platform", "codex", "access", "cli"])
+    assert node.kind == "subchannel"
+    assert node.metadata.get("status") == "available"
+    assert node.payload and node.payload.get("command") == "astroengine codex"
+
+
+def test_resolved_files_for_python_helpers_points_to_docs() -> None:
+    paths = codex.resolved_files(["developer_platform", "codex", "access", "python"])
+    filenames = {Path(p).name for p in paths}
+    assert "codex.md" in filenames
+    for path in paths:
+        assert Path(path).exists()


### PR DESCRIPTION
## Summary
- expose new `astroengine.codex` helpers for programmatic registry navigation and file resolution
- add the `astroengine codex` CLI subcommand plus developer documentation for codex access surfaces
- restore backward-compatible config exports used during package import (astrocartography and plugin settings)

## Testing
- pytest tests/test_codex.py tests/test_cli_codex.py

------
https://chatgpt.com/codex/tasks/task_e_68e2f20662b883248d8df31b9ad81509