### PR TITLE
Improve Postgres database configuration

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -236,6 +236,7 @@ class TraditionalRun(ModuleScopeMixin, TimestampMixin, Base):
     __tablename__ = "traditional_runs"
     __table_args__ = _table_args(
         Index("ix_traditional_runs_kind", "kind"),
+        Index("ix_traditional_runs_kind_name", "kind", "name"),
         UniqueConstraint(
             "module",
             "submodule",

--- a/app/db/session.py
+++ b/app/db/session.py
@@ -1,22 +1,74 @@
 from __future__ import annotations
+
 import os
 from contextlib import contextmanager
+from typing import Any
+
 from sqlalchemy import create_engine, event
+from sqlalchemy.engine import URL, Engine, make_url
 from sqlalchemy.orm import sessionmaker
 
+
+def _postgres_engine_kwargs() -> dict[str, Any]:
+    """Return connection pooling and prepared statement settings for Postgres."""
+
+    pool_size = int(os.getenv("DB_POOL_SIZE", "5"))
+    max_overflow = int(os.getenv("DB_POOL_MAX_OVERFLOW", "10"))
+    pool_timeout = int(os.getenv("DB_POOL_TIMEOUT", "30"))
+    pool_recycle = int(os.getenv("DB_POOL_RECYCLE", "1800"))
+    batch_size = int(os.getenv("DB_EXECUTEMANY_BATCH_SIZE", "500"))
+
+    return {
+        "pool_size": pool_size,
+        "max_overflow": max_overflow,
+        "pool_timeout": pool_timeout,
+        "pool_recycle": pool_recycle,
+        "pool_pre_ping": True,
+        "executemany_mode": "values_plus_batch",
+        "executemany_parameters": {"batch_size": batch_size},
+    }
+
+
+def _enrich_postgres_url(url: URL) -> URL:
+    """Attach prepared statement configuration hints to a Postgres URL."""
+
+    query = dict(url.query)
+    prepare_threshold = os.getenv("PG_PREPARE_THRESHOLD") or "1"
+    prepared_cache = os.getenv("PG_PREPARED_STATEMENT_CACHE_SIZE") or "256"
+    query.setdefault("prepare_threshold", prepare_threshold)
+    query.setdefault("prepared_statement_cache_size", prepared_cache)
+    return url.set(query=query)
+
+
+def build_engine(db_url: str | URL | None = None) -> Engine:
+    """Create a SQLAlchemy engine configured from the provided or default URL."""
+
+    resolved_url = make_url(str(db_url or os.getenv("DATABASE_URL", "sqlite:///./dev.db")))
+    engine_kwargs: dict[str, Any] = {"echo": False, "future": True}
+
+    if resolved_url.get_backend_name() in {"postgresql", "postgres"}:
+        engine_kwargs.update(_postgres_engine_kwargs())
+        resolved_url = _enrich_postgres_url(resolved_url)
+
+    engine = create_engine(resolved_url, **engine_kwargs)
+
+    if resolved_url.get_backend_name() == "sqlite":
+
+        @event.listens_for(engine, "connect")
+        def _sqlite_configure(dbapi_connection, connection_record):  # pragma: no cover - depends on driver
+            cursor = dbapi_connection.cursor()
+            try:
+                cursor.execute("PRAGMA journal_mode=WAL;")
+                cursor.execute("PRAGMA synchronous=NORMAL;")
+            finally:
+                cursor.close()
+
+    return engine
+
+
 DB_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
-engine = create_engine(DB_URL, echo=False, future=True)
+engine = build_engine(DB_URL)
 
-if engine.url.get_backend_name() == "sqlite":
-
-    @event.listens_for(engine, "connect")
-    def _sqlite_configure(dbapi_connection, connection_record):  # pragma: no cover - depends on driver
-        cursor = dbapi_connection.cursor()
-        try:
-            cursor.execute("PRAGMA journal_mode=WAL;")
-            cursor.execute("PRAGMA synchronous=NORMAL;")
-        finally:
-            cursor.close()
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
 
 @contextmanager

--- a/migrations/versions/20241130_0006_postgres_indexes.py
+++ b/migrations/versions/20241130_0006_postgres_indexes.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Ensure composite indexes exist for Postgres query paths."""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import Inspector
+from sqlalchemy.exc import SQLAlchemyError
+
+revision = "20241130_0006"
+down_revision = "20241122_0005"
+branch_labels = None
+depends_on = None
+
+
+def _has_index(inspector: Inspector, table: str, name: str) -> bool:
+    try:
+        return any(index["name"] == name for index in inspector.get_indexes(table))
+    except SQLAlchemyError:
+        return False
+
+
+def _column_exists(inspector: Inspector, table: str, column: str) -> bool:
+    try:
+        return any(col["name"] == column for col in inspector.get_columns(table))
+    except SQLAlchemyError:
+        return False
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _column_exists(inspector, "traditional_runs", "name") and not _has_index(
+        inspector, "traditional_runs", "ix_traditional_runs_kind_name"
+    ):
+        op.create_index(
+            "ix_traditional_runs_kind_name",
+            "traditional_runs",
+            ["kind", "name"],
+            unique=False,
+        )
+
+    if _column_exists(inspector, "charts", "dt_utc") and not _has_index(
+        inspector, "charts", "ix_charts_dt_utc"
+    ):
+        op.create_index("ix_charts_dt_utc", "charts", ["dt_utc"], unique=False)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+
+    if _has_index(inspector, "traditional_runs", "ix_traditional_runs_kind_name"):
+        op.drop_index("ix_traditional_runs_kind_name", table_name="traditional_runs")
+
+    # ``ix_charts_dt_utc`` is created in an earlier migration.  We leave it in
+    # place so a downgrade returns the schema to its previous state when the
+    # index already existed.
+    return None

--- a/tests/test_db_session_config.py
+++ b/tests/test_db_session_config.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from sqlalchemy.engine import URL
+
+
+@pytest.fixture
+def session_module(monkeypatch):
+    """Provide an isolated import of ``app.db.session`` for each test."""
+
+    import app.db.session as session
+
+    yield session
+
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_POOL_SIZE", raising=False)
+    monkeypatch.delenv("DB_POOL_MAX_OVERFLOW", raising=False)
+    monkeypatch.delenv("DB_POOL_TIMEOUT", raising=False)
+    monkeypatch.delenv("DB_POOL_RECYCLE", raising=False)
+    monkeypatch.delenv("DB_EXECUTEMANY_BATCH_SIZE", raising=False)
+    monkeypatch.delenv("PG_PREPARE_THRESHOLD", raising=False)
+    monkeypatch.delenv("PG_PREPARED_STATEMENT_CACHE_SIZE", raising=False)
+    importlib.reload(session)
+
+
+def test_postgres_engine_uses_pooling_and_prepared_statements(monkeypatch, session_module):
+    """Ensure Postgres engines are built with pooling and prepared statement hints."""
+
+    captured: dict[str, object] = {}
+
+    def fake_create_engine(url, **kwargs):  # type: ignore[override]
+        captured["url"] = url
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(url=url)
+
+    monkeypatch.setenv("DB_POOL_SIZE", "9")
+    monkeypatch.setenv("DB_POOL_MAX_OVERFLOW", "2")
+    monkeypatch.setenv("DB_POOL_TIMEOUT", "15")
+    monkeypatch.setenv("DB_POOL_RECYCLE", "600")
+    monkeypatch.setenv("DB_EXECUTEMANY_BATCH_SIZE", "123")
+    monkeypatch.setenv("PG_PREPARE_THRESHOLD", "2")
+    monkeypatch.setenv("PG_PREPARED_STATEMENT_CACHE_SIZE", "300")
+
+    monkeypatch.setattr(session_module, "create_engine", fake_create_engine)
+
+    engine = session_module.build_engine("postgresql+psycopg://user:pass@localhost/dbname")
+
+    assert isinstance(engine, SimpleNamespace)
+
+    kwargs = cast(dict[str, Any], captured["kwargs"])
+    assert kwargs["pool_size"] == 9
+    assert kwargs["max_overflow"] == 2
+    assert kwargs["pool_timeout"] == 15
+    assert kwargs["pool_recycle"] == 600
+    assert kwargs["pool_pre_ping"] is True
+    assert kwargs["executemany_mode"] == "values_plus_batch"
+    assert kwargs["executemany_parameters"] == {"batch_size": 123}
+
+    url = cast(URL, captured["url"])
+    assert url.query["prepare_threshold"] == "2"
+    assert url.query["prepared_statement_cache_size"] == "300"


### PR DESCRIPTION
## Summary
- centralize engine construction so Postgres connections use pooling, prepared statement hints, and statement batching
- add a composite `(kind, name)` index for traditional run lookups and ensure required indexes exist via Alembic
- cover the Postgres configuration path with a focused unit test

## Testing
- pytest *(fails: existing ImportError loading astroengine.config.apply_narrative_profile_overlay)*
- pytest tests/test_db_session_config.py


------
https://chatgpt.com/codex/tasks/task_e_68e2fcd5999883249d19df4398fcff0a