### PR TITLE
Add chart library persistence and UI

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import enum
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Mapping
 from uuid import uuid4
 
 
@@ -311,6 +311,7 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
         ),
         Index("ix_charts_dt_utc", "dt_utc"),
         Index("ix_charts_created_at", "created_at"),
+        Index("ix_charts_kind_name", "kind", "name"),
     )
 
 
@@ -321,8 +322,10 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
         String(32), nullable=False, default=ChartKind.natal.value, server_default=text("'natal'")
 
     )
-    profile_key: Mapped[str] = mapped_column(String(64), nullable=False)
-    kind: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    name: Mapped[str | None] = mapped_column(String(120), nullable=True)
+    tags: Mapped[str | None] = mapped_column(String(240), nullable=True)
+    memo: Mapped[str | None] = mapped_column(Text, nullable=True)
+    gender: Mapped[str | None] = mapped_column(String(32), nullable=True)
     _dt_utc: Mapped[datetime | None] = mapped_column(
         "dt_utc", DateTime(timezone=True), nullable=True
     )
@@ -332,7 +335,14 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
     location_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
     timezone: Mapped[str | None] = mapped_column(String(64), nullable=True)
     source: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    location_label: Mapped[str | None] = synonym("location_name")
     data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    settings_snapshot: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    narrative_profile: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    bodies: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    houses: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False, default=dict)
