### PR TITLE
Normalize ephemeris angles and speeds

### DIFF
--- a/astroengine/cache/positions_cache.py
+++ b/astroengine/cache/positions_cache.py
@@ -5,6 +5,7 @@ import sqlite3
 from collections.abc import Iterable
 import numpy as np
 
+from ..canonical import canonical_round, normalize_longitude, normalize_speed_per_day
 from ..ephemeris import SwissEphemerisAdapter
 from ..infrastructure.home import ae_home
 
@@ -82,9 +83,13 @@ def get_daily_entry(
         row = cur.fetchone()
         if row is not None:
             lon, lat, speed = row
-            lon_f = float(lon)
-            lat_f = None if lat is None else float(lat)
-            speed_f = None if speed is None else float(speed)
+            lon_f = normalize_longitude(float(lon))
+            lat_f = None if lat is None else canonical_round(float(lat))
+            speed_f = (
+                None
+                if speed is None
+                else normalize_speed_per_day(float(speed))
+            )
             return lon_f, lat_f, speed_f
     finally:
         con.close()
@@ -99,9 +104,9 @@ def get_daily_entry(
         raise ValueError(f"Unsupported body '{body}' for daily cache") from exc
     adapter = SwissEphemerisAdapter.get_default_adapter()
     sample = adapter.body_position(float(_day_jd(jd_ut)), code, body_name=body.title())
-    lon = float(sample.longitude)
-    lat = float(sample.latitude)
-    speed = float(sample.speed_longitude)
+    lon = normalize_longitude(float(sample.longitude))
+    lat = canonical_round(float(sample.latitude))
+    speed = normalize_speed_per_day(float(sample.speed_longitude))
     con = _connect()
     try:
         con.execute(

--- a/astroengine/providers/swiss_provider.py
+++ b/astroengine/providers/swiss_provider.py
@@ -331,7 +331,17 @@ class SwissFallbackProvider:
                 speed = self._lon_speed(name, epoch)
             except KeyError:
                 continue
-            out[name] = {"lon": lon_deg % 360.0, "decl": lat_deg, "speed_lon": speed}
+            position = BodyPosition(
+                lon=lon_deg,
+                lat=lat_deg,
+                dec=lat_deg,
+                speed_lon=speed,
+            )
+            out[name] = {
+                "lon": position.lon,
+                "decl": position.dec,
+                "speed_lon": position.speed_lon,
+            }
         return out
 
     def position(self, body: str, ts_utc: str) -> BodyPosition:

--- a/astroengine/report/builders.py
+++ b/astroengine/report/builders.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Iterable, Protocol, Sequence
 
+from ..canonical import canonical_round, normalize_longitude
 from .pdf import AspectEntry, ChartReportContext, WheelEntry
 
 __all__ = [
@@ -48,7 +49,7 @@ _ASPECT_NAMES = {0: "Conjunction", 60: "Sextile", 90: "Square", 120: "Trine", 18
 
 
 def _normalise_longitude(value: float) -> float:
-    return value % 360.0
+    return normalize_longitude(value)
 
 
 def _sign_name(longitude: float) -> str:
@@ -57,7 +58,7 @@ def _sign_name(longitude: float) -> str:
 
 
 def _sign_degree(longitude: float) -> float:
-    return _normalise_longitude(longitude) % 30.0
+    return canonical_round(_normalise_longitude(longitude) % 30.0)
 
 
 def _house_for(longitude: float, cusps: Sequence[float]) -> int | None:
@@ -82,7 +83,7 @@ def build_wheel_entries(natal) -> list[WheelEntry]:
     cusps = list(getattr(natal.houses, "cusps", []) or [])
     entries: list[WheelEntry] = []
     for body, position in natal.positions.items():
-        longitude = _normalise_longitude(position.longitude)
+        longitude = canonical_round(_normalise_longitude(position.longitude))
         entries.append(
             WheelEntry(
                 body=body,

--- a/tests/test_canonical_body_position.py
+++ b/tests/test_canonical_body_position.py
@@ -9,7 +9,7 @@ from astroengine.canonical import BodyPosition
 
 def test_body_position_wraps_longitude_into_range() -> None:
     pos = BodyPosition(lon=720.123456789, lat=0.0, dec=0.0, speed_lon=0.0)
-    assert pos.lon == pytest.approx(0.12345679)
+    assert pos.lon == pytest.approx(0.12346, abs=1e-6)
 
 
 def test_body_position_handles_negative_longitude() -> None:
@@ -24,10 +24,10 @@ def test_body_position_rounds_precision() -> None:
         dec=0.123456789,
         speed_lon=0.98765432109,
     )
-    assert pos.lon == pytest.approx(12.34567891)
-    assert pos.lat == pytest.approx(1.23456789)
-    assert pos.dec == pytest.approx(0.12345679)
-    assert pos.speed_lon == pytest.approx(0.98765432)
+    assert pos.lon == pytest.approx(12.34568, abs=1e-6)
+    assert pos.lat == pytest.approx(1.23457, abs=1e-6)
+    assert pos.dec == pytest.approx(0.12346, abs=1e-6)
+    assert pos.speed_lon == pytest.approx(0.98765, abs=1e-6)
 
 
 def test_body_position_clamps_declination_upper() -> None:


### PR DESCRIPTION
## Summary
- tighten canonical rounding to five decimals and expose helpers for longitude, declination, and speed normalization
- normalize cached, provider, and frame payloads through the canonical helpers to keep angles in-range and speeds in degrees/day
- update reporting utilities and canonical tests to match the new precision policy

## Testing
- pytest *(fails: ImportError for apply_narrative_profile_overlay in app config during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fc6112388324b0ae3926c7b1a792