### PR TITLE
Add schema versioning to settings snapshots

### DIFF
--- a/astroengine/config/__init__.py
+++ b/astroengine/config/__init__.py
@@ -48,6 +48,7 @@ from .settings import (
     delete_user_narrative_profile,
     list_narrative_profiles,
     load_narrative_profile_overlay,
+    apply_narrative_profile_overlay,
     VoidOfCourseCfg,
     ZodiacCfg,
     config_path,

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -12,6 +12,9 @@ from pydantic import BaseModel, Field, field_validator, model_validator
 
 from astroengine.plugins.registry import apply_plugin_settings
 
+
+CURRENT_SETTINGS_SCHEMA_VERSION = 2
+
 # -------------------- Settings Schema --------------------
 
 
@@ -657,6 +660,11 @@ class ChatCfg(BaseModel):
 class Settings(BaseModel):
     """Top-level settings model persisted on disk."""
 
+    schema_version: int = Field(
+        default=CURRENT_SETTINGS_SCHEMA_VERSION,
+        ge=1,
+        description="Version marker for persisted configuration payloads.",
+    )
     preset: Literal[
         "modern_western",
         "traditional_western",
@@ -891,6 +899,42 @@ def save_settings(settings: Settings, path: Optional[Path] = None) -> Path:
     return target_path
 
 
+def _coerce_schema_version(raw: object) -> int:
+    """Return a normalised schema version value with sane bounds."""
+
+    try:
+        value = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 1
+    return max(1, value)
+
+
+def _upgrade_settings_payload(
+    data: dict[str, object], *, schema_version: int
+) -> tuple[dict[str, object], bool]:
+    """Apply in-place upgrades required for older settings payloads."""
+
+    upgraded = deepcopy(data)
+    version = max(1, schema_version)
+    changed = False
+
+    if version < 2:
+        # v2 introduces the explicit schema version marker. No structural
+        # adjustments are required; we simply record the new version.
+        version = 2
+        changed = True
+
+    if version < CURRENT_SETTINGS_SCHEMA_VERSION:
+        version = CURRENT_SETTINGS_SCHEMA_VERSION
+        changed = True
+
+    if upgraded.get("schema_version") != version:
+        upgraded["schema_version"] = version
+        changed = True
+
+    return upgraded, changed
+
+
 def load_settings(path: Optional[Path] = None) -> Settings:
     """Load settings from disk, creating defaults if missing."""
 
@@ -900,8 +944,14 @@ def load_settings(path: Optional[Path] = None) -> Settings:
         save_settings(settings, source_path)
         return settings
     with source_path.open("r", encoding="utf-8") as handle:
-        data = yaml.safe_load(handle) or {}
+        raw = yaml.safe_load(handle) or {}
+    if not isinstance(raw, dict):
+        raw = {}
+    schema_version = _coerce_schema_version(raw.get("schema_version"))
+    data, upgraded = _upgrade_settings_payload(raw, schema_version=schema_version)
     settings = Settings(**data)
+    if upgraded:
+        save_settings(settings, source_path)
     apply_plugin_settings(settings)
     return settings
 

--- a/docs/changelog/settings-schema-version.md
+++ b/docs/changelog/settings-schema-version.md
@@ -1,0 +1,5 @@
+# Settings Snapshot Schema Versioning
+
+- Added an explicit `schema_version` marker to persisted settings snapshots and `/v1/settings` responses so that historical chart runs can declare which schema they rely on.
+- The settings loader now normalises legacy payloads by stamping the current schema version and resaving `config.yaml`, ensuring previously exported bundles continue to load without manual edits.
+- No manual migration steps are required; existing installations will be updated the next time the configuration file is read.


### PR DESCRIPTION
## Summary
- add an explicit schema version field to persisted settings snapshots and export responses
- upgrade legacy configuration payloads on load and persist the updated schema version marker
- document the automatic migration behaviour for settings snapshots

## Testing
- pytest *(fails: ImportError: cannot import name 'narrative_mix_router' from 'app.routers')*

------
https://chatgpt.com/codex/tasks/task_e_68e2fc78079c83249de0cf60afc5d715