+    aspects: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
+    patterns: Mapped[list[dict[str, Any]]] = mapped_column(JSON, nullable=False, default=list)
 
     events: Mapped[list["Event"]] = relationship(
         back_populates="chart", cascade="all, delete-orphan"
@@ -363,6 +373,44 @@ class Chart(ModuleScopeMixin, TimestampMixin, Base):
 
         data = kwargs.pop("data", None)
         kwargs.setdefault("data", data or {})
+
+        snapshot = kwargs.pop("settings_snapshot", None)
+        if snapshot is not None:
+            if hasattr(snapshot, "model_dump"):
+                kwargs["settings_snapshot"] = snapshot.model_dump()  # type: ignore[attr-defined]
+            elif isinstance(snapshot, Mapping):
+                kwargs["settings_snapshot"] = dict(snapshot)
+            else:
+                kwargs["settings_snapshot"] = {}
+
+        bodies = kwargs.pop("bodies", None)
+        if bodies is not None:
+            if isinstance(bodies, Mapping):
+                kwargs["bodies"] = dict(bodies)
+            else:
+                kwargs["bodies"] = dict(bodies or {})  # type: ignore[arg-type]
+
+        houses = kwargs.pop("houses", None)
+        if houses is not None:
+            if isinstance(houses, Mapping):
+                kwargs["houses"] = dict(houses)
+            else:
+                kwargs["houses"] = dict(houses or {})  # type: ignore[arg-type]
+
+        aspects = kwargs.pop("aspects", None)
+        if aspects is not None:
+            if isinstance(aspects, Mapping):
+                kwargs["aspects"] = [dict(aspects)]
+            else:
+                kwargs["aspects"] = list(aspects)  # type: ignore[arg-type]
+
+        patterns = kwargs.pop("patterns", None)
+        if patterns is not None:
+            kwargs["patterns"] = list(patterns)  # type: ignore[arg-type]
+
+        narrative_profile = kwargs.pop("narrative_profile", None)
+        if narrative_profile is not None:
+            kwargs["narrative_profile"] = str(narrative_profile)
 
         super().__init__(**kwargs)
 

--- a/app/routers/charts.py
+++ b/app/routers/charts.py
@@ -2,19 +2,423 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
+from typing import Any, Mapping
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Query, Response
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy import select
 
 from astroengine.chart.natal import ChartLocation, compute_natal_chart
-from astroengine.config import load_settings
+from astroengine.compute import build_payload
+from astroengine.config import (
+    Settings,
+    apply_profile_overlay,
+    load_profile_overlay,
+    load_settings,
+)
 from astroengine.report import render_chart_pdf
 from astroengine.report.builders import build_chart_report_context
 from app.db.models import Chart
 from app.db.session import session_scope
 
+
 router = APIRouter(prefix="/v1/charts", tags=["charts"])
+
+
+def _ensure_utc(moment: datetime | None) -> datetime | None:
+    if moment is None:
+        return None
+    if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
+        return moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _apply_profile(settings: Settings, profile_name: str | None) -> tuple[Settings, str]:
+    if not profile_name:
+        return settings, settings.preset
+    try:
+        overlay = load_profile_overlay(profile_name)
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=f"Profile '{profile_name}' was not found") from exc
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=400, detail=f"Failed to load profile '{profile_name}'") from exc
+    merged = apply_profile_overlay(settings, overlay)
+    return merged, profile_name
+
+
+def _chart_metadata(chart: Chart) -> dict[str, Any]:
+    if isinstance(chart.data, Mapping):
+        raw = chart.data.get("metadata")
+        if isinstance(raw, Mapping):
+            return dict(raw)
+    return {}
+
+
+class ChartCreate(BaseModel):
+    """Payload for creating a persisted chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(..., description="Display name for the chart subject.")
+    kind: str = Field(default="natal", description="Chart classification, e.g. natal or transit.")
+    dt_utc: datetime = Field(..., description="Reference datetime in UTC.")
+    tz: str = Field(..., description="Original timezone identifier (IANA).")
+    lat: float = Field(..., description="Latitude in decimal degrees.")
+    lon: float = Field(..., description="Longitude in decimal degrees.")
+    location: str | None = Field(default=None, description="Human-readable location label.")
+    gender: str | None = Field(default=None, description="Optional gender marker.")
+    tags: str | None = Field(default=None, description="Comma-separated tag list.")
+    notes: str | None = Field(default=None, description="Free-form notes stored with the chart.")
+    profile: str | None = Field(default=None, description="Profile overlay to apply before computation.")
+    narrative_profile: str | None = Field(default=None, description="Narrative profile or mix name.")
+
+
+class ChartUpdate(BaseModel):
+    """Metadata updates for an existing chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = Field(default=None)
+    tags: str | None = Field(default=None)
+    notes: str | None = Field(default=None)
+    gender: str | None = Field(default=None)
+    location: str | None = Field(default=None)
+    tz: str | None = Field(default=None)
+    narrative_profile: str | None = Field(default=None)
+
+
+class ChartDerive(BaseModel):
+    """Input payload when deriving a chart from an existing record."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str = Field(default="transit", description="Derived chart type, e.g. transit or solar_return.")
+    dt_utc: datetime | None = Field(default=None, description="Target datetime for derivation in UTC.")
+    profile: str | None = Field(default=None, description="Optional profile override for derivation.")
+
+
+class ChartImport(BaseModel):
+    """Payload used when importing a chart from an export bundle."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chart: Mapping[str, Any]
+
+
+class ChartResponse(BaseModel):
+    """API representation of a persisted chart."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: int
+    chart_key: str
+    name: str | None
+    kind: str | None
+    dt_utc: datetime | None
+    tz: str | None
+    lat: float | None
+    lon: float | None
+    location: str | None
+    gender: str | None
+    tags: str | None
+    notes: str | None
+    profile_applied: str | None
+    narrative_profile: str | None
+    bodies: dict[str, Any] = Field(default_factory=dict)
+    houses: dict[str, Any] = Field(default_factory=dict)
+    aspects: list[dict[str, Any]] = Field(default_factory=list)
+    patterns: list[dict[str, Any]] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    settings_snapshot: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime
+    updated_at: datetime
+
+
+def _chart_to_response(chart: Chart) -> ChartResponse:
+    metadata = _chart_metadata(chart)
+    return ChartResponse(
+        id=chart.id,
+        chart_key=str(chart.chart_key),
+        name=chart.name,
+        kind=str(chart.kind) if chart.kind else None,
+        dt_utc=_ensure_utc(chart.dt_utc),
+        tz=chart.timezone,
+        lat=float(chart.lat) if chart.lat is not None else None,
+        lon=float(chart.lon) if chart.lon is not None else None,
+        location=chart.location_name,
+        gender=chart.gender,
+        tags=chart.tags,
+        notes=chart.memo,
+        profile_applied=chart.profile_key,
+        narrative_profile=chart.narrative_profile,
+        bodies=dict(chart.bodies or {}),
+        houses=dict(chart.houses or {}),
+        aspects=list(chart.aspects or []),
+        patterns=list(chart.patterns or []),
+        metadata=metadata,
+        settings_snapshot=dict(chart.settings_snapshot or {}),
+        created_at=_ensure_utc(chart.created_at),
+        updated_at=_ensure_utc(chart.updated_at),
+    )
+
+
+def _parse_import_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return _ensure_utc(value)
+    if isinstance(value, str):
+        try:
+            dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError as exc:  # pragma: no cover - defensive guard
+            raise HTTPException(status_code=400, detail=f"Invalid datetime value: {value}") from exc
+        return _ensure_utc(dt)
+    raise HTTPException(status_code=400, detail="dt_utc must be an ISO timestamp")
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"Unable to coerce numeric value: {value}") from exc
+
+
+def _ensure_mapping(value: Any) -> dict[str, Any]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _ensure_list(value: Any) -> list[Any]:
+    if isinstance(value, list):
+        return [dict(item) if isinstance(item, Mapping) else item for item in value]
+    if isinstance(value, tuple):
+        return [dict(item) if isinstance(item, Mapping) else item for item in value]
+    return []
+
+
+@router.post("", response_model=ChartResponse, status_code=201)
+def create_chart(payload: ChartCreate) -> ChartResponse:
+    base_settings = load_settings()
+    settings, profile_key = _apply_profile(base_settings, payload.profile)
+    moment = _ensure_utc(payload.dt_utc)
+    if moment is None:
+        raise HTTPException(status_code=400, detail="dt_utc is required")
+    result = build_payload(moment, float(payload.lat), float(payload.lon), settings)
+    metadata = dict(result.get("metadata") or {})
+    with session_scope() as db:
+        chart = Chart(
+            name=payload.name,
+            kind=payload.kind,
+            dt_utc=moment,
+            lat=float(payload.lat),
+            lon=float(payload.lon),
+            timezone=payload.tz,
+            location_name=payload.location,
+            gender=payload.gender,
+            tags=payload.tags,
+            memo=payload.notes,
+            profile_key=profile_key,
+            narrative_profile=payload.narrative_profile,
+            settings_snapshot=settings.model_dump(),
+            bodies=result["bodies"],
+            houses=result["houses"],
+            aspects=result["aspects"],
+            patterns=result["patterns"],
+            data={"metadata": metadata},
+        )
+        db.add(chart)
+        db.flush()
+        db.refresh(chart)
+        response = _chart_to_response(chart)
+    return response
+
+
+@router.get("", response_model=list[ChartResponse])
+def list_charts(
+    kind: str | None = Query(default=None, description="Filter by chart kind."),
+    q: str | None = Query(default=None, description="Case-insensitive name search."),
+    limit: int = Query(default=200, ge=1, le=500),
+) -> list[ChartResponse]:
+    stmt = select(Chart)
+    if kind:
+        stmt = stmt.where(Chart.kind == kind)
+    if q:
+        stmt = stmt.where(Chart.name.ilike(f"%{q}%"))
+    stmt = stmt.order_by(Chart.created_at.desc()).limit(limit)
+    with session_scope() as db:
+        records = db.execute(stmt).scalars().all()
+    return [_chart_to_response(chart) for chart in records]
+
+
+@router.get("/{chart_id}", response_model=ChartResponse)
+def get_chart(chart_id: int) -> ChartResponse:
+    with session_scope() as db:
+        chart = db.get(Chart, chart_id)
+        if chart is None:
+            raise HTTPException(status_code=404, detail="Chart not found")
+        return _chart_to_response(chart)
+
+
+@router.put("/{chart_id}", response_model=ChartResponse)
+def update_chart(chart_id: int, payload: ChartUpdate) -> ChartResponse:
+    with session_scope() as db:
+        chart = db.get(Chart, chart_id)
+        if chart is None:
+            raise HTTPException(status_code=404, detail="Chart not found")
+        updates = payload.model_dump(exclude_unset=True)
+        if "notes" in updates:
+            chart.memo = updates.pop("notes")
+        if "location" in updates:
+            chart.location_name = updates.pop("location")
+        if "tz" in updates:
+            chart.timezone = updates.pop("tz")
+        if "narrative_profile" in updates:
+            chart.narrative_profile = updates.pop("narrative_profile")
+        for field, value in updates.items():
+            setattr(chart, field, value)
+        db.flush()
+        db.refresh(chart)
+        return _chart_to_response(chart)
+
+
+@router.delete("/{chart_id}", status_code=204)
+def delete_chart(chart_id: int) -> None:
+    with session_scope() as db:
+        chart = db.get(Chart, chart_id)
+        if chart is None:
+            raise HTTPException(status_code=404, detail="Chart not found")
+        db.delete(chart)
+
+
+@router.post("/{chart_id}/derive", response_model=ChartResponse)
+def derive_chart(chart_id: int, payload: ChartDerive) -> ChartResponse:
+    with session_scope() as db:
+        base_chart = db.get(Chart, chart_id)
+        if base_chart is None:
+            raise HTTPException(status_code=404, detail="Chart not found")
+        try:
+            base_settings = Settings.model_validate(base_chart.settings_snapshot or {})
+        except ValidationError:
+            base_settings = load_settings()
+        settings = base_settings
+        profile_key = base_chart.profile_key
+        if payload.profile:
+            settings, profile_key = _apply_profile(base_settings, payload.profile)
+        dt_value = payload.dt_utc or base_chart.dt_utc
+        dt_utc = _ensure_utc(dt_value)
+        if dt_utc is None:
+            raise HTTPException(status_code=400, detail="Derivation requires a datetime")
+        if base_chart.lat is None or base_chart.lon is None:
+            raise HTTPException(status_code=400, detail="Base chart is missing coordinates")
+        result = build_payload(dt_utc, float(base_chart.lat), float(base_chart.lon), settings)
+        metadata = dict(result.get("metadata") or {})
+        name_prefix = base_chart.name or base_chart.chart_key
+        derived_name = f"{name_prefix} — {payload.kind}"
+        derived = Chart(
+            name=derived_name,
+            kind=payload.kind,
+            dt_utc=dt_utc,
+            lat=base_chart.lat,
+            lon=base_chart.lon,
+            timezone=base_chart.timezone,
+            location_name=base_chart.location_name,
+            gender=base_chart.gender,
+            tags=base_chart.tags,
+            memo=base_chart.memo,
+            profile_key=profile_key,
+            narrative_profile=base_chart.narrative_profile,
+            settings_snapshot=settings.model_dump(),
+            bodies=result["bodies"],
+            houses=result["houses"],
+            aspects=result["aspects"],
+            patterns=result["patterns"],
+            data={"metadata": metadata, "source_chart_id": chart_id},
+        )
+        db.add(derived)
+        db.flush()
+        db.refresh(derived)
+        return _chart_to_response(derived)
+
+
+@router.get("/{chart_id}/export", response_model=ChartResponse)
+def export_chart(chart_id: int) -> ChartResponse:
+    with session_scope() as db:
+        chart = db.get(Chart, chart_id)
+        if chart is None:
+            raise HTTPException(status_code=404, detail="Chart not found")
+        return _chart_to_response(chart)
+
+
+@router.post("/import", response_model=ChartResponse)
+def import_chart(payload: ChartImport) -> ChartResponse:
+    data = dict(payload.chart)
+    dt_utc = _parse_import_datetime(data.get("dt_utc"))
+    chart_key = data.get("chart_key")
+    lat = _coerce_float(data.get("lat"))
+    lon = _coerce_float(data.get("lon"))
+    profile_key = data.get("profile_applied") or data.get("profile_key") or "default"
+    bodies = _ensure_mapping(data.get("bodies"))
+    houses = _ensure_mapping(data.get("houses"))
+    aspects = _ensure_list(data.get("aspects"))
+    patterns = _ensure_list(data.get("patterns"))
+    settings_snapshot = _ensure_mapping(data.get("settings_snapshot"))
+    metadata = _ensure_mapping(data.get("metadata"))
+    with session_scope() as db:
+        existing = None
+        if chart_key:
+            existing = db.execute(select(Chart).where(Chart.chart_key == str(chart_key))).scalar_one_or_none()
+        if existing is None:
+            chart = Chart(
+                chart_key=str(chart_key) if chart_key is not None else None,
+                name=data.get("name"),
+                kind=data.get("kind"),
+                dt_utc=dt_utc,
+                lat=lat,
+                lon=lon,
+                timezone=data.get("tz") or data.get("timezone"),
+                location_name=data.get("location"),
+                gender=data.get("gender"),
+                tags=data.get("tags"),
+                memo=data.get("notes"),
+                profile_key=profile_key,
+                narrative_profile=data.get("narrative_profile"),
+                settings_snapshot=settings_snapshot,
+                bodies=bodies,
+                houses=houses,
+                aspects=aspects,
+                patterns=patterns,
+                data={"metadata": metadata},
+            )
+            db.add(chart)
+            db.flush()
+            db.refresh(chart)
+        else:
+            existing.name = data.get("name")
+            existing.kind = data.get("kind")
+            existing.dt_utc = dt_utc
+            existing.lat = lat
+            existing.lon = lon
+            existing.timezone = data.get("tz") or data.get("timezone")
+            existing.location_name = data.get("location")
+            existing.gender = data.get("gender")
+            existing.tags = data.get("tags")
+            existing.memo = data.get("notes")
+            existing.profile_key = profile_key
+            existing.narrative_profile = data.get("narrative_profile")
+            existing.settings_snapshot = settings_snapshot
+            existing.bodies = bodies
+            existing.houses = houses
+            existing.aspects = aspects
+            existing.patterns = patterns
+            existing.data = {"metadata": metadata}
+            db.flush()
+            db.refresh(existing)
+            chart = existing
+        return _chart_to_response(chart)
 
 
 @router.get("/{chart_id}/pdf")
@@ -30,10 +434,8 @@ def chart_pdf(chart_id: int) -> Response:
         if chart.dt_utc is None or chart.lat is None or chart.lon is None:
             raise HTTPException(status_code=400, detail="Chart is missing birth data")
         moment = chart.dt_utc
-        # SQLite often round-trips timestamps without timezone info. Treat stored
-        # UTC datetimes as UTC explicitly so Swiss ephemeris adapters accept them.
         if moment.tzinfo is None or moment.tzinfo.utcoffset(moment) is None:
-            moment = moment.replace(tzinfo=timezone.utc)
+            moment = moment.replace(tzinfo=UTC)
 
         location = ChartLocation(latitude=float(chart.lat), longitude=float(chart.lon))
         natal = compute_natal_chart(moment, location)
@@ -49,9 +451,7 @@ def chart_pdf(chart_id: int) -> Response:
         generated_at=datetime.now(timezone.utc),
     )
     pdf_bytes = render_chart_pdf(context)
-    headers = {
-        "Content-Disposition": f'attachment; filename="chart_{chart_id}.pdf"'
-    }
+    headers = {"Content-Disposition": f'attachment; filename="chart_{chart_id}.pdf"'}
     return Response(content=pdf_bytes, media_type="application/pdf", headers=headers)
 
 

--- a/app/routers/data_io.py
+++ b/app/routers/data_io.py
@@ -25,6 +25,7 @@ _VALID_SCOPES = {"charts", "settings"}
 def _chart_to_payload(chart: Chart) -> Mapping[str, object | None]:
     return {
         "id": chart.id,
+        "name": chart.name,
         "chart_key": chart.chart_key,
         "profile_key": chart.profile_key,
         "kind": chart.kind,
@@ -34,6 +35,15 @@ def _chart_to_payload(chart: Chart) -> Mapping[str, object | None]:
         "location_name": chart.location_name,
         "timezone": chart.timezone,
         "source": chart.source,
+        "tags": chart.tags,
+        "notes": chart.memo,
+        "gender": chart.gender,
+        "narrative_profile": chart.narrative_profile,
+        "settings_snapshot": chart.settings_snapshot,
+        "bodies": chart.bodies,
+        "houses": chart.houses,
+        "aspects": chart.aspects,
+        "patterns": chart.patterns,
         "module": chart.module,
         "submodule": chart.submodule,
         "channel": chart.channel,
@@ -49,6 +59,20 @@ def _parse_datetime(value: str | None) -> datetime | None:
         return datetime.fromisoformat(value.replace("Z", "+00:00"))
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=f"Invalid datetime value: {value}") from exc
+
+
+def _as_mapping(value: object) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return dict(value)
+    return {}
+
+
+def _as_list(value: object) -> list[object]:
+    if isinstance(value, list):
+        return list(value)
+    if isinstance(value, tuple):
+        return list(value)
+    return []
 
 
 def _normalize_chart_payload(record: Mapping[str, object]) -> dict[str, object | None]:
@@ -69,6 +93,11 @@ def _normalize_chart_payload(record: Mapping[str, object]) -> dict[str, object |
     payload["profile_key"] = str(profile_key) if profile_key is not None else "default"
     kind = record.get("kind")
     payload["kind"] = str(kind) if kind is not None else None
+    payload["name"] = record.get("name")
+    payload["tags"] = record.get("tags")
+    payload["memo"] = record.get("notes") if record.get("notes") is not None else record.get("memo")
+    payload["gender"] = record.get("gender")
+    payload["narrative_profile"] = record.get("narrative_profile")
     payload["lat"] = _as_float(record.get("lat"), "lat")
     payload["lon"] = _as_float(record.get("lon"), "lon")
     payload["location_name"] = record.get("location_name")
@@ -78,7 +107,12 @@ def _normalize_chart_payload(record: Mapping[str, object]) -> dict[str, object |
         value = record.get(scope_field)
         payload[scope_field] = str(value) if value is not None else None
     data = record.get("data")
-    payload["data"] = dict(data) if isinstance(data, Mapping) else {}
+    payload["data"] = _as_mapping(data)
+    payload["settings_snapshot"] = _as_mapping(record.get("settings_snapshot"))
+    payload["bodies"] = _as_mapping(record.get("bodies"))
+    payload["houses"] = _as_mapping(record.get("houses"))
+    payload["aspects"] = _as_list(record.get("aspects"))
+    payload["patterns"] = _as_list(record.get("patterns"))
     dt_raw = record.get("dt_utc")
     payload["dt_utc"] = _parse_datetime(dt_raw) if isinstance(dt_raw, str) else None
     return payload

--- a/astroengine/analysis/__init__.py
+++ b/astroengine/analysis/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .dignities import condition_report, score_accidental, score_essential
 from .midpoints import compute_midpoints, get_midpoint_settings, midpoint_longitude
+from .declinations import DeclinationAspect, declination_aspects, get_declinations
 from .returns import aries_ingress_year, lunar_return_datetimes, solar_return_datetime
 from .timeline import (
     VoidOfCourseEvent,
@@ -17,6 +18,9 @@ __all__ = [
     "compute_midpoints",
     "get_midpoint_settings",
     "midpoint_longitude",
+    "DeclinationAspect",
+    "declination_aspects",
+    "get_declinations",
     "condition_report",
     "score_accidental",
     "score_essential",

--- a/astroengine/compute/__init__.py
+++ b/astroengine/compute/__init__.py
@@ -1,0 +1,5 @@
+"""Computation helpers for persisting chart results."""
+
+from .save import build_payload
+
+__all__ = ["build_payload"]

--- a/astroengine/compute/save.py
+++ b/astroengine/compute/save.py
@@ -1,0 +1,92 @@
+"""Helpers for computing and serialising chart payloads."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict
+
+from astroengine.chart.config import ChartConfig
+from astroengine.chart.natal import ChartLocation, compute_natal_chart
+from astroengine.config.settings import Settings
+
+
+def _chart_config_from_settings(settings: Settings) -> ChartConfig:
+    zodiac = settings.zodiac.type
+    ayanamsha = settings.zodiac.ayanamsa if zodiac == "sidereal" else None
+    house_system = settings.houses.system
+    return ChartConfig(
+        zodiac=zodiac,
+        ayanamsha=ayanamsha,
+        house_system=house_system,
+    )
+
+
+def _serialize_bodies(chart) -> dict[str, Any]:
+    payload: dict[str, Any] = {}
+    for name, position in chart.positions.items():
+        payload[name] = {
+            "longitude": float(position.longitude),
+            "latitude": float(position.latitude),
+            "distance_au": float(position.distance_au),
+            "speed_longitude": float(position.speed_longitude),
+            "speed_latitude": float(position.speed_latitude),
+            "retrograde": bool(position.speed_longitude < 0.0),
+            "declination": float(position.declination),
+        }
+    return payload
+
+
+def _serialize_houses(chart) -> dict[str, Any]:
+    houses_dict = chart.houses.to_dict()
+    cusps = houses_dict.get("cusps")
+    if isinstance(cusps, tuple):
+        houses_dict["cusps"] = list(cusps)
+    return houses_dict
+
+
+def _serialize_aspects(chart) -> list[dict[str, Any]]:
+    aspects: list[dict[str, Any]] = []
+    for aspect in chart.aspects:
+        aspects.append(
+            {
+                "body_a": aspect.body_a,
+                "body_b": aspect.body_b,
+                "angle": int(aspect.angle),
+                "orb": float(aspect.orb),
+                "separation": float(aspect.separation),
+            }
+        )
+    return aspects
+
+
+def build_payload(
+    dt_utc: datetime,
+    lat: float,
+    lon: float,
+    settings: Settings,
+) -> Dict[str, Any]:
+    """Return serialisable chart payloads ready for persistence."""
+
+    chart_config = _chart_config_from_settings(settings)
+    chart = compute_natal_chart(
+        dt_utc,
+        ChartLocation(latitude=float(lat), longitude=float(lon)),
+        config=chart_config,
+    )
+
+    bodies = _serialize_bodies(chart)
+    houses = _serialize_houses(chart)
+    aspects = _serialize_aspects(chart)
+    patterns: list[dict[str, Any]] = []
+
+    metadata = {}
+    if chart.metadata:
+        metadata = dict(chart.metadata)
+
+    return {
+        "bodies": bodies,
+        "houses": houses,
+        "aspects": aspects,
+        "patterns": patterns,
+        "metadata": metadata,
+    }

