### PR TITLE
Add doctor diagnostics endpoint and UI

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ from app.routers import (
     declinations_router,
     electional_router,
     events_router,
+    doctor_router,
     health_router,
     interpret_router,
     lots_router,
@@ -51,6 +52,7 @@ app.include_router(aspects_router)
 app.include_router(declinations_router)
 app.include_router(electional_router)
 app.include_router(events_router)
+app.include_router(doctor_router)
 app.include_router(transits_router)
 app.include_router(policies_router)
 app.include_router(lots_router)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "events_router",
 
     "declinations_router",
+    "doctor_router",
 
     "policies_router",
     "lots_router",
@@ -62,6 +63,10 @@ def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampolin
         from .health import router as health_router
 
         return health_router
+    if name == "doctor_router":
+        from .doctor import router as doctor_router
+
+        return doctor_router
     if name == "interpret_router":
         from .interpret import router as interpret_router
 

--- a/app/routers/doctor.py
+++ b/app/routers/doctor.py
@@ -1,0 +1,31 @@
+"""System doctor API endpoint returning runtime diagnostics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Request
+
+from astroengine.config import Settings
+from astroengine.observability import run_system_doctor
+
+router = APIRouter(prefix="/v1/doctor", tags=["system"])
+
+
+def _extract_settings(request: Request) -> Settings | None:
+    settings = getattr(request.app.state, "settings", None)
+    return settings if isinstance(settings, Settings) else None
+
+
+@router.get(
+    "",
+    summary="Run system doctor",
+    description="Return Swiss ephemeris, database, migration, and cache diagnostics.",
+)
+async def system_doctor(request: Request) -> dict[str, Any]:
+    """Return the aggregated diagnostics report."""
+
+    return run_system_doctor(settings=_extract_settings(request))
+
+
+__all__ = ["router"]

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Dict, List, Literal, Optional
 
 import yaml
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from astroengine.plugins.registry import apply_plugin_settings
 

--- a/astroengine/observability/__init__.py
+++ b/astroengine/observability/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .doctor import DoctorCheck, run_system_doctor
 from .metrics import (
     EPHEMERIS_CACHE_COMPUTE_DURATION,
     EPHEMERIS_CACHE_HITS,
@@ -14,4 +15,6 @@ __all__ = [
     "EPHEMERIS_CACHE_MISSES",
     "EPHEMERIS_CACHE_COMPUTE_DURATION",
     "ensure_metrics_registered",
+    "DoctorCheck",
+    "run_system_doctor",
 ]

--- a/astroengine/observability/doctor.py
+++ b/astroengine/observability/doctor.py
@@ -1,0 +1,291 @@
+"""Runtime diagnostics powering the system doctor endpoints."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib import import_module
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping
+
+import sqlite3
+from astroengine.config import Settings, load_settings
+from astroengine.ephemeris.utils import get_se_ephe_path
+
+if TYPE_CHECKING:  # pragma: no cover - imported for typing only
+    from astroengine.ephemeris import SwissEphemerisAdapter as _SwissEphemerisAdapter
+
+Status = Literal["ok", "warn", "error"]
+
+
+@dataclass(frozen=True, slots=True)
+class DoctorCheck:
+    """Structure returned for each doctor subsystem check."""
+
+    name: str
+    status: Status
+    detail: str
+    data: Mapping[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+        }
+        if self.data is not None:
+            payload["data"] = dict(self.data)
+        return payload
+
+
+_STATUS_WEIGHT: dict[Status, int] = {"ok": 0, "warn": 1, "error": 2}
+
+
+def _merge_status(values: Iterable[Status]) -> Status:
+    """Return the most severe status present in ``values``."""
+
+    worst = "ok"
+    for value in values:
+        if _STATUS_WEIGHT.get(value, 2) > _STATUS_WEIGHT[worst]:
+            worst = value
+    return worst  # type: ignore[return-value]
+
+
+def _get_default_adapter() -> "_SwissEphemerisAdapter":
+    from astroengine.ephemeris import SwissEphemerisAdapter
+
+    return SwissEphemerisAdapter.get_default_adapter()
+
+
+def _check_swisseph(settings: Settings) -> DoctorCheck:
+    """Verify pyswisseph availability and ability to compute within configured caps."""
+
+    try:
+        swe = import_module("swisseph")
+    except ModuleNotFoundError as exc:
+        return DoctorCheck(
+            name="swiss_ephemeris",
+            status="error",
+            detail="pyswisseph is not installed",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        return DoctorCheck(
+            name="swiss_ephemeris",
+            status="error",
+            detail="unable to import pyswisseph",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    version = getattr(swe, "__version__", "unknown")
+    ephe_path = get_se_ephe_path()
+    path_info: dict[str, Any] = {"configured": ephe_path}
+    path_status: Status = "ok"
+    if ephe_path:
+        candidate = Path(ephe_path).expanduser()
+        path_info["exists"] = candidate.exists()
+        path_info["resolved"] = str(candidate)
+        if not candidate.exists():
+            path_status = "warn"
+            path_info["warning"] = "configured ephemeris directory is missing"
+    else:
+        path_status = "warn"
+        path_info["warning"] = "SE_EPHE_PATH not set; falling back to built-in data"
+
+    samples: list[dict[str, Any]] = []
+    compute_status: Status = "ok"
+    try:
+        adapter = _get_default_adapter()
+    except Exception as exc:  # pragma: no cover - adapter should be available when swe loads
+        return DoctorCheck(
+            name="swiss_ephemeris",
+            status="error",
+            detail="SwissEphemerisAdapter unavailable",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    for year in {settings.swiss_caps.min_year, settings.swiss_caps.max_year}:
+        try:
+            jd = swe.julday(int(year), 1, 1, 0.0)
+            sample = adapter.body_position(jd, int(getattr(swe, "SUN")), "Sun")
+        except Exception as exc:  # pragma: no cover - runtime failure reported in detail
+            compute_status = "error"
+            samples.append(
+                {
+                    "year": int(year),
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+            )
+        else:
+            samples.append(
+                {
+                    "year": int(year),
+                    "julian_day_ut": float(jd),
+                    "longitude": float(sample.longitude),
+                    "declination": float(sample.declination),
+                }
+            )
+
+    status = _merge_status(("ok", path_status, compute_status))
+    detail = f"pyswisseph {version}"
+    if status != "ok":
+        detail += " (issues detected)"
+
+    return DoctorCheck(
+        name="swiss_ephemeris",
+        status=status,
+        detail=detail,
+        data={
+            "version": version,
+            "ephemeris_path": path_info,
+            "range_samples": samples,
+            "caps": {
+                "min_year": settings.swiss_caps.min_year,
+                "max_year": settings.swiss_caps.max_year,
+            },
+        },
+    )
+
+
+def _check_database() -> DoctorCheck:
+    """Execute a lightweight connectivity probe against the configured database."""
+
+    try:
+        from sqlalchemy import text
+
+        from app.db.session import engine, session_scope
+    except Exception as exc:  # pragma: no cover - missing optional dependency
+        return DoctorCheck(
+            name="database",
+            status="error",
+            detail="database stack unavailable",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    try:
+        with session_scope() as session:
+            session.execute(text("SELECT 1"))
+    except Exception as exc:
+        return DoctorCheck(
+            name="database",
+            status="error",
+            detail="database query failed",
+            data={"error": f"{type(exc).__name__}: {exc}"},
+        )
+
+    url = engine.url
+    detail = f"connected ({url.get_backend_name()}://)"
+    return DoctorCheck(
+        name="database",
+        status="ok",
+        detail=detail,
+        data={
+            "backend": url.get_backend_name(),
+            "database": url.database,
+        },
+    )
+
+
+def _check_migrations() -> DoctorCheck:
+    """Compare the applied alembic revision with the migration head."""
+
+    try:
+        from alembic.config import Config
+        from alembic.runtime.migration import MigrationContext
+        from alembic.script import ScriptDirectory
+        from app.db.session import engine
+    except Exception as exc:  # pragma: no cover - alembic optional in some envs
+        return DoctorCheck(
+            name="migrations",
+            status="warn",
+            detail="alembic stack unavailable",
+            data={"warning": f"{type(exc).__name__}: {exc}"},
+        )
+
+    config_path = Path(__file__).resolve().parents[2] / "alembic.ini"
+    script_location = Path(__file__).resolve().parents[2] / "migrations"
+    cfg = Config(str(config_path))
+    cfg.set_main_option("script_location", str(script_location))
+    cfg.set_main_option("sqlalchemy.url", engine.url.render_as_string(hide_password=False))
+    script = ScriptDirectory.from_config(cfg)
+    head_revision = script.get_current_head()
+
+    with engine.connect() as connection:
+        context = MigrationContext.configure(connection)
+        current_revision = context.get_current_revision()
+
+    if head_revision == current_revision:
+        status: Status = "ok"
+        detail = "database is at latest revision"
+    else:
+        status = "error"
+        detail = "database revision mismatch"
+
+    return DoctorCheck(
+        name="migrations",
+        status=status,
+        detail=detail,
+        data={
+            "head": head_revision,
+            "current": current_revision,
+        },
+    )
+
+
+def _check_cache() -> DoctorCheck:
+    """Ensure the Swiss ephemeris cache is reachable and writable."""
+
+    from astroengine.cache import positions_cache
+
+    cache_db = positions_cache.DB
+    cache_dir = cache_db.parent
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    info: dict[str, Any] = {
+        "path": str(cache_db),
+        "exists": cache_db.exists(),
+    }
+
+    try:
+        connection = sqlite3.connect(str(cache_db))
+        try:
+            cursor = connection.execute("PRAGMA integrity_check")
+            result = cursor.fetchone()
+            info["integrity"] = result[0] if result else None
+        finally:
+            connection.close()
+    except Exception as exc:
+        return DoctorCheck(
+            name="cache",
+            status="error",
+            detail="cache database unavailable",
+            data={"error": f"{type(exc).__name__}: {exc}", **info},
+        )
+
+    return DoctorCheck(
+        name="cache",
+        status="ok" if info.get("integrity") == "ok" else "warn",
+        detail="cache database healthy" if info.get("integrity") == "ok" else "cache integrity uncertain",
+        data=info,
+    )
+
+
+def run_system_doctor(settings: Settings | None = None) -> dict[str, Any]:
+    """Execute all doctor checks and return a serialisable payload."""
+
+    effective_settings = settings or load_settings()
+    checks = [
+        _check_swisseph(effective_settings),
+        _check_database(),
+        _check_migrations(),
+        _check_cache(),
+    ]
+    overall = _merge_status(check.status for check in checks)
+    return {
+        "status": overall,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "checks": {check.name: check.as_dict() for check in checks},
+    }
+
+
+__all__ = ["DoctorCheck", "run_system_doctor"]

--- a/docs/DIAGNOSTICS.md
+++ b/docs/DIAGNOSTICS.md
@@ -31,4 +31,9 @@ python -m astroengine.diagnostics --smoketest "2025-01-01T00:00:00Z"
 * Diagnostics never require network access and will not modify your system.
 * The report now surfaces the active ephemeris time-scale (`UTC→TT` by default) and whether the observer is geocentric or topocentric.
 
+## API & UI integrations
+
+* `GET /v1/doctor` returns the same Swiss ephemeris, database, migration, and cache checks as JSON for operators and monitoring agents.
+* The "🩺 System Doctor" Streamlit page (under `ui/streamlit/pages/13_System_Doctor.py`) visualises the live report for dashboard use.
+
 # >>> AUTO-GEN END: Diagnostics Guide v1.0

--- a/tests/observability/test_doctor.py
+++ b/tests/observability/test_doctor.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+from astroengine.observability import doctor
+
+
+class _DummySample:
+    def __init__(self, longitude: float, declination: float) -> None:
+        self.longitude = longitude
+        self.declination = declination
+
+
+class _DummyAdapter:
+    def body_position(self, jd_ut: float, _code: int, body_name: str | None = None) -> _DummySample:
+        return _DummySample(longitude=jd_ut % 360.0, declination=0.0)
+
+
+class _DummySwissAdapter:
+    @staticmethod
+    def get_default_adapter() -> _DummyAdapter:
+        return _DummyAdapter()
+
+
+def _fake_check(name: str) -> doctor.DoctorCheck:
+    return doctor.DoctorCheck(name=name, status="ok", detail="ok")
+
+
+def test_run_system_doctor_happy_path(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    swe_dir = tmp_path / "swisseph"
+    swe_dir.mkdir()
+
+    fake_swe = types.SimpleNamespace(
+        __version__="2.10",
+        SUN=0,
+        julday=lambda year, *_args: float(year),
+    )
+    monkeypatch.setitem(sys.modules, "swisseph", fake_swe)
+    monkeypatch.setattr(doctor, "_get_default_adapter", _DummySwissAdapter.get_default_adapter)
+    monkeypatch.setattr(doctor, "get_se_ephe_path", lambda: str(swe_dir))
+    monkeypatch.setattr(doctor, "_check_database", lambda: _fake_check("database"))
+    monkeypatch.setattr(doctor, "_check_migrations", lambda: _fake_check("migrations"))
+    monkeypatch.setattr(doctor, "_check_cache", lambda: _fake_check("cache"))
+
+    settings = types.SimpleNamespace(
+        swiss_caps=types.SimpleNamespace(min_year=1900, max_year=1901)
+    )
+
+    report = doctor.run_system_doctor(settings=settings)
+
+    assert report["status"] == "ok"
+    swiss = report["checks"]["swiss_ephemeris"]
+    samples = swiss["data"]["range_samples"]
+    years = {entry["year"] for entry in samples}
+    assert years == {1900, 1901}
+
+
+def test_run_system_doctor_missing_swisseph(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _raise_import(name: str) -> None:
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(doctor, "import_module", _raise_import)
+    monkeypatch.setattr(doctor, "_check_database", lambda: _fake_check("database"))
+    monkeypatch.setattr(doctor, "_check_migrations", lambda: _fake_check("migrations"))
+    monkeypatch.setattr(doctor, "_check_cache", lambda: _fake_check("cache"))
+
+    settings = types.SimpleNamespace(
+        swiss_caps=types.SimpleNamespace(min_year=1900, max_year=1901)
+    )
+
+    report = doctor.run_system_doctor(settings=settings)
+    assert report["status"] == "error"
+    assert report["checks"]["swiss_ephemeris"]["status"] == "error"

--- a/ui/streamlit/api.py
+++ b/ui/streamlit/api.py
@@ -67,6 +67,16 @@ class APIClient:
         except ValueError as exc:  # pragma: no cover - streamlit UI only
             raise RuntimeError("API returned a non-JSON response") from exc
 
+    def system_doctor(self) -> Dict[str, Any]:
+        """Return the diagnostics payload from the /v1/doctor endpoint."""
+
+        response = requests.get(f"{self.base}/v1/doctor", timeout=30)
+        response.raise_for_status()
+        data = response.json()
+        if not isinstance(data, dict):  # pragma: no cover - defensive
+            raise RuntimeError("Unexpected response payload from /v1/doctor")
+        return data
+
     # ---- Natals ------------------------------------------------------------
     def list_natals(self, page: int = 1, page_size: int = 100) -> Dict[str, Any]:
         """Return a page of stored natal charts."""

--- a/ui/streamlit/pages/13_System_Doctor.py
+++ b/ui/streamlit/pages/13_System_Doctor.py
@@ -1,0 +1,52 @@
+import streamlit as st
+
+from ui.streamlit.api import APIClient
+
+st.set_page_config(page_title="System Doctor", page_icon="🩺", layout="wide")
+st.title("🩺 System Doctor")
+
+api = APIClient()
+
+try:
+    report = api.system_doctor()
+except Exception as exc:  # pragma: no cover - user feedback only
+    st.error(f"Unable to load diagnostics: {exc}")
+    st.stop()
+
+status_icon = {"ok": "✅", "warn": "⚠️", "error": "❌"}
+overall_status = str(report.get("status", "warn"))
+generated_at = report.get("generated_at")
+
+info_cols = st.columns(2)
+with info_cols[0]:
+    st.metric("Overall Status", overall_status.upper(), help="Aggregated worst status across checks.")
+with info_cols[1]:
+    if generated_at:
+        st.metric("Generated", generated_at)
+    else:  # pragma: no cover - optional metadata
+        st.metric("Generated", "n/a")
+
+checks = report.get("checks", {})
+if not isinstance(checks, dict):  # pragma: no cover - defensive
+    st.warning("Doctor report did not include detailed checks.")
+    st.stop()
+
+for name in sorted(checks):
+    payload = checks.get(name)
+    if not isinstance(payload, dict):  # pragma: no cover - defensive
+        continue
+    status = str(payload.get("status", "warn"))
+    icon = status_icon.get(status, "❔")
+    detail = payload.get("detail", "")
+    header = f"{icon} {name.replace('_', ' ').title()}"
+    expanded = status != "ok"
+    with st.expander(header, expanded=expanded):
+        if detail:
+            st.write(detail)
+        data = payload.get("data")
+        if isinstance(data, dict) and data:
+            st.json(data)
+        elif data:
+            st.write(data)
+
+st.caption("Results derive from live Swiss Ephemeris, database, migration, and cache checks.")


### PR DESCRIPTION
## Summary
- add an observability doctor module that verifies Swiss Ephemeris availability, database connectivity, migrations, and cache health
- expose the aggregated doctor report via a new `/v1/doctor` FastAPI route and Streamlit dashboard page
- document the endpoint and cover the doctor runner with unit tests

## Testing
- pytest tests/observability/test_doctor.py

------
https://chatgpt.com/codex/tasks/task_e_68e2faadd18483248bf00a4276707541