### PR TITLE
Add PIN gate to developer mode endpoints

### DIFF
--- a/app/devmode/api.py
+++ b/app/devmode/api.py
@@ -5,15 +5,20 @@ from __future__ import annotations
 import os
 import time
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from .gitops import GitOps
 from .history import Entry, append_changelog, append_history, read_history
-from .security import is_allowed, is_blocked, is_protected
+from .security import is_allowed, is_blocked, is_protected, require_dev_pin
 from .validate import pipeline
 
-router = APIRouter(prefix="/v1/dev", tags=["dev"], include_in_schema=False)
+router = APIRouter(
+    prefix="/v1/dev",
+    tags=["dev"],
+    include_in_schema=False,
+    dependencies=[Depends(require_dev_pin)],
+)
 
 CONFIRM_PHRASE = os.environ.get(
     "DEV_CORE_EDIT_CONFIRM", "I UNDERSTAND THIS MAY BREAK THE APP"

--- a/tests/api/test_devmode_pin.py
+++ b/tests/api/test_devmode_pin.py
@@ -1,0 +1,44 @@
+"""Tests for developer-mode PIN enforcement."""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def build_client() -> TestClient:
+    """Return a TestClient with the devmode router attached."""
+
+    for module in ["app.devmode.api", "app.devmode.security"]:
+        if module in sys.modules:
+            del sys.modules[module]
+
+    os.environ["DEV_MODE"] = "1"
+    os.environ["DEV_PIN"] = "pin-code"
+
+    devmode_api = importlib.import_module("app.devmode.api")
+    app = FastAPI()
+    app.include_router(devmode_api.router)
+    return TestClient(app)
+
+
+def test_dev_actions_require_pin() -> None:
+    """Requests without the developer PIN are rejected."""
+
+    client = build_client()
+    response = client.get("/v1/dev/history")
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Developer PIN required"
+
+
+def test_dev_actions_accept_valid_pin() -> None:
+    """Requests proceed when the correct PIN is supplied."""
+
+    client = build_client()
+    response = client.get("/v1/dev/history", headers={"X-Dev-Pin": "pin-code"})
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- require an `X-Dev-Pin` header that matches `DEV_PIN` for all `/v1/dev` routes
- surface a PIN input in the Streamlit dev-mode UI and send it with requests
- add regression coverage to confirm PIN enforcement behaviour

## Testing
- pytest tests/api/test_devmode_pin.py *(fails: missing pydantic v2 runtime support in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fabb08648324bc0e84375518a0c4