--- a/migrations/versions/20241130_0006_chart_library.py
+++ b/migrations/versions/20241130_0006_chart_library.py
@@ -1,0 +1,72 @@
+"""Add chart library metadata columns."""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20241130_0006"
+down_revision = "20241122_0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("charts", sa.Column("name", sa.String(length=120), nullable=True))
+    op.add_column("charts", sa.Column("tags", sa.String(length=240), nullable=True))
+    op.add_column("charts", sa.Column("memo", sa.Text(), nullable=True))
+    op.add_column("charts", sa.Column("gender", sa.String(length=32), nullable=True))
+    op.add_column(
+        "charts",
+        sa.Column(
+            "settings_snapshot", sa.JSON(), nullable=False, server_default=sa.text("'{}'"),
+        ),
+    )
+    op.add_column(
+        "charts",
+        sa.Column("narrative_profile", sa.String(length=80), nullable=True),
+    )
+    op.add_column(
+        "charts",
+        sa.Column("bodies", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.add_column(
+        "charts",
+        sa.Column("houses", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+    )
+    op.add_column(
+        "charts",
+        sa.Column("aspects", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.add_column(
+        "charts",
+        sa.Column("patterns", sa.JSON(), nullable=False, server_default=sa.text("'[]'")),
+    )
+    op.create_index("ix_charts_kind_name", "charts", ["kind", "name"])
+
+    # Drop server defaults to avoid future inserts inheriting stringified JSON.
+    op.alter_column("charts", "settings_snapshot", server_default=None)
+    op.alter_column("charts", "bodies", server_default=None)
+    op.alter_column("charts", "houses", server_default=None)
+    op.alter_column("charts", "aspects", server_default=None)
+    op.alter_column("charts", "patterns", server_default=None)
+
+
+def downgrade() -> None:
+    op.alter_column("charts", "patterns", server_default=sa.text("'[]'"))
+    op.alter_column("charts", "aspects", server_default=sa.text("'[]'"))
+    op.alter_column("charts", "houses", server_default=sa.text("'{}'"))
+    op.alter_column("charts", "bodies", server_default=sa.text("'{}'"))
+    op.alter_column("charts", "settings_snapshot", server_default=sa.text("'{}'"))
+    op.drop_index("ix_charts_kind_name", table_name="charts")
+    op.drop_column("charts", "patterns")
+    op.drop_column("charts", "aspects")
+    op.drop_column("charts", "houses")
+    op.drop_column("charts", "bodies")
+    op.drop_column("charts", "narrative_profile")
+    op.drop_column("charts", "settings_snapshot")
+    op.drop_column("charts", "gender")
+    op.drop_column("charts", "memo")
+    op.drop_column("charts", "tags")
+    op.drop_column("charts", "name")

--- a/ui/streamlit/chart_library.py
+++ b/ui/streamlit/chart_library.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import requests
+import streamlit as st
+
+
+API_BASE_URL = os.getenv("API_BASE_URL", "http://127.0.0.1:8000").rstrip("/")
+
+
+def _to_utc_iso(moment: datetime, tz_name: str) -> str:
+    try:
+        tzinfo = ZoneInfo(tz_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ValueError(f"Unknown timezone '{tz_name}'") from exc
+    localized = moment.replace(tzinfo=tzinfo)
+    utc_value = localized.astimezone(timezone.utc)
+    return utc_value.isoformat().replace("+00:00", "Z")
+
+
+def _api_get(path: str, *, params: dict | None = None, timeout: int = 20) -> dict | list:
+    url = f"{API_BASE_URL}{path}"
+    response = requests.get(url, params=params, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(response.text)
+    return response.json()
+
+
+def _api_post(path: str, payload: dict, *, timeout: int = 30) -> dict:
+    url = f"{API_BASE_URL}{path}"
+    response = requests.post(url, json=payload, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(response.text)
+    return response.json()
+
+
+def _api_put(path: str, payload: dict, *, timeout: int = 30) -> dict:
+    url = f"{API_BASE_URL}{path}"
+    response = requests.put(url, json=payload, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(response.text)
+    return response.json()
+
+
+def _api_delete(path: str, *, timeout: int = 30) -> None:
+    url = f"{API_BASE_URL}{path}"
+    response = requests.delete(url, timeout=timeout)
+    if not response.ok:
+        raise RuntimeError(response.text)
+
+
+st.set_page_config(page_title="AstroEngine — Chart Library", layout="wide")
+st.title("🗂️ Chart Library")
+
+
+with st.expander("Create new chart", expanded=True):
+    with st.form("create-chart-form"):
+        name = st.text_input("Name", placeholder="Jane Doe")
+        col1, col2, col3 = st.columns(3)
+        with col1:
+            dt_value = st.datetime_input("Date & time (local)", value=datetime.now())
+            tz_name = st.text_input("Timezone (IANA)", value="UTC")
+        with col2:
+            lat = st.number_input("Latitude", value=0.0, format="%.6f")
+            lon = st.number_input("Longitude", value=0.0, format="%.6f")
+        with col3:
+            location = st.text_input("Location label", placeholder="City, Country")
+            gender = st.text_input("Gender (optional)")
+        tags = st.text_input("Tags", placeholder="client, vip")
+        notes = st.text_area("Notes")
+        profile = st.text_input("Profile to apply (optional)", placeholder="modern_western")
+        narrative_profile = st.text_input("Narrative profile (optional)")
+        submitted = st.form_submit_button("Save & compute natal", type="primary", disabled=not name)
+    if submitted:
+        try:
+            dt_iso = _to_utc_iso(dt_value, tz_name)
+            payload = {
+                "name": name,
+                "kind": "natal",
+                "dt_utc": dt_iso,
+                "tz": tz_name,
+                "lat": float(lat),
+                "lon": float(lon),
+                "location": location or None,
+                "gender": gender or None,
+                "tags": tags or None,
+                "notes": notes or None,
+                "profile": profile or None,
+                "narrative_profile": narrative_profile or None,
+            }
+            _api_post("/v1/charts", payload)
+        except Exception as exc:
+            st.error(str(exc))
+        else:
+            st.success("Chart saved.")
+            st.experimental_rerun()
+
+st.divider()
+
+
+col_list, col_detail = st.columns([2, 3])
+
+with col_list:
+    st.subheader("Stored charts")
+    search = st.text_input("Search name")
+    kind_filter = st.selectbox(
+        "Kind",
+        ["any", "natal", "transit", "progressed", "solar_return", "lunar_return", "custom"],
+        index=0,
+    )
+    query_params: dict[str, str] = {}
+    if kind_filter != "any":
+        query_params["kind"] = kind_filter
+    if search:
+        query_params["q"] = search
+    try:
+        items = _api_get("/v1/charts", params=query_params)
+        if not isinstance(items, list):  # pragma: no cover - defensive
+            raise RuntimeError("Unexpected response shape from /v1/charts")
+    except Exception as exc:
+        st.error(str(exc))
+        items = []
+    label_by_id: dict[str, int] = {}
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        label = f"{entry.get('name') or entry.get('chart_key')} — {entry.get('kind')}"
+        label += f" ({entry.get('dt_utc')})"
+        label_by_id[label] = entry.get("id")
+    selection = st.selectbox("Select chart", ["(none)"] + list(label_by_id.keys()))
+    selected_id = label_by_id.get(selection)
+
+with col_detail:
+    st.subheader("Chart details")
+    if not selected_id:
+        st.info("Select a chart from the list to view details.")
+    else:
+        try:
+            detail = _api_get(f"/v1/charts/{selected_id}")
+            if not isinstance(detail, dict):  # pragma: no cover - defensive
+                raise RuntimeError("Unexpected response payload from chart detail")
+        except Exception as exc:
+            st.error(str(exc))
+            detail = None
+
+        if detail:
+            meta_cols = st.columns(3)
+            meta_cols[0].metric("Kind", detail.get("kind", "—"))
+            meta_cols[1].metric("Profile", detail.get("profile_applied", "—"))
+            meta_cols[2].metric("Narrative", detail.get("narrative_profile", "—"))
+
+            st.markdown("### Metadata")
+            st.json({
+                "name": detail.get("name"),
+                "dt_utc": detail.get("dt_utc"),
+                "tz": detail.get("tz"),
+                "location": detail.get("location"),
+                "lat": detail.get("lat"),
+                "lon": detail.get("lon"),
+                "tags": detail.get("tags"),
+                "gender": detail.get("gender"),
+            })
+
+            with st.form(f"update-chart-{selected_id}"):
+                st.write("Update metadata")
+                name_edit = st.text_input("Name", value=detail.get("name") or "")
+                tags_edit = st.text_input("Tags", value=detail.get("tags") or "")
+                notes_edit = st.text_area("Notes", value=detail.get("notes") or "")
+                gender_edit = st.text_input("Gender", value=detail.get("gender") or "")
+                location_edit = st.text_input("Location", value=detail.get("location") or "")
+                tz_edit = st.text_input("Timezone", value=detail.get("tz") or "")
+                narrative_edit = st.text_input("Narrative profile", value=detail.get("narrative_profile") or "")
+                submitted_update = st.form_submit_button("Save changes")
+            if submitted_update:
+                payload = {
+                    "name": name_edit or None,
+                    "tags": tags_edit or None,
+                    "notes": notes_edit or None,
+                    "gender": gender_edit or None,
+                    "location": location_edit or None,
+                    "tz": tz_edit or None,
+                    "narrative_profile": narrative_edit or None,
+                }
+                try:
+                    _api_put(f"/v1/charts/{selected_id}", payload)
+                except Exception as exc:
+                    st.error(str(exc))
+                else:
+                    st.success("Chart updated.")
+                    st.experimental_rerun()
+
+            st.markdown("### Derive new chart")
+            with st.form(f"derive-chart-{selected_id}"):
+                derive_kind = st.selectbox(
+                    "Derivation",
+                    ["transit", "progressed", "solar_return", "lunar_return", "custom"],
+                )
+                derive_dt = st.datetime_input(
+                    "Target datetime (UTC)", value=datetime.now(timezone.utc)
+                )
+                derive_profile = st.text_input(
+                    "Profile override (optional)", key=f"derive-profile-{selected_id}"
+                )
+                submitted_derive = st.form_submit_button("Run derivation", type="primary")
+            if submitted_derive:
+                payload = {
+                    "kind": derive_kind,
+                    "dt_utc": derive_dt.replace(tzinfo=timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "profile": derive_profile or None,
+                }
+                try:
+                    _api_post(f"/v1/charts/{selected_id}/derive", payload)
+                except Exception as exc:
+                    st.error(str(exc))
+                else:
+                    st.success("Derived chart saved.")
+                    st.experimental_rerun()
+
+            st.markdown("### Computed data")
+            tabs = st.tabs(["Bodies", "Houses", "Aspects", "Patterns", "Settings"])
+            with tabs[0]:
+                st.json(detail.get("bodies"))
+            with tabs[1]:
+                st.json(detail.get("houses"))
+            with tabs[2]:
+                st.json(detail.get("aspects"))
+            with tabs[3]:
+                st.json(detail.get("patterns"))
+            with tabs[4]:
+                st.json(detail.get("settings_snapshot"))
+
+            export_payload = json.dumps(detail, indent=2, ensure_ascii=False)
+            st.download_button(
+                "Download JSON export",
+                data=export_payload.encode("utf-8"),
+                file_name=f"chart_{selected_id}.json",
+                mime="application/json",
+            )
+
+            if st.button("Delete chart", type="secondary"):
+                try:
+                    _api_delete(f"/v1/charts/{selected_id}")
+                except Exception as exc:
+                    st.error(str(exc))
+                else:
+                    st.success("Chart deleted.")
+                    st.experimental_rerun()
+
+st.caption(
+    "Charts are persisted with their computed placements and the settings snapshot used for calculation."
+)

--- a/ui/streamlit/main_portal.py
+++ b/ui/streamlit/main_portal.py
@@ -35,6 +35,7 @@ st.markdown(
 )
 
 st.title("🌌 AstroEngine — Main Portal")
+st.page_link("ui/streamlit/chart_library.py", label="Open Chart Library →")
 
 
 def _api_base() -> str:


### PR DESCRIPTION
## Summary
- extend the `Chart` persistence model and migrations to retain metadata, computation payloads, and profile snapshots
- add chart CRUD, derivation, and import/export endpoints powered by a reusable computation helper
- surface a Streamlit chart library page and navigation link for managing stored charts

## Testing
- pytest *(fails: environment lacks optional ephemeris and supporting dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fa1606148324868a424bee1f5a5c