### PR TITLE
Optimize Swiss ephemeris body sampling for timeline workflows

### DIFF
--- a/astroengine/electional/solver.py
+++ b/astroengine/electional/solver.py
@@ -147,10 +147,9 @@ class SwissElectionalProvider:
         if ts < self._start or ts > self._end:
             raise ValueError("timestamp outside configured scan window")
         jd = self._adapter.julian_day(ts)
-        positions: Dict[str, BodyPosition] = {
-            name: self._adapter.body_position(jd, code, body_name=name)
-            for name, code in self._body_codes.items()
-        }
+        positions: Dict[str, BodyPosition] = self._adapter.compute_bodies_many(
+            jd, self._body_codes
+        )
         houses = self._adapter.houses(jd, self._lat, self._lon, system=self._chart.house_system)
         asc = norm360(houses.ascendant)
         mc = norm360(houses.midheaven)

--- a/tests/test_swisseph_adapter_extensions.py
+++ b/tests/test_swisseph_adapter_extensions.py
@@ -57,6 +57,33 @@ def test_fixed_star_matches_native_computation() -> None:
     assert star.flags == retflags
 
 
+def test_compute_bodies_many_matches_single_calls() -> None:
+    adapter = SwissEphemerisAdapter()
+    jd = swe.julday(2024, 2, 1, 0.0)
+    bodies = {
+        "Sun": int(swe.SUN),
+        "Moon": int(swe.MOON),
+        "Mars": int(swe.MARS),
+    }
+    aggregated = adapter.compute_bodies_many(jd, bodies)
+    assert set(aggregated) == set(bodies)
+    for name, code in bodies.items():
+        single = adapter.body_position(jd, int(code), body_name=name)
+        combined = aggregated[name]
+        assert combined.body == single.body
+        assert combined.julian_day == pytest.approx(single.julian_day)
+        assert combined.longitude == pytest.approx(single.longitude)
+        assert combined.latitude == pytest.approx(single.latitude)
+        assert combined.distance_au == pytest.approx(single.distance_au)
+        assert combined.speed_longitude == pytest.approx(single.speed_longitude)
+        assert combined.speed_latitude == pytest.approx(single.speed_latitude)
+        assert combined.speed_distance == pytest.approx(single.speed_distance)
+        assert combined.declination == pytest.approx(single.declination)
+        assert combined.speed_declination == pytest.approx(
+            single.speed_declination
+        )
+
+
 def test_ayanamsa_variants() -> None:
     adapter = SwissEphemerisAdapter(zodiac="sidereal", ayanamsa="lahiri")
     jd = swe.julday(2024, 5, 10, 0.0)


### PR DESCRIPTION
## Summary
- add a compute_bodies_many helper to SwissEphemerisAdapter to batch Swiss ephemeris calls and reuse it from body_positions
- switch electional context and outer cycle timeline calculations to the batched API to avoid per-body loops
- add a regression test proving the aggregated results match single-body sampling

## Testing
- pytest *(fails: ImportError: cannot import name 'apply_narrative_profile_overlay' from 'astroengine.config')*

------
https://chatgpt.com/codex/tasks/task_e_68e2fcb1d2dc8324ae4195401b910e77