### PR TITLE
Warm ephemeris cache grid during startup

### DIFF
--- a/astroengine/cache/positions_cache.py
+++ b/astroengine/cache/positions_cache.py
@@ -1,16 +1,22 @@
 # >>> AUTO-GEN BEGIN: positions-cache v1.0
 from __future__ import annotations
 
+import logging
 import sqlite3
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
+from datetime import datetime, timezone
+from time import perf_counter
 import numpy as np
 
 from ..ephemeris import SwissEphemerisAdapter
 from ..infrastructure.home import ae_home
+from ..core.time import julian_day
 
 CACHE_DIR = ae_home() / "cache"
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
 DB = CACHE_DIR / "positions.sqlite"
+
+_LOGGER = logging.getLogger(__name__)
 
 _BODY_CODES = {
     "sun": "SUN",
@@ -140,6 +146,64 @@ def warm_daily(bodies: Iterable[str], start_jd: float, end_jd: float) -> int:
             get_daily_entry(day_jd, body)
             count += 1
     return count
+
+
+_BOOTSTRAP_BODIES: tuple[str, ...] = ("sun", "moon", "mercury")
+_BOOTSTRAP_DAY_OFFSETS: tuple[int, ...] = (0, 1)
+
+
+def warm_startup_grid(
+    *,
+    max_duration_ms: float = 150.0,
+    bodies: Sequence[str] | None = None,
+    day_offsets: Sequence[int] | None = None,
+) -> int:
+    """Warm a small JD/body grid for cold starts within ``max_duration_ms``.
+
+    The helper focuses on the most frequently accessed luminaries so
+    subsequent requests can rely on cached Swiss Ephemeris results.  The
+    warm-up stops immediately when ``max_duration_ms`` is exceeded to
+    ensure startup remains bounded.
+    """
+
+    if max_duration_ms <= 0:
+        return 0
+
+    selected_bodies = tuple(
+        body.lower()
+        for body in (bodies or _BOOTSTRAP_BODIES)
+        if supported_body(body)
+    )
+    if not selected_bodies:
+        return 0
+
+    offsets = tuple(int(offset) for offset in (day_offsets or _BOOTSTRAP_DAY_OFFSETS))
+    if not offsets:
+        return 0
+
+    start = perf_counter()
+    warmed = 0
+
+    base_day = int(julian_day(datetime.now(tz=timezone.utc)))
+
+    for offset in offsets:
+        for body in selected_bodies:
+            elapsed_ms = (perf_counter() - start) * 1000.0
+            if elapsed_ms >= max_duration_ms:
+                return warmed
+            day_jd = float(base_day + offset)
+            try:
+                get_daily_entry(day_jd, body)
+            except RuntimeError:
+                _LOGGER.debug("Startup warm skipped; Swiss ephemeris unavailable.")
+                return warmed
+            except Exception as exc:  # pragma: no cover - defensive guard
+                _LOGGER.warning(
+                    "Startup warm failed for %s @ JD %s: %s", body, day_jd, exc
+                )
+                return warmed
+            warmed += 1
+    return warmed
 
 
 # >>> AUTO-GEN END: positions-cache v1.0

--- a/tests/test_positions_cache_startup.py
+++ b/tests/test_positions_cache_startup.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from astroengine.cache import positions_cache
+
+
+def test_warm_startup_grid_respects_time_budget(monkeypatch):
+    calls: List[Tuple[float, str]] = []
+    current = {"value": 0.0}
+
+    def fake_perf_counter() -> float:
+        return current["value"]
+
+    def fake_get_daily_entry(jd: float, body: str) -> tuple[float, float, float]:
+        calls.append((jd, body))
+        current["value"] += 0.2  # simulate 200 ms of work per call
+        return 0.0, 0.0, 0.0
+
+    monkeypatch.setattr(positions_cache, "perf_counter", fake_perf_counter)
+    monkeypatch.setattr(positions_cache, "get_daily_entry", fake_get_daily_entry)
+
+    warmed = positions_cache.warm_startup_grid(
+        max_duration_ms=150.0,
+        bodies=("sun", "moon"),
+        day_offsets=(0, 1),
+    )
+
+    assert warmed == 1
+    assert len(calls) == 1
+
+
+def test_warm_startup_grid_ignores_unsupported(monkeypatch):
+    monkeypatch.setattr(
+        positions_cache,
+        "get_daily_entry",
+        lambda *_args, **_kwargs: (_args[0], _args[1], 0.0),
+    )
+
+    warmed = positions_cache.warm_startup_grid(
+        max_duration_ms=150.0,
+        bodies=("unknown",),
+        day_offsets=(0,),
+    )
+
+    assert warmed == 0
+
+
+def test_warm_startup_grid_handles_runtime_error(monkeypatch):
+    def raise_runtime_error(_jd: float, _body: str) -> tuple[float, float, float]:
+        raise RuntimeError("Swiss unavailable")
+
+    monkeypatch.setattr(positions_cache, "get_daily_entry", raise_runtime_error)
+    monkeypatch.setattr(positions_cache, "perf_counter", lambda: 0.0)
+
+    warmed = positions_cache.warm_startup_grid(
+        max_duration_ms=150.0,
+        bodies=("sun",),
+        day_offsets=(0,),
+    )
+
+    assert warmed == 0


### PR DESCRIPTION
## Summary
- add a bounded startup warm helper for the ephemeris positions cache so frequent bodies are preloaded within 150 ms
- invoke the warm helper during FastAPI startup and record the warmed entry count on the app state
- cover the warm helper with unit tests guarding the budget limit, unsupported bodies, and runtime error handling

## Testing
- pytest *(fails: ImportError: cannot import name 'apply_narrative_profile_overlay' from 'astroengine.config')*
- pytest tests/test_positions_cache_startup.py


------
https://chatgpt.com/codex/tasks/task_e_68e2fcdd0ad88324b0e55254de4d3bcd