### PR TITLE
Improve atlas controls and DST visibility

### DIFF
--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -614,6 +614,7 @@ class AtlasCfg(BaseModel):
 
     offline_enabled: bool = False
     data_path: Optional[str] = None
+    online_fallback_enabled: bool = False
 
 
 class ObservabilityCfg(BaseModel):

--- a/astroengine/geo/atlas.py
+++ b/astroengine/geo/atlas.py
@@ -30,6 +30,7 @@ class AtlasLookupError(RuntimeError):
 class _AtlasConfig:
     offline_enabled: bool
     data_path: Path | None
+    online_fallback_enabled: bool
 
 
 def geocode(query: str, *, settings: Settings | None = None) -> GeocodeResult:
@@ -70,6 +71,15 @@ def geocode(query: str, *, settings: Settings | None = None) -> GeocodeResult:
         except AtlasLookupError as exc:
             offline_failure = exc
 
+    if not cfg.online_fallback_enabled:
+        if offline_failure:
+            raise AtlasLookupError(
+                f"Offline atlas lookup failed ({offline_failure}). Online fallback is disabled in settings."
+            ) from offline_failure
+        raise AtlasLookupError(
+            "Online atlas fallback is disabled. Enable the offline atlas dataset or allow the online fallback in settings."
+        )
+
     try:
         return _geocode_online(trimmed)
     except AtlasLookupError as online_exc:
@@ -83,9 +93,13 @@ def geocode(query: str, *, settings: Settings | None = None) -> GeocodeResult:
 def _extract_config(settings: Settings) -> _AtlasConfig:
     atlas_cfg = getattr(settings, "atlas", None)
     if atlas_cfg is None:
-        return _AtlasConfig(False, None)
+        return _AtlasConfig(False, None, False)
     data_path = Path(atlas_cfg.data_path).expanduser() if atlas_cfg.data_path else None
-    return _AtlasConfig(bool(atlas_cfg.offline_enabled), data_path)
+    return _AtlasConfig(
+        bool(atlas_cfg.offline_enabled),
+        data_path,
+        bool(getattr(atlas_cfg, "online_fallback_enabled", False)),
+    )
 
 
 def _geocode_offline(query: str, db_path: Path) -> GeocodeResult:

--- a/data/atlas/README.md
+++ b/data/atlas/README.md
@@ -34,3 +34,19 @@ sqlite3 offline_sample.sqlite < offline_sample.sql
 
 The resulting `offline_sample.sqlite` file can be referenced via the settings
 panel or CLI configuration when exercising offline atlas lookups.
+
+## Selecting the dataset in the UI
+
+The Streamlit settings panel now enumerates SQLite files discovered under
+`data/atlas` so you can choose the bundled sample without retyping paths. Pick a
+package from the **Bundled offline atlases** dropdown or enter a custom path in
+the adjacent text field if your dataset lives elsewhere.
+
+## Online fallback controls
+
+Online geocoding is disabled by default to prioritize reproducible, offline
+results. Enable the "Allow online fallback geocoding" toggle in the settings UI
+only when you have the `geopy` extra installed and are comfortable querying the
+network. When the fallback remains disabled, atlas lookups fail fast with a
+message directing you to refresh the offline dataset instead of silently
+contacting external services.


### PR DESCRIPTION
## Summary
- add a settings-panel selector for bundled offline atlas files and persist the new online fallback toggle
- default geocoding to offline-only mode unless the online fallback is explicitly enabled, with updated error handling and tests
- show recent and upcoming DST transitions in the location picker and document the new atlas controls

## Testing
- pytest tests/test_geo_atlas.py tests/test_atlas_tz.py


------
https://chatgpt.com/codex/tasks/task_e_68e2fc9ce6e08324a43620cb80f0a64d