### PR TITLE
Add profiles registry, API, and Streamlit manager

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,6 +26,7 @@ from app.routers import (
     interpret_router,
     lots_router,
     policies_router,
+    profiles_router,
     settings_router,
     reports_router,
     relationship_router,
@@ -60,6 +61,7 @@ app.include_router(settings_router)
 app.include_router(notes_router)
 app.include_router(data_router)
 app.include_router(charts_router)
+app.include_router(profiles_router)
 if DEV_MODE_ENABLED:
     from app.devmode import router as devmode_router
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -23,6 +23,7 @@ __all__ = [
     "notes_router",
     "data_router",
     "charts_router",
+    "profiles_router",
     "configure_position_provider",
     "clear_position_provider",
 ]
@@ -72,6 +73,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .relationship import router as relationship_router
 
         return relationship_router
+    if name == "profiles_router":
+        from .profiles import router as profiles_router
+
+        return profiles_router
     if name == "reports_router":
         from .reports import router as reports_router
 

--- a/app/routers/profiles.py
+++ b/app/routers/profiles.py
@@ -1,0 +1,84 @@
+"""Profiles API endpoints for AstroEngine settings management."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from astroengine.config import (
+    Settings,
+    apply_profile_overlay,
+    delete_user_profile,
+    list_profiles,
+    load_profile_overlay,
+    load_settings,
+    save_settings,
+    save_user_profile,
+)
+
+router = APIRouter(prefix="/v1/profiles", tags=["profiles"])
+
+
+class NamedSettings(BaseModel):
+    """Bundle a settings payload with a profile name."""
+
+    name: str
+    settings: Settings
+
+
+@router.get("")
+async def get_profiles() -> dict[str, list[str]]:
+    """Return the available built-in and user-defined profiles."""
+
+    return list_profiles()
+
+
+@router.get("/{name}", response_model=Settings)
+async def get_profile(name: str) -> Settings:
+    """Return the settings that would result from applying ``name``."""
+
+    try:
+        overlay = load_profile_overlay(name)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive mapping
+        raise HTTPException(status_code=404, detail="profile not found") from exc
+    base = load_settings()
+    return apply_profile_overlay(base, overlay)
+
+
+@router.post("/{name}/apply", response_model=Settings)
+async def apply_profile(name: str) -> Settings:
+    """Apply ``name`` to the persisted settings and return the new state."""
+
+    try:
+        overlay = load_profile_overlay(name)
+    except FileNotFoundError as exc:  # pragma: no cover - defensive mapping
+        raise HTTPException(status_code=404, detail="profile not found") from exc
+    current = load_settings()
+    merged = apply_profile_overlay(current, overlay)
+    save_settings(merged)
+    return merged
+
+
+@router.post("", response_model=dict)
+async def create_profile(payload: NamedSettings) -> dict[str, str]:
+    """Persist a new user profile."""
+
+    saved_path = save_user_profile(payload.name, payload.settings)
+    return {"saved": str(saved_path)}
+
+
+@router.put("/{name}")
+async def update_profile(name: str, settings: Settings) -> dict[str, str]:
+    """Replace the stored profile ``name`` with ``settings``."""
+
+    saved_path = save_user_profile(name, settings)
+    return {"saved": str(saved_path)}
+
+
+@router.delete("/{name}")
+async def delete_profile_api(name: str) -> dict[str, str]:
+    """Delete the persisted user profile if it exists."""
+
+    if delete_user_profile(name):
+        return {"deleted": name}
+    raise HTTPException(status_code=404, detail="not found")

--- a/astroengine/config/__init__.py
+++ b/astroengine/config/__init__.py
@@ -50,6 +50,16 @@ from .settings import (
     load_settings,
     save_settings,
 )
+from .profiles import (
+    PROFILES_DIRNAME,
+    apply_profile_overlay,
+    built_in_profiles,
+    delete_user_profile,
+    list_profiles,
+    load_profile_overlay,
+    profiles_home,
+    save_user_profile,
+)
 
 __all__ = [
     "load_profile_json",
@@ -104,4 +114,12 @@ __all__ = [
     "load_settings",
     "save_settings",
     "ensure_default_config",
+    "PROFILES_DIRNAME",
+    "built_in_profiles",
+    "profiles_home",
+    "list_profiles",
+    "load_profile_overlay",
+    "apply_profile_overlay",
+    "save_user_profile",
+    "delete_user_profile",
 ]

--- a/astroengine/config/profiles.py
+++ b/astroengine/config/profiles.py
@@ -1,0 +1,218 @@
+"""Profiles registry and helpers for AstroEngine settings."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Dict
+
+from .settings import Settings, get_config_home
+
+PROFILES_DIRNAME = "profiles"
+
+
+def built_in_profiles() -> Dict[str, dict]:
+    """Return overlays describing the built-in settings profiles."""
+
+    return {
+        "modern_western": {
+            "preset": "modern_western",
+            "zodiac": {"type": "tropical"},
+            "houses": {"system": "placidus"},
+            "aspects": {
+                "sets": {"ptolemaic": True, "minor": True, "harmonics": False},
+                "orbs_global": 6.0,
+                "orbs_by_aspect": {
+                    "conjunction": 8.0,
+                    "opposition": 8.0,
+                    "trine": 7.0,
+                    "square": 6.0,
+                    "sextile": 4.0,
+                    "quincunx": 3.0,
+                },
+                "orbs_by_body": {"sun": 10.0, "moon": 8.0},
+            },
+            "narrative": {"library": "western_basic"},
+        },
+        "traditional_western": {
+            "preset": "traditional_western",
+            "zodiac": {"type": "tropical"},
+            "houses": {"system": "regiomontanus"},
+            "aspects": {
+                "sets": {"ptolemaic": True, "minor": False, "harmonics": False},
+                "orbs_by_aspect": {
+                    "conjunction": 8.0,
+                    "opposition": 8.0,
+                    "trine": 6.0,
+                    "square": 6.0,
+                    "sextile": 4.0,
+                },
+            },
+            "dignities": {
+                "scoring": "lilly",
+                "weights": {
+                    "domicile": 5,
+                    "exaltation": 4,
+                    "triplicity": 3,
+                    "term": 2,
+                    "face": 1,
+                    "detriment": -5,
+                    "fall": -4,
+                },
+            },
+        },
+        "hellenistic": {
+            "preset": "hellenistic",
+            "houses": {"system": "whole_sign"},
+            "aspects": {
+                "sets": {"ptolemaic": True, "minor": False, "harmonics": False},
+                "detect_patterns": False,
+            },
+            "narrative": {"library": "hellenistic"},
+        },
+        "vedic": {
+            "preset": "vedic",
+            "zodiac": {"type": "sidereal", "ayanamsa": "lahiri"},
+            "houses": {"system": "whole_sign"},
+            "aspects": {
+                "sets": {"ptolemaic": False, "minor": False, "harmonics": False},
+            },
+            "charts": {
+                "enabled": {
+                    "varga_d1": True,
+                    "varga_d9": True,
+                    "varga_d10": True,
+                    "vedic_dasha_vimshottari": True,
+                    "vedic_dasha_yogini": True,
+                }
+            },
+            "narrative": {"library": "vedic"},
+        },
+        "horary": {
+            "preset": "traditional_western",
+            "houses": {"system": "regiomontanus"},
+            "aspects": {
+                "sets": {"ptolemaic": True, "minor": False},
+                "orbs_by_aspect": {
+                    "conjunction": 5.0,
+                    "opposition": 5.0,
+                    "trine": 4.0,
+                    "square": 4.0,
+                    "sextile": 3.0,
+                },
+                "orbs_by_body": {"sun": 7.0, "moon": 6.0},
+            },
+            "declinations": {"orb_deg": 0.5},
+            "dignities": {
+                "weights": {"retrograde": -6, "combustion": -6, "cazimi": 6}
+            },
+        },
+        "electional": {
+            "preset": "modern_western",
+            "electional": {
+                "enabled": True,
+                "weights": {
+                    "benefic_on_angles": 6,
+                    "malefic_on_angles": -6,
+                    "moon_void": -8,
+                    "dignity_bonus": 4,
+                    "retrograde_penalty": -4,
+                    "combustion_penalty": -5,
+                    "cazimi_bonus": 5,
+                },
+                "step_minutes": 3,
+            },
+            "forecast_stack": {"exactness_deg": 0.25, "min_orb_deg": 0.25},
+        },
+        "minimalist": {
+            "preset": "minimalist",
+            "bodies": {
+                "groups": {
+                    "luminaries": True,
+                    "classical": True,
+                    "modern": False,
+                    "dwarf": False,
+                    "asteroids_major": False,
+                }
+            },
+            "aspects": {
+                "sets": {"ptolemaic": True, "minor": False},
+                "detect_patterns": False,
+            },
+        },
+    }
+
+
+def profiles_home() -> Path:
+    """Return the directory containing persisted profiles."""
+
+    return get_config_home() / PROFILES_DIRNAME
+
+
+def list_profiles() -> Dict[str, list[str]]:
+    """Return a mapping of built-in and user profile names."""
+
+    built_in = sorted(built_in_profiles().keys())
+    user_profiles: list[str] = []
+    directory = profiles_home()
+    if directory.exists():
+        for file_path in directory.glob("*.yaml"):
+            user_profiles.append(file_path.stem)
+    return {"built_in": built_in, "user": sorted(user_profiles)}
+
+
+def load_profile_overlay(name: str) -> dict:
+    """Load a profile overlay by name, preferring built-ins."""
+
+    built_ins = built_in_profiles()
+    if name in built_ins:
+        return deepcopy(built_ins[name])
+    profile_path = profiles_home() / f"{name}.yaml"
+    if not profile_path.exists():
+        raise FileNotFoundError(name)
+    import yaml
+
+    return yaml.safe_load(profile_path.read_text(encoding="utf-8")) or {}
+
+
+def apply_profile_overlay(base: Settings, overlay: dict) -> Settings:
+    """Return a new Settings object with ``overlay`` merged into ``base``."""
+
+    def deep_merge(left: object, right: object) -> object:
+        if isinstance(left, dict) and isinstance(right, dict):
+            merged: dict = dict(left)
+            for key, value in right.items():
+                if key in merged:
+                    merged[key] = deep_merge(merged[key], value)
+                else:
+                    merged[key] = deepcopy(value)
+            return merged
+        return deepcopy(right)
+
+    merged_dict = deep_merge(base.model_dump(), overlay)
+    return Settings(**merged_dict)
+
+
+def save_user_profile(name: str, settings: Settings) -> Path:
+    """Persist ``settings`` to a user-defined profile file."""
+
+    directory = profiles_home()
+    directory.mkdir(parents=True, exist_ok=True)
+    profile_path = directory / f"{name}.yaml"
+    import yaml
+
+    profile_path.write_text(
+        yaml.safe_dump(settings.model_dump(), sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return profile_path
+
+
+def delete_user_profile(name: str) -> bool:
+    """Delete the stored profile if it exists."""
+
+    profile_path = profiles_home() / f"{name}.yaml"
+    if profile_path.exists():
+        profile_path.unlink()
+        return True
+    return False

--- a/ui/streamlit/profiles_manager.py
+++ b/ui/streamlit/profiles_manager.py
@@ -1,0 +1,158 @@
+"""Streamlit UI for managing AstroEngine profiles and presets."""
+
+from __future__ import annotations
+
+import requests
+import streamlit as st
+import yaml
+
+from astroengine.config import (
+    apply_profile_overlay,
+    list_profiles,
+    load_profile_overlay,
+    load_settings,
+    profiles_home,
+    save_user_profile,
+)
+
+st.set_page_config(page_title="AstroEngine — Profiles", layout="wide")
+st.title("📚 Profiles & Presets")
+
+api_base = st.session_state.get("API_BASE") or "http://127.0.0.1:8000"
+
+left, right = st.columns([2, 3])
+
+with left:
+    st.subheader("Built-in profiles")
+    catalog = list_profiles()
+    built_in = catalog.get("built_in", [])
+    user_profiles = catalog.get("user", [])
+
+    if built_in:
+        default_index = built_in.index("modern_western") if "modern_western" in built_in else 0
+        selected_builtin = st.selectbox(
+            "Select a built-in profile",
+            built_in,
+            index=default_index,
+        )
+        if st.button("Apply built-in profile", type="primary", disabled=not selected_builtin):
+            try:
+                response = requests.post(
+                    f"{api_base}/v1/profiles/{selected_builtin}/apply",
+                    timeout=15,
+                )
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                st.error(f"Failed to apply profile: {exc}")
+            else:
+                st.success("Profile applied and saved.")
+    else:
+        st.info("No built-in profiles available.")
+
+    st.divider()
+    st.subheader("User profiles")
+    selected_user = st.selectbox(
+        "Select a user profile",
+        user_profiles,
+        index=0 if user_profiles else None,
+        placeholder="No user profiles yet",
+    )
+
+    cols_actions = st.columns(3)
+    with cols_actions[0]:
+        if st.button("Apply user profile", disabled=not selected_user):
+            try:
+                response = requests.post(
+                    f"{api_base}/v1/profiles/{selected_user}/apply",
+                    timeout=15,
+                )
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                st.error(f"Failed to apply profile: {exc}")
+            else:
+                st.success("Profile applied and saved.")
+    with cols_actions[1]:
+        if st.button("Delete user profile", disabled=not selected_user):
+            try:
+                response = requests.delete(
+                    f"{api_base}/v1/profiles/{selected_user}", timeout=15
+                )
+                response.raise_for_status()
+            except requests.RequestException as exc:
+                st.error(f"Failed to delete profile: {exc}")
+            else:
+                st.success("Profile deleted.")
+                st.rerun()
+    with cols_actions[2]:
+        if selected_user:
+            overlay = load_profile_overlay(selected_user)
+            st.download_button(
+                "Export YAML",
+                yaml.safe_dump(overlay, sort_keys=False).encode("utf-8"),
+                file_name=f"{selected_user}.yaml",
+            )
+        else:
+            st.download_button(
+                "Export YAML",
+                b"",
+                file_name="profile.yaml",
+                disabled=True,
+            )
+
+    st.divider()
+    st.subheader("Save current settings as a profile")
+    new_profile_name = st.text_input("Profile name", placeholder="my_team_preset")
+    if st.button("Save current settings", type="primary", disabled=not new_profile_name):
+        settings = load_settings()
+        save_user_profile(new_profile_name, settings)
+        st.success("Profile saved.")
+        st.rerun()
+
+    st.divider()
+    st.subheader("Import profile YAML")
+    uploaded_file = st.file_uploader("Choose a .yaml profile", type=["yaml", "yml"])
+    import_name = st.text_input("Import as", value="imported_profile")
+    if uploaded_file and st.button("Import profile", disabled=not import_name):
+        try:
+            overlay = yaml.safe_load(uploaded_file.getvalue()) or {}
+            current = load_settings()
+            merged = apply_profile_overlay(current, overlay)
+            save_user_profile(import_name, merged)
+        except yaml.YAMLError as exc:
+            st.error(f"Invalid YAML: {exc}")
+        else:
+            st.success("Profile imported.")
+            st.rerun()
+
+with right:
+    st.subheader("Preview changes")
+    mode = st.radio("Profile source", ["Built-in", "User"], horizontal=True)
+    target_name = None
+    if mode == "Built-in" and built_in:
+        target_name = st.selectbox("Preview built-in", built_in, key="preview_builtin")
+    elif mode == "User" and user_profiles:
+        target_name = st.selectbox("Preview user", user_profiles, key="preview_user")
+
+    if target_name:
+        try:
+            overlay = load_profile_overlay(target_name)
+            base = load_settings()
+            merged = apply_profile_overlay(base, overlay)
+        except FileNotFoundError:
+            st.error("Profile not found on disk.")
+        else:
+            st.caption("Settings preview after applying the profile")
+            st.json(merged.model_dump())
+            st.caption("Top-level keys that would change")
+            current_dump = base.model_dump()
+            merged_dump = merged.model_dump()
+            changed_keys = [
+                key
+                for key, value in merged_dump.items()
+                if current_dump.get(key) != value
+            ]
+            st.code("\n".join(changed_keys) if changed_keys else "No changes", language="text")
+    else:
+        st.info("Select a profile to preview differences.")
+
+st.caption(f"Profiles are stored in: {profiles_home()}")

--- a/ui/streamlit/settings_panel.py
+++ b/ui/streamlit/settings_panel.py
@@ -21,6 +21,7 @@ from astroengine.plugins.registry import (
 st.set_page_config(page_title="AstroEngine Settings", layout="wide")
 
 st.title("⚙️ AstroEngine Settings")
+st.page_link("ui/streamlit/profiles_manager.py", label="Open Profiles & Presets →")
 
 current_settings = load_settings()
 st.sidebar.success(f"Profile: {config_path()}")


### PR DESCRIPTION
## Summary
- add a profiles registry with built-in overlays and helpers for persisting user presets
- expose a FastAPI router for listing, applying, and managing profiles
- ship a Streamlit profiles manager UI and link it from the existing settings panel

## Testing
- pytest *(fails: existing import errors in test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68e2f4cfb038832498ef8c047a032fde