### PR TITLE
Harden narrative mix API validation

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -27,6 +27,7 @@ from app.routers import (
     lots_router,
     policies_router,
     profiles_router,
+    narrative_mix_router,
     settings_router,
     reports_router,
     relationship_router,
@@ -62,6 +63,7 @@ app.include_router(notes_router)
 app.include_router(data_router)
 app.include_router(charts_router)
 app.include_router(profiles_router)
+app.include_router(narrative_mix_router)
 if DEV_MODE_ENABLED:
     from app.devmode import router as devmode_router
 

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -24,6 +24,7 @@ __all__ = [
     "data_router",
     "charts_router",
     "profiles_router",
+    "narrative_mix_router",
     "configure_position_provider",
     "clear_position_provider",
 ]
@@ -77,6 +78,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .profiles import router as profiles_router
 
         return profiles_router
+    if name == "narrative_mix_router":
+        from .narrative_mix import router as narrative_mix_router
+
+        return narrative_mix_router
     if name == "reports_router":
         from .reports import router as reports_router
 

--- a/astroengine/config/__init__.py
+++ b/astroengine/config/__init__.py
@@ -31,6 +31,7 @@ from .settings import (
     MidpointsCfg,
     MultiWheelCfg,
     NarrativeCfg,
+    NarrativeMixCfg,
     ObservabilityCfg,
     PerfCfg,
     PrimaryDirectionsCfg,
@@ -51,6 +52,16 @@ from .settings import (
     get_config_home,
     load_settings,
     save_settings,
+    compose_narrative_from_mix,
+    save_mix_as_user_narrative_profile,
+)
+from .narrative_profiles import (
+    NARRATIVE_PROFILES_DIRNAME,
+    built_in_narrative_profiles,
+    list_narrative_profiles,
+    load_narrative_profile_overlay,
+    narrative_profiles_home,
+    save_user_narrative_profile,
 )
 from .profiles import (
     PROFILES_DIRNAME,
@@ -102,6 +113,7 @@ __all__ = [
     "MidpointsCfg",
     "MidpointTreeCfg",
     "NarrativeCfg",
+    "NarrativeMixCfg",
     "MultiWheelCfg",
     "RenderingCfg",
     "FixedStarsCfg",
@@ -114,6 +126,8 @@ __all__ = [
     "default_settings",
     "load_settings",
     "save_settings",
+    "compose_narrative_from_mix",
+    "save_mix_as_user_narrative_profile",
     "ensure_default_config",
     "PROFILES_DIRNAME",
     "built_in_profiles",
@@ -123,4 +137,10 @@ __all__ = [
     "apply_profile_overlay",
     "save_user_profile",
     "delete_user_profile",
+    "NARRATIVE_PROFILES_DIRNAME",
+    "built_in_narrative_profiles",
+    "list_narrative_profiles",
+    "load_narrative_profile_overlay",
+    "narrative_profiles_home",
+    "save_user_narrative_profile",
 ]

--- a/astroengine/config/narrative_profiles.py
+++ b/astroengine/config/narrative_profiles.py
@@ -1,0 +1,186 @@
+"""Narrative profile overlay helpers exposed under :mod:`astroengine.config`."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Dict, Mapping, MutableMapping
+
+import yaml
+
+from .settings import NarrativeCfg, get_config_home
+
+__all__ = [
+    "NARRATIVE_PROFILES_DIRNAME",
+    "built_in_narrative_profiles",
+    "narrative_profiles_home",
+    "list_narrative_profiles",
+    "load_narrative_profile_overlay",
+    "save_user_narrative_profile",
+]
+
+
+NARRATIVE_PROFILES_DIRNAME = "narrative_profiles"
+
+
+def _default_esoteric() -> Dict[str, Any]:
+    return {
+        "tarot_enabled": False,
+        "tarot_deck": "rws",
+        "numerology_enabled": False,
+        "numerology_system": "pythagorean",
+    }
+
+
+_BUILT_IN_NARRATIVE_PROFILES: Dict[str, Dict[str, Any]] = {
+    "modern_psychological": {
+        "narrative": {
+            "mode": "modern_psychological",
+            "library": "western_basic",
+            "tone": "teaching",
+            "length": "medium",
+            "verbosity": 0.65,
+            "sources": {
+                "transits": True,
+                "progressions": True,
+                "midpoints": True,
+                "timelords": True,
+            },
+            "frameworks": {
+                "psychological": True,
+                "jungian": False,
+                "data_driven": True,
+            },
+            "esoteric": _default_esoteric(),
+            "disclaimers": True,
+        }
+    },
+    "data_minimal": {
+        "narrative": {
+            "mode": "data_minimal",
+            "library": "none",
+            "tone": "brief",
+            "length": "short",
+            "verbosity": 0.3,
+            "sources": {
+                "transits": True,
+                "progressions": False,
+                "midpoints": False,
+                "timelords": False,
+            },
+            "frameworks": {
+                "psychological": False,
+                "jungian": False,
+                "data_driven": True,
+            },
+            "esoteric": _default_esoteric(),
+            "disclaimers": False,
+        }
+    },
+    "jungian_archetypal": {
+        "narrative": {
+            "mode": "jungian_archetypal",
+            "library": "western_basic",
+            "tone": "teaching",
+            "length": "long",
+            "verbosity": 0.75,
+            "sources": {
+                "transits": True,
+                "progressions": True,
+                "midpoints": True,
+                "timelords": True,
+            },
+            "frameworks": {
+                "psychological": True,
+                "jungian": True,
+                "mythic": True,
+            },
+            "esoteric": {
+                "tarot_enabled": True,
+                "tarot_deck": "thoth",
+                "numerology_enabled": True,
+                "numerology_system": "pythagorean",
+            },
+            "disclaimers": True,
+        }
+    },
+    "hellenistic_sober": {
+        "narrative": {
+            "mode": "hellenistic_sober",
+            "library": "hellenistic",
+            "tone": "neutral",
+            "length": "medium",
+            "verbosity": 0.5,
+            "sources": {
+                "transits": True,
+                "lots": True,
+                "sect": True,
+            },
+            "frameworks": {
+                "traditional": True,
+                "psychological": False,
+                "data_driven": False,
+            },
+            "esoteric": _default_esoteric(),
+            "disclaimers": True,
+        }
+    },
+}
+
+
+def built_in_narrative_profiles() -> Dict[str, Dict[str, Any]]:
+    """Return a deep copy of built-in narrative overlays."""
+
+    return deepcopy(_BUILT_IN_NARRATIVE_PROFILES)
+
+
+def narrative_profiles_home() -> Path:
+    """Return the directory containing user narrative profiles."""
+
+    return get_config_home() / NARRATIVE_PROFILES_DIRNAME
+
+
+def list_narrative_profiles() -> Dict[str, list[str]]:
+    """Return available built-in and user narrative profile identifiers."""
+
+    built_in = sorted(built_in_narrative_profiles().keys())
+    user_profiles: list[str] = []
+    directory = narrative_profiles_home()
+    if directory.exists():
+        for file_path in directory.glob("*.yaml"):
+            user_profiles.append(file_path.stem)
+    return {"built_in": built_in, "user": sorted(user_profiles)}
+
+
+def load_narrative_profile_overlay(name: str) -> Dict[str, Any]:
+    """Load a narrative overlay from built-ins or disk."""
+
+    built_ins = built_in_narrative_profiles()
+    if name in built_ins:
+        return deepcopy(built_ins[name])
+    path = narrative_profiles_home() / f"{name}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(name)
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return data or {}
+
+
+def save_user_narrative_profile(
+    name: str, narrative: NarrativeCfg | Mapping[str, Any] | MutableMapping[str, Any]
+) -> Path:
+    """Persist a user-defined narrative overlay to disk."""
+
+    directory = narrative_profiles_home()
+    directory.mkdir(parents=True, exist_ok=True)
+    path = directory / f"{name}.yaml"
+
+    if isinstance(narrative, NarrativeCfg):
+        payload: Dict[str, Any] = narrative.model_dump()
+    else:
+        payload = dict(narrative)
+
+    path.write_text(
+        yaml.safe_dump({"narrative": payload}, sort_keys=False, allow_unicode=True),
+        encoding="utf-8",
+    )
+    return path

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
-from typing import Dict, List, Literal, Optional
+from typing import Dict, List, Literal, Optional, Tuple
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
@@ -196,15 +196,28 @@ class ChartsCfg(BaseModel):
     )
 
 
+class NarrativeEsotericCfg(BaseModel):
+    """Optional esoteric add-ons that influence narrative tone."""
+
+    tarot_enabled: bool = False
+    tarot_deck: str = "rws"
+    numerology_enabled: bool = False
+    numerology_system: str = "pythagorean"
+
+
 class NarrativeCfg(BaseModel):
     """Narrative rendering preferences for interpretive output."""
 
+    mode: str = "modern_psychological"
     library: Literal["western_basic", "hellenistic", "vedic", "none"] = "western_basic"
     tone: Literal["neutral", "teaching", "brief"] = "neutral"
     length: Literal["short", "medium", "long"] = "medium"
     language: str = "en"
     disclaimers: bool = True
     verbosity: float = 0.5
+    sources: Dict[str, bool] = Field(default_factory=dict)
+    frameworks: Dict[str, bool] = Field(default_factory=dict)
+    esoteric: NarrativeEsotericCfg = Field(default_factory=NarrativeEsotericCfg)
 
     @field_validator("verbosity", mode="before")
     @classmethod
@@ -212,6 +225,35 @@ class NarrativeCfg(BaseModel):
         numeric = float(value)
         return max(0.0, min(1.0, numeric))
 
+
+class NarrativeMixCfg(BaseModel):
+    """Weighted blend of narrative profiles."""
+
+    enabled: bool = False
+    profiles: Dict[str, float] = Field(default_factory=dict)
+    normalize: bool = True
+
+    @field_validator("profiles", mode="before")
+    @classmethod
+    def _coerce_weights(cls, value: object) -> Dict[str, float]:
+        if isinstance(value, dict):
+            items = value.items()
+        else:
+            try:
+                mapping = dict(value or {})  # type: ignore[arg-type]
+            except Exception:
+                return {}
+            items = mapping.items()
+        capped: Dict[str, float] = {}
+        for key, weight in items:
+            try:
+                numeric = float(weight)
+            except (TypeError, ValueError):
+                continue
+            if numeric < 0:
+                numeric = 0.0
+            capped[key] = min(numeric, 1_000_000.0)
+        return capped
 
 class RenderingCfg(BaseModel):
     """Chart rendering options."""
@@ -626,6 +668,154 @@ class Settings(BaseModel):
     reports: ReportsCfg = Field(default_factory=ReportsCfg)
     atlas: AtlasCfg = Field(default_factory=AtlasCfg)
     plugins: PluginCfg = Field(default_factory=PluginCfg)
+    narrative_mix: NarrativeMixCfg = Field(default_factory=NarrativeMixCfg)
+
+
+# -------------------- Narrative Mixing Helpers --------------------
+
+
+def _normalize_weights(weights: Dict[str, float]) -> Dict[str, float]:
+    total = sum(weights.values())
+    if total <= 0:
+        return {name: 0.0 for name in weights}
+    return {name: (value / total) for name, value in weights.items()}
+
+
+_TONE_ORDER: Tuple[str, ...] = ("brief", "neutral", "teaching")
+_LENGTH_ORDER: Tuple[str, ...] = ("short", "medium", "long")
+
+
+def _vote_enum(values: List[str], weights: List[float], order: Tuple[str, ...]) -> str:
+    if not order:
+        return ""
+    scores = {choice: 0.0 for choice in order}
+    for value, weight in zip(values, weights):
+        if value in scores:
+            scores[value] += weight
+    return max(scores.items(), key=lambda item: item[1])[0]
+
+
+def _merge_bool_maps(
+    maps: List[Dict[str, bool]],
+    weights: List[float],
+    *,
+    threshold: float = 0.5,
+) -> Dict[str, bool]:
+    keys = set()
+    for mapping in maps:
+        keys.update(mapping.keys())
+    result: Dict[str, bool] = {}
+    for key in sorted(keys):
+        score = 0.0
+        for mapping, weight in zip(maps, weights):
+            if mapping.get(key, False):
+                score += weight
+        result[key] = score >= threshold
+    return result
+
+
+def compose_narrative_from_mix(base: Settings, mix: NarrativeMixCfg) -> NarrativeCfg:
+    """Blend narrative overlays declared in ``mix`` onto ``base``."""
+
+    if not mix.enabled or not mix.profiles:
+        return base.narrative
+
+    positive = {name: float(weight) for name, weight in mix.profiles.items() if weight > 0}
+    if not positive:
+        return base.narrative
+
+    from .narrative_profiles import load_narrative_profile_overlay
+
+    entries: List[Tuple[str, float, NarrativeCfg]] = []
+    for name, weight in positive.items():
+        try:
+            overlay = load_narrative_profile_overlay(name)
+        except FileNotFoundError:
+            continue
+        block = overlay.get("narrative") or overlay
+        try:
+            merged = {**base.narrative.model_dump(), **block}
+            cfg = NarrativeCfg(**merged)
+        except Exception:
+            continue
+        entries.append((name, weight, cfg))
+
+    if not entries:
+        return base.narrative
+
+    names = [name for name, _, _ in entries]
+    weights = [weight for _, weight, _ in entries]
+    if mix.normalize:
+        normalized = _normalize_weights(dict(zip(names, weights)))
+        weights = [normalized[name] for name in names]
+
+    narratives = [cfg for _, _, cfg in entries]
+    top_index = max(range(len(weights)), key=lambda idx: weights[idx])
+    top_narrative = narratives[top_index]
+
+    tones = [cfg.tone for cfg in narratives]
+    lengths = [cfg.length for cfg in narratives]
+    verb = sum((cfg.verbosity or 0.0) * weight for cfg, weight in zip(narratives, weights))
+
+    sources = _merge_bool_maps([cfg.sources for cfg in narratives], weights)
+    frameworks = _merge_bool_maps([cfg.frameworks for cfg in narratives], weights)
+
+    tarot_enabled_score = sum(
+        (1.0 if cfg.esoteric.tarot_enabled else 0.0) * weight
+        for cfg, weight in zip(narratives, weights)
+    )
+    numerology_enabled_score = sum(
+        (1.0 if cfg.esoteric.numerology_enabled else 0.0) * weight
+        for cfg, weight in zip(narratives, weights)
+    )
+
+    sorted_entries = sorted(
+        zip(narratives, weights), key=lambda item: item[1], reverse=True
+    )
+    tarot_deck = base.narrative.esoteric.tarot_deck
+    numerology_system = base.narrative.esoteric.numerology_system
+    for cfg, weight in sorted_entries:
+        if cfg.esoteric.tarot_enabled:
+            tarot_deck = cfg.esoteric.tarot_deck
+            break
+    for cfg, weight in sorted_entries:
+        if cfg.esoteric.numerology_enabled:
+            numerology_system = cfg.esoteric.numerology_system
+            break
+
+    payload = base.narrative.model_dump()
+    payload.update(
+        {
+            "mode": "mixed",
+            "library": top_narrative.library,
+            "tone": _vote_enum(tones, weights, _TONE_ORDER),
+            "length": _vote_enum(lengths, weights, _LENGTH_ORDER),
+            "verbosity": max(0.0, min(1.0, verb)),
+            "sources": sources,
+            "frameworks": frameworks,
+            "esoteric": {
+                "tarot_enabled": tarot_enabled_score >= 0.5,
+                "tarot_deck": tarot_deck,
+                "numerology_enabled": numerology_enabled_score >= 0.5,
+                "numerology_system": numerology_system,
+            },
+            "disclaimers": bool(
+                base.narrative.disclaimers
+                or any(cfg.disclaimers for cfg in narratives)
+            ),
+        }
+    )
+    return NarrativeCfg(**payload)
+
+
+def save_mix_as_user_narrative_profile(
+    name: str, base: Settings, mix: NarrativeMixCfg
+) -> Path:
+    from .narrative_profiles import save_user_narrative_profile
+
+    narrative = compose_narrative_from_mix(base, mix)
+    return save_user_narrative_profile(name, narrative)
+
 
 
 # -------------------- I/O Helpers --------------------

--- a/ui/streamlit/narrative_mixer.py
+++ b/ui/streamlit/narrative_mixer.py
@@ -1,0 +1,116 @@
+"""Streamlit UI for blending narrative profiles with adjustable weights."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict
+
+import requests
+import streamlit as st
+
+from astroengine.config import list_narrative_profiles
+
+st.set_page_config(page_title="AstroEngine — Narrative Mixer", layout="wide")
+st.title("🎚️ Narrative Mixer — Blend Multiple Styles")
+
+API_DEFAULT = os.environ.get("ASTROENGINE_API", "http://127.0.0.1:8000")
+
+profiles_catalog = list_narrative_profiles()
+all_profiles = profiles_catalog.get("built_in", []) + profiles_catalog.get("user", [])
+
+control_col, preview_col = st.columns([3, 4], gap="large")
+
+with control_col:
+    st.subheader("Select Profiles & Weights")
+    api_base = st.text_input(
+        "API base URL",
+        value=st.session_state.get("narrative_mix_api", API_DEFAULT),
+        help="Endpoint used when applying the mix.",
+    )
+    st.session_state["narrative_mix_api"] = api_base
+
+    default_selection = [name for name in ("modern_psychological", "data_minimal") if name in all_profiles]
+    picked = st.multiselect(
+        "Profiles to mix",
+        all_profiles,
+        default=default_selection or all_profiles[:2],
+        help="Pick one or more narrative profiles to blend.",
+    )
+
+    weights: Dict[str, float] = {}
+    for name in picked:
+        key = f"mix_weight_{name}"
+        current = st.session_state.get(key, 0.5)
+        weights[name] = st.slider(
+            f"Weight — {name}",
+            min_value=0.0,
+            max_value=1.0,
+            value=float(current),
+            step=0.05,
+            key=key,
+        )
+
+    actions = st.columns(3)
+    with actions[0]:
+        if st.button("Equalize") and picked:
+            equal = round(1.0 / len(picked), 4)
+            for name in picked:
+                st.session_state[f"mix_weight_{name}"] = equal
+            st.rerun()
+    with actions[1]:
+        normalize = st.toggle(
+            "Normalize weights",
+            value=st.session_state.get("mix_normalize", True),
+            help="If enabled, weights are scaled to sum to 1.0 before mixing.",
+            key="mix_normalize",
+        )
+    with actions[2]:
+        save_as = st.text_input(
+            "Save blend as",
+            value=st.session_state.get("mix_save_name", ""),
+            placeholder="my_jungian_mix",
+            key="mix_save_name",
+        )
+
+    if st.button("Apply Mix", type="primary"):
+        payload = {
+            "profiles": {name: st.session_state.get(f"mix_weight_{name}", weight) for name, weight in weights.items()},
+            "normalize": normalize,
+            "save_as": save_as or None,
+        }
+        try:
+            response = requests.post(
+                api_base.rstrip("/") + "/v1/narrative-mix/apply",
+                json=payload,
+                timeout=15,
+            )
+        except Exception as exc:  # pragma: no cover - network errors in UI only
+            st.error(f"Request failed: {exc}")
+        else:
+            if response.ok:
+                st.success("Mix applied and persisted to settings.")
+            else:
+                st.error(f"Failed to apply mix: {response.status_code} — {response.text}")
+
+with preview_col:
+    st.subheader("Preview Effective Narrative")
+    try:
+        preview = requests.get(
+            st.session_state["narrative_mix_api"].rstrip("/") + "/v1/narrative-mix",
+            timeout=10,
+        )
+    except Exception as exc:  # pragma: no cover - UI only
+        st.error(f"Could not contact API: {exc}")
+    else:
+        if preview.ok:
+            data = preview.json()
+            st.caption("Current mix configuration")
+            st.json(data.get("mix", {}))
+            st.caption("Effective narrative (used by the copilot & interpreters)")
+            st.json(data.get("effective", {}))
+            with st.expander("Available profiles", expanded=False):
+                st.json(data.get("available", {}))
+        else:
+            st.error(f"Failed to load mix: {preview.status_code} — {preview.text}")
+
+st.caption("Adjust narrative profiles to fine-tune tone, sources, and esoteric layers.")


### PR DESCRIPTION
## Summary
- require at least one positive-weight profile before applying a narrative mix and return a clear 422 error otherwise
- persist the sanitized weights and reuse the computed effective narrative when saving settings
- clean up an unused import in the settings module

## Testing
- pytest *(fails: ImportError: cannot import name 'declination_aspects' from 'astroengine.analysis')*

------
https://chatgpt.com/codex/tasks/task_e_68e2f7dbe4548324847cd35b18d1fe74