### PR TITLE
Enable orjson responses and HTTP compression for FastAPI app

### DIFF
--- a/astroengine/web/middleware.py
+++ b/astroengine/web/middleware.py
@@ -1,0 +1,106 @@
+"""HTTP middleware helpers for FastAPI/Starlette applications."""
+
+from __future__ import annotations
+
+import zlib
+
+from fastapi import FastAPI
+from starlette.datastructures import Headers
+from starlette.middleware.gzip import GZipMiddleware, IdentityResponder
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+
+def _parse_accept_encoding(header: str) -> dict[str, float]:
+    """Return mapping of encodings to their declared quality values."""
+
+    encodings: dict[str, float] = {}
+    for raw_token in header.split(","):
+        token = raw_token.strip()
+        if not token:
+            continue
+        parts = [part.strip() for part in token.split(";") if part.strip()]
+        if not parts:
+            continue
+        name = parts[0].lower()
+        q = 1.0
+        for option in parts[1:]:
+            if option.startswith("q="):
+                try:
+                    q = float(option[2:])
+                except ValueError:
+                    q = 0.0
+        encodings[name] = q
+    return encodings
+
+
+def _encoding_quality(encodings: dict[str, float], name: str) -> float:
+    """Look up the quality value for *name*, falling back to ``*`` if present."""
+
+    name = name.lower()
+    if name in encodings:
+        return encodings[name]
+    if "*" in encodings:
+        return encodings["*"]
+    return 0.0
+
+
+class DeflateResponder(IdentityResponder):
+    """Stream ``deflate`` compressed responses."""
+
+    content_encoding = "deflate"
+
+    def __init__(self, app: ASGIApp, minimum_size: int, compresslevel: int = 9) -> None:
+        super().__init__(app, minimum_size)
+        self._compressor = zlib.compressobj(level=compresslevel, wbits=-zlib.MAX_WBITS)
+
+    def apply_compression(self, body: bytes, *, more_body: bool) -> bytes:  # noqa: D401 - base class docs
+        chunk = self._compressor.compress(body)
+        if not more_body:
+            chunk += self._compressor.flush()
+        return chunk
+
+
+class DeflateMiddleware:
+    """Serve ``deflate`` responses when clients explicitly request them."""
+
+    def __init__(self, app: ASGIApp, minimum_size: int = 500, compresslevel: int = 9) -> None:
+        self.app = app
+        self.minimum_size = minimum_size
+        self.compresslevel = compresslevel
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":  # pragma: no cover - delegated to Starlette
+            await self.app(scope, receive, send)
+            return
+
+        headers = Headers(scope=scope)
+        accept_encoding = headers.get("Accept-Encoding", "")
+        encodings = _parse_accept_encoding(accept_encoding)
+        gzip_q = _encoding_quality(encodings, "gzip")
+        deflate_q = _encoding_quality(encodings, "deflate")
+
+        if deflate_q > 0.0 and gzip_q <= 0.0:
+            responder: ASGIApp = DeflateResponder(
+                self.app, self.minimum_size, compresslevel=self.compresslevel
+            )
+        else:
+            responder = IdentityResponder(self.app, self.minimum_size)
+
+        await responder(scope, receive, send)
+
+
+def configure_compression(
+    app: FastAPI, *, minimum_size: int = 256, compresslevel: int = 6
+) -> None:
+    """Attach gzip and deflate compression middleware to *app*."""
+
+    app.add_middleware(GZipMiddleware, minimum_size=minimum_size, compresslevel=compresslevel)
+    app.add_middleware(
+        DeflateMiddleware, minimum_size=minimum_size, compresslevel=compresslevel
+    )
+
+
+__all__ = [
+    "configure_compression",
+    "DeflateMiddleware",
+]

--- a/tests/test_web_compression.py
+++ b/tests/test_web_compression.py
@@ -1,0 +1,76 @@
+"""Tests for HTTP compression helpers."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from astroengine.utils.json import has_orjson
+from astroengine.web.middleware import configure_compression
+
+try:  # pragma: no cover - optional dependency missing
+    from fastapi.responses import ORJSONResponse
+except ImportError:  # pragma: no cover
+    ORJSONResponse = JSONResponse  # type: ignore[assignment]
+
+try:  # pragma: no cover - optional router dependencies missing in CI
+    from app.main import app as main_app
+except ImportError:  # pragma: no cover
+    main_app = None  # type: ignore[assignment]
+
+
+def _build_test_app() -> FastAPI:
+    app = FastAPI(default_response_class=ORJSONResponse)
+    configure_compression(app, minimum_size=0, compresslevel=6)
+
+    @app.get("/payload")
+    def payload() -> dict[str, str]:
+        return {"message": "x" * 2048}
+
+    return app
+
+
+@pytest.mark.skipif(main_app is None, reason="app.main unavailable in test environment")
+def test_main_app_uses_orjson_response_class() -> None:
+    """Ensure the production app prefers ``orjson`` when available."""
+
+    if has_orjson():
+        assert main_app.default_response_class is ORJSONResponse
+    else:
+        assert main_app.default_response_class is JSONResponse
+
+
+def test_gzip_compression_enabled() -> None:
+    """Clients requesting gzip should receive gzip encoded payloads."""
+
+    app = _build_test_app()
+    client = TestClient(app)
+    response = client.get("/payload", headers={"Accept-Encoding": "gzip"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"
+    assert response.json() == {"message": "x" * 2048}
+
+
+def test_deflate_compression_enabled() -> None:
+    """Clients requesting deflate without gzip fallback should be supported."""
+
+    app = _build_test_app()
+    client = TestClient(app)
+    response = client.get("/payload", headers={"Accept-Encoding": "deflate"})
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "deflate"
+    assert response.json() == {"message": "x" * 2048}
+
+
+def test_gzip_preferred_over_deflate_when_available() -> None:
+    """When both encodings are accepted, gzip should win."""
+
+    app = _build_test_app()
+    client = TestClient(app)
+    response = client.get(
+        "/payload", headers={"Accept-Encoding": "gzip, deflate"}
+    )
+    assert response.status_code == 200
+    assert response.headers.get("content-encoding") == "gzip"


### PR DESCRIPTION
## Summary
- configure the FastAPI application to default to ORJSON responses when the optional dependency is available
- add shared middleware utilities that provide gzip and deflate compression and apply them to the main app
- cover the compression helpers with focused tests, including a guard that validates the production app default response class when importable

## Testing
- `pytest` *(fails: optional narrative profile dependencies missing when importing app.main)*
- `pytest tests/test_web_compression.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2fcbd9b3883249cd88107d2b16a00