### PR TITLE
Add Streamlit client support for data export bundle

### DIFF
--- a/tests/test_streamlit_api_client.py
+++ b/tests/test_streamlit_api_client.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import pytest
+import requests
+
+from ui.streamlit.api import APIClient
+
+
+class DummyResponse:
+    def __init__(
+        self,
+        *,
+        status_code: int = 200,
+        content: bytes = b"",
+        json_data: object | None = None,
+        text: str | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.content = content
+        self._json_data = json_data
+        if text is not None:
+            self.text = text
+        elif isinstance(content, bytes):
+            self.text = content.decode("utf-8", errors="ignore")
+        else:
+            self.text = str(content)
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} error", response=self)
+
+    def json(self) -> object:
+        if self._json_data is None:
+            raise ValueError("No JSON payload")
+        return self._json_data
+
+
+def test_export_bundle_success(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_get(url: str, params=None, timeout: int | None = None):  # type: ignore[override]
+        captured["url"] = url
+        captured["params"] = params
+        captured["timeout"] = timeout
+        return DummyResponse(content=b"zip-bytes")
+
+    monkeypatch.setattr("ui.streamlit.api.requests.get", fake_get)
+
+    client = APIClient(base_url="http://astro.test")
+    payload = client.export_bundle()
+
+    assert payload == b"zip-bytes"
+    assert captured["url"] == "http://astro.test/v1/export"
+    assert captured["timeout"] == 60
+    assert captured["params"] == {"scope": "charts,settings"}
+
+
+def test_export_bundle_custom_scope(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_get(url: str, params=None, timeout: int | None = None):  # type: ignore[override]
+        captured["params"] = params
+        return DummyResponse(content=b"zip-bytes")
+
+    monkeypatch.setattr("ui.streamlit.api.requests.get", fake_get)
+
+    client = APIClient(base_url="http://astro.test")
+    client.export_bundle(["charts", " settings "])
+
+    assert captured["params"] == {"scope": "charts,settings"}
+
+
+def test_export_bundle_http_error(monkeypatch) -> None:
+    def fake_get(url: str, params=None, timeout: int | None = None):  # type: ignore[override]
+        assert params == {"scope": "charts"}
+        return DummyResponse(status_code=500, json_data={"detail": "failure"})
+
+    monkeypatch.setattr("ui.streamlit.api.requests.get", fake_get)
+
+    client = APIClient(base_url="http://astro.test")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        client.export_bundle(["charts"])
+
+    assert "failure" in str(excinfo.value)

--- a/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
+++ b/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
@@ -10,6 +10,7 @@ from astroengine.config import load_settings
 from core.viz_plus.wheel_svg import WheelOptions, build_aspect_hits, render_chart_wheel
 from core.viz_plus.aspect_grid import aspect_grid_symbols, render_aspect_grid
 from core.aspects_plus.harmonics import BASE_ASPECTS
+from ui.streamlit.api import APIClient
 
 st.set_page_config(page_title="Chart Wheel & Aspectarian", page_icon="🎡", layout="wide")
 st.title("Chart Wheel & Aspectarian 🎡")


### PR DESCRIPTION
## Summary
- extend the Streamlit API client with an export_bundle helper that returns the zipped charts/settings archive
- wire the Chart Wheel & Aspectarian page to import the API client used for exports
- cover the new client helper with unit tests to validate parameter handling and error propagation

## Testing
- pytest tests/test_api_import_export.py tests/test_streamlit_api_client.py *(fails: ImportError NameError: name 'model_validator' is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fac38f7c8324b0eae95be5ca0158