### PR TITLE
Handle DST gaps and folds when resolving local timestamps

### DIFF
--- a/astroengine/__init__.py
+++ b/astroengine/__init__.py
@@ -30,6 +30,9 @@ def get_version() -> str:
 
 
 from .atlas.tz import (  # noqa: F401
+    FoldPolicy,
+    GapPolicy,
+    LocalTimeResolution,
     Policy,
     from_utc,
     is_ambiguous,
@@ -254,6 +257,9 @@ from .analysis import condition_report, score_accidental, score_essential
 
 __all__ = [
     "__version__",
+    "FoldPolicy",
+    "GapPolicy",
+    "LocalTimeResolution",
     "Policy",
     "tzid_for",
     "to_utc",

--- a/astroengine/atlas/__init__.py
+++ b/astroengine/atlas/__init__.py
@@ -2,6 +2,9 @@
 """Timezone resolution utilities for atlas channel."""
 
 from .tz import (
+    FoldPolicy,
+    GapPolicy,
+    LocalTimeResolution,
     Policy,
     from_utc,
     is_ambiguous,
@@ -11,6 +14,9 @@ from .tz import (
 )
 
 __all__ = [
+    "FoldPolicy",
+    "GapPolicy",
+    "LocalTimeResolution",
     "Policy",
     "from_utc",
     "is_ambiguous",

--- a/docs/ATLAS_TZ_SPEC.md
+++ b/docs/ATLAS_TZ_SPEC.md
@@ -104,7 +104,9 @@ sources; synthetic values are prohibited.
 3. **Gap/Fold Handling** — `local_to_utc` detects non-existent times (DST
    spring-forward gaps) and ambiguous folds. Policies (`gap: raise|post|pre`,
    `fold: earliest|latest|flag`) are configurable per channel. Responses include
-   diagnostics describing which transitions triggered the policy.
+   diagnostics describing which transitions triggered the policy, the resolved
+   Olson zone identifier, and the UTC instant selected so downstream workflows
+   retain both the local and UTC representations.
 4. **UTC→Local Conversion** — `utc_to_local` returns `datetime` objects annotated
    with the PEP‑495 `fold` flag when ambiguous. Abbreviations and DST state are
    relayed for UI display and logging.

--- a/docs/module/ux/overlays_data_sources.md
+++ b/docs/module/ux/overlays_data_sources.md
@@ -4,7 +4,7 @@ The UX module reserves runtime surfaces for maps, timelines, and plugin panels. 
 
 ## Atlas and timezone inputs
 
-- `astroengine/atlas/tz.py` wraps the `timezonefinder` dataset to resolve Olson timezone identifiers from latitude/longitude pairs. Overlay renderers must use `tzid_for`, `to_utc`, and `from_utc` to convert Solar Fire event timestamps into local presentation time without discarding provenance.
+- `astroengine/atlas/tz.py` wraps the `timezonefinder` dataset to resolve Olson timezone identifiers from latitude/longitude pairs. Overlay renderers must use `tzid_for`, `to_utc`, and `from_utc` to convert Solar Fire event timestamps into local presentation time without discarding provenance. The `to_utc` helper now returns a `LocalTimeResolution` record so overlays can persist the chosen fold, resolved timezone, and UTC instant alongside the caller-supplied local moment.
 - Coordinate metadata for overlays is derived from the Solar Fire comparison exports archived under `qa/artifacts/solarfire/2025-10-02/`. The checksums are tracked in `qa/artifacts/solarfire/2025-10-02/provenance_ingestion.md` to guarantee that overlay timelines reproduce the same event positions used for runtime validation.
 
 ## Map overlays

--- a/tests/property/test_timezones.py
+++ b/tests/property/test_timezones.py
@@ -32,9 +32,12 @@ def _ensure_datetime(value: Any) -> datetime:
         candidate = value[0]
     else:
         candidate = value
-    if not isinstance(candidate, datetime):
-        raise TypeError(f"Expected datetime from timezone helper, got {type(candidate)!r}")
-    return candidate
+    if isinstance(candidate, datetime):
+        return candidate
+    utc_value = getattr(candidate, "utc", None)
+    if isinstance(utc_value, datetime):
+        return utc_value
+    raise TypeError(f"Expected datetime from timezone helper, got {type(candidate)!r}")
 
 
 def _call_from_utc(moment: datetime, lat: float, lon: float) -> datetime:
@@ -47,10 +50,8 @@ def _call_from_utc(moment: datetime, lat: float, lon: float) -> datetime:
 
 def _call_to_utc(moment: datetime, lat: float, lon: float, *, ambiguous: bool = False) -> datetime:
     kwargs: dict[str, Any] = {}
-    if "policy" in _TO_UTC_PARAMS:
-        kwargs.setdefault("policy", "shift_forward")
     if "nonexistent" in _TO_UTC_PARAMS:
-        kwargs.setdefault("nonexistent", "shift_forward")
+        kwargs.setdefault("nonexistent", "post")
     if ambiguous and "ambiguous" in _TO_UTC_PARAMS:
         kwargs.setdefault("ambiguous", "earliest")
     try:

--- a/tests/test_atlas_tz.py
+++ b/tests/test_atlas_tz.py
@@ -27,9 +27,13 @@ def test_ambiguous_fall_back():
     dt = datetime(2025, 11, 2, 1, 30)
     tzid = tzid_for(*NYC)
     assert is_ambiguous(dt, tzid)
-    early = to_utc(dt, *NYC, policy="earliest")
-    late = to_utc(dt, *NYC, policy="latest")
-    assert (late - early).total_seconds() == 3600
+    early = to_utc(dt, *NYC, ambiguous="earliest")
+    late = to_utc(dt, *NYC, ambiguous="latest")
+    assert (late.utc - early.utc).total_seconds() == 3600
+    assert early.fold == 0 and late.fold == 1
+    assert early.tzid == tzid == late.tzid
+    assert early.local.tzinfo is not None and getattr(early.local.tzinfo, "key", tzid) == tzid
+    assert late.local.fold == 1
 
 
 
@@ -39,8 +43,10 @@ def test_nonexistent_spring_forward_shift():
     tzid = tzid_for(*NYC)
     assert is_nonexistent(dt, tzid)
 
-    shifted = to_utc(dt, *NYC, policy="shift_forward")
-    local = from_utc(shifted, *NYC)
+    shifted = to_utc(dt, *NYC, nonexistent="post")
+    assert shifted.nonexistent and shifted.gap is not None
+    assert shifted.gap.total_seconds() == 3600
+    local = from_utc(shifted.utc, *NYC)
     assert local.hour >= 3
 
 
@@ -48,32 +54,47 @@ def test_round_trip():
     utc_dt = datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc)
     local = from_utc(utc_dt, *NYC)
     round_tripped = to_utc(local.replace(tzinfo=None), *NYC)
-    assert round_tripped == utc_dt
+    assert round_tripped.utc == utc_dt
 
 
 def test_policy_raise_for_nonexistent():
     dt = datetime(2025, 3, 9, 2, 30)
     with pytest.raises(ValueError):
-        to_utc(dt, *NYC, policy="raise")
+        to_utc(dt, *NYC, nonexistent="raise")
 
 
 def test_policy_raise_for_ambiguous():
     dt = datetime(2025, 11, 2, 1, 30)
     with pytest.raises(ValueError):
-        to_utc(dt, *NYC, policy="raise")
+        to_utc(dt, *NYC, ambiguous="raise")
 
 
 def test_to_utc_ambiguous_golden_values():
     dt = datetime(2025, 11, 2, 1, 30)
-    earliest = to_utc(dt, *NYC, policy="earliest")
-    latest = to_utc(dt, *NYC, policy="latest")
-    assert earliest == datetime(2025, 11, 2, 5, 30, tzinfo=timezone.utc)
-    assert latest == datetime(2025, 11, 2, 6, 30, tzinfo=timezone.utc)
+    earliest = to_utc(dt, *NYC, ambiguous="earliest")
+    latest = to_utc(dt, *NYC, ambiguous="latest")
+    assert earliest.utc == datetime(2025, 11, 2, 5, 30, tzinfo=timezone.utc)
+    assert latest.utc == datetime(2025, 11, 2, 6, 30, tzinfo=timezone.utc)
 
 
 def test_to_utc_shift_forward_golden_value():
     dt = datetime(2025, 3, 9, 2, 30)
-    shifted = to_utc(dt, *NYC, policy="shift_forward")
-    assert shifted == datetime(2025, 3, 9, 7, 30, tzinfo=timezone.utc)
+    shifted = to_utc(dt, *NYC, nonexistent="post")
+    assert shifted.utc == datetime(2025, 3, 9, 7, 30, tzinfo=timezone.utc)
+
+
+def test_to_utc_pre_gap_policy():
+    dt = datetime(2025, 3, 9, 2, 30)
+    pre_policy = to_utc(dt, *NYC, nonexistent="pre")
+    assert pre_policy.nonexistent
+    assert pre_policy.utc == datetime(2025, 3, 9, 6, 30, tzinfo=timezone.utc)
+
+
+def test_to_utc_flagged_ambiguous():
+    dt = datetime(2025, 11, 2, 1, 15)
+    flagged = to_utc(dt, *NYC, ambiguous="flag")
+    assert flagged.ambiguous
+    assert flagged.ambiguous_flagged
+    assert flagged.fold == 0
 
 


### PR DESCRIPTION
## Summary
- add a LocalTimeResolution record that captures fold decisions, DST gap handling, and the resolved timezone when converting naive local times to UTC
- expose the new fold and gap policies through the atlas exports and update UX/timezone docs to describe the richer context
- extend timezone edge-case tests (gap/overlap) and property helpers to assert the new metadata behaviour

## Testing
- pytest tests/test_atlas_tz.py tests/property/test_timezones.py


------
https://chatgpt.com/codex/tasks/task_e_68e2fc68393c8324b2fe793bb0909a56