### PR TITLE
Configure SQLite pragmas for Windows defaults

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -4,6 +4,8 @@ from contextlib import contextmanager
 from sqlalchemy import create_engine, event
 from sqlalchemy.orm import sessionmaker
 
+from astroengine.infrastructure.storage.sqlite import apply_default_pragmas
+
 DB_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
 engine = create_engine(DB_URL, echo=False, future=True)
 
@@ -11,12 +13,7 @@ if engine.url.get_backend_name() == "sqlite":
 
     @event.listens_for(engine, "connect")
     def _sqlite_configure(dbapi_connection, connection_record):  # pragma: no cover - depends on driver
-        cursor = dbapi_connection.cursor()
-        try:
-            cursor.execute("PRAGMA journal_mode=WAL;")
-            cursor.execute("PRAGMA synchronous=NORMAL;")
-        finally:
-            cursor.close()
+        apply_default_pragmas(dbapi_connection)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
 
 @contextmanager

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -10,6 +10,7 @@ from sqlalchemy import text
 
 from app.db.session import session_scope
 from astroengine.cache import positions_cache
+from astroengine.infrastructure.storage.sqlite import apply_default_pragmas
 from astroengine.ephemeris.utils import get_se_ephe_path
 
 router = APIRouter(tags=["observability"])
@@ -34,6 +35,7 @@ def _check_database() -> dict[str, Any]:
 def _check_cache() -> dict[str, Any]:
     try:
         connection = sqlite3.connect(str(positions_cache.DB))
+        apply_default_pragmas(connection)
         try:
             connection.execute("SELECT 1")
         finally:

--- a/astroengine/cache/positions_cache.py
+++ b/astroengine/cache/positions_cache.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Iterable
+
 import numpy as np
 
 from ..ephemeris import SwissEphemerisAdapter
 from ..infrastructure.home import ae_home
+from ..infrastructure.storage.sqlite import apply_default_pragmas
 
 CACHE_DIR = ae_home() / "cache"
 CACHE_DIR.mkdir(parents=True, exist_ok=True)
@@ -51,8 +53,7 @@ CREATE INDEX IF NOT EXISTS ix_positions_daily_day_body
 
 def _connect():
     con = sqlite3.connect(str(DB))
-    con.execute("PRAGMA journal_mode=WAL;")
-    con.execute("PRAGMA synchronous=NORMAL;")
+    apply_default_pragmas(con)
     con.executescript(_SQL["init"])
     con.commit()
     return con

--- a/astroengine/canonical.py
+++ b/astroengine/canonical.py
@@ -10,11 +10,20 @@ from typing import Any, Literal, Protocol
 _SQLITE_IMPORT_ERROR: ModuleNotFoundError | None = None
 
 try:  # pragma: no cover - optional storage dependency
-    from .infrastructure.storage.sqlite import ensure_sqlite_schema
+    from .infrastructure.storage.sqlite import (
+        apply_default_pragmas,
+        ensure_sqlite_schema,
+    )
 except ModuleNotFoundError as exc:  # pragma: no cover - allows lightweight imports
     _SQLITE_IMPORT_ERROR = exc
 
     def ensure_sqlite_schema(*_args, **_kwargs):  # type: ignore
+
+        raise RuntimeError(
+            "SQLite storage support unavailable"
+        ) from _SQLITE_IMPORT_ERROR
+
+    def apply_default_pragmas(*_args, **_kwargs):  # type: ignore
 
         raise RuntimeError(
             "SQLite storage support unavailable"
@@ -334,6 +343,7 @@ def sqlite_write_canonical(
 
     ensure_sqlite_schema(db_path)
     con = sqlite3.connect(db_path)
+    apply_default_pragmas(con)
     try:
         cur = con.cursor()
         cur.executemany(
@@ -365,6 +375,7 @@ def sqlite_read_canonical(
     ensure_sqlite_schema(db_path)
     con = sqlite3.connect(db_path)
     con.row_factory = sqlite3.Row
+    apply_default_pragmas(con)
     try:
         query = (
 

--- a/astroengine/cli_legacy.py
+++ b/astroengine/cli_legacy.py
@@ -75,6 +75,7 @@ from .exporters_ics import (
     write_ics_calendar,
     write_ics_canonical,
 )
+from .infrastructure.storage.sqlite import apply_default_pragmas
 from .infrastructure.storage.sqlite.query import top_events_by_score
 from .mundane import compute_solar_ingress_chart, compute_solar_quartet
 from .narrative import compose_narrative, summarize_top_events
@@ -296,6 +297,7 @@ def cmd_cache_info(_: argparse.Namespace) -> int:
         size = POSITIONS_DB.stat().st_size
         row_count = 0
         con = sqlite3.connect(str(POSITIONS_DB))
+        apply_default_pragmas(con)
         try:
             cur = con.execute("SELECT COUNT(*) FROM positions_daily")
             row = cur.fetchone()

--- a/astroengine/exporters/__init__.py
+++ b/astroengine/exporters/__init__.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any as _TypingAny
 
 from ..canonical import parquet_write_canonical, sqlite_write_canonical
+from ..infrastructure.storage.sqlite import apply_default_pragmas
 
 try:  # pragma: no cover - optional dependency
     import sqlite3
@@ -94,7 +95,9 @@ class SQLiteExporter:
 
     def _connect(self):  # pragma: no cover - trivial wrapper
         assert sqlite3 is not None
-        return sqlite3.connect(self.path)
+        connection = sqlite3.connect(self.path)
+        apply_default_pragmas(connection)
+        return connection
 
     def _ensure_schema(self) -> None:
         con = self._connect()

--- a/astroengine/geo/atlas.py
+++ b/astroengine/geo/atlas.py
@@ -11,6 +11,7 @@ from typing import TypedDict
 
 from astroengine.atlas.tz import tzid_for
 from astroengine.config import Settings, load_settings
+from astroengine.infrastructure.storage.sqlite import apply_default_pragmas
 
 
 class GeocodeResult(TypedDict):
@@ -95,6 +96,7 @@ def _geocode_offline(query: str, db_path: Path) -> GeocodeResult:
     normalized = _normalize(query)
     with sqlite3.connect(str(db_path)) as conn:
         conn.row_factory = sqlite3.Row
+        apply_default_pragmas(conn)
         row = conn.execute(
             """
             SELECT name, latitude, longitude, tzid

--- a/astroengine/infrastructure/storage/sqlite/__init__.py
+++ b/astroengine/infrastructure/storage/sqlite/__init__.py
@@ -9,10 +9,12 @@ from .engine import (
     get_sqlite_config,
     upgrade_sqlite,
 )
+from .pragmas import apply_default_pragmas
 from .schema import metadata, transits_events
 
 __all__ = [
     "SQLiteMigrator",
+    "apply_default_pragmas",
     "downgrade_sqlite",
     "ensure_sqlite_schema",
     "get_sqlite_config",

--- a/astroengine/infrastructure/storage/sqlite/pragmas.py
+++ b/astroengine/infrastructure/storage/sqlite/pragmas.py
@@ -1,0 +1,54 @@
+"""Shared SQLite pragma configuration helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+_PRAGMA_STATEMENTS: tuple[str, ...] = (
+    "PRAGMA journal_mode=WAL;",
+    "PRAGMA synchronous=NORMAL;",
+    "PRAGMA cache_size=-40000;",
+    "PRAGMA temp_store=MEMORY;",
+    "PRAGMA busy_timeout=5000;",
+)
+
+
+def _consume_cursor(cursor: Any) -> None:
+    """Exhaust and close the cursor returned by a PRAGMA statement."""
+
+    if cursor is None:
+        return
+    try:
+        cursor.fetchall()
+    except Exception:
+        pass
+    finally:
+        try:
+            cursor.close()
+        except Exception:
+            pass
+
+
+def apply_default_pragmas(dbapi_connection: Any) -> None:
+    """Apply the project's default SQLite PRAGMA tuning options."""
+
+    execute: Callable[[str], Any] | None = getattr(dbapi_connection, "execute", None)
+    if execute is None:
+        cursor_factory = getattr(dbapi_connection, "cursor", None)
+        if cursor_factory is None:
+            return
+        cursor = cursor_factory()
+        try:
+            for statement in _PRAGMA_STATEMENTS:
+                cursor.execute(statement)
+        finally:
+            cursor.close()
+        return
+
+    for statement in _PRAGMA_STATEMENTS:
+        cursor = execute(statement)
+        _consume_cursor(cursor)
+
+
+__all__ = ["apply_default_pragmas"]

--- a/astroengine/infrastructure/storage/sqlite/query.py
+++ b/astroengine/infrastructure/storage/sqlite/query.py
@@ -6,6 +6,7 @@ import json
 from typing import Any
 
 from .engine import ensure_sqlite_schema
+from .pragmas import apply_default_pragmas
 
 __all__ = ["top_events_by_score"]
 
@@ -27,6 +28,7 @@ def top_events_by_score(
     ensure_sqlite_schema(db_path)
     con = sqlite3.connect(db_path)
     con.row_factory = sqlite3.Row
+    apply_default_pragmas(con)
     try:
         query = (
             "SELECT ts, moving, target, aspect, score, profile_id, natal_id, event_year, meta_json "

--- a/astroengine/scheduler/db.py
+++ b/astroengine/scheduler/db.py
@@ -4,10 +4,11 @@ import sqlite3
 import time
 from pathlib import Path
 
+from astroengine.infrastructure.storage.sqlite import apply_default_pragmas
+
 DB_PATH = Path("./.astroengine/queue.sqlite")
 
 DDL = """
-PRAGMA journal_mode=WAL;
 CREATE TABLE IF NOT EXISTS jobs (
   id TEXT PRIMARY KEY,
   type TEXT NOT NULL,
@@ -34,6 +35,7 @@ def connect() -> sqlite3.Connection:
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     con = sqlite3.connect(DB_PATH)
     con.row_factory = sqlite3.Row
+    apply_default_pragmas(con)
     con.executescript(DDL)
     return con
 


### PR DESCRIPTION
## Summary
- add a shared helper that applies the desired SQLite PRAGMA defaults
- invoke the helper across SQLite entry points (ORM engine, caches, scheduler queue, exporters, CLI/health checks, atlas, and canonical storage)

## Testing
- pytest *(fails: ImportError: cannot import name 'apply_narrative_profile_overlay' from 'astroengine.config')*

------
https://chatgpt.com/codex/tasks/task_e_68e2fcc9a2ec8324bd1a86d0c4bc7de7