### PR TITLE
Add safe Lots formula parser and validation

### DIFF
--- a/app/routers/lots.py
+++ b/app/routers/lots.py
@@ -20,6 +20,7 @@ from core.lots_plus.catalog import (
     compute_lots,
     register_lot,
 )
+from core.lots_plus.parser import FormulaSyntaxError, parse_formula
 
 router = APIRouter(prefix="", tags=["Plus"])
 
@@ -57,6 +58,12 @@ def _persist_custom_lots(custom_lots: List[LotDefIn]) -> Dict[str, LotDef]:
                 status_code=400,
                 detail="custom_lots entries require name/day/night",
             )
+        try:
+            parse_formula(c.day)
+            parse_formula(c.night)
+        except FormulaSyntaxError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
         definition = LotDef(
             name=c.name,
             day=c.day,

--- a/core/lots_plus/__init__.py
+++ b/core/lots_plus/__init__.py
@@ -11,12 +11,19 @@ from .catalog import (
     register_lot,
     unregister_lot,
 )
+from .parser import (
+    FormulaSyntaxError,
+    extract_symbols,
+    parse_formula,
+    validate_formula,
+)
 
 __all__ = [
     "eval_formula",
     "norm360",
     "deg_add",
     "deg_sub",
+    "FormulaSyntaxError",
     "LotDef",
     "Sect",
     "BUILTIN",
@@ -25,4 +32,7 @@ __all__ = [
     "compute_lots",
     "register_lot",
     "unregister_lot",
+    "extract_symbols",
+    "parse_formula",
+    "validate_formula",
 ]

--- a/core/lots_plus/catalog.py
+++ b/core/lots_plus/catalog.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, Iterable, Optional, Set
 
 from core.lots_plus.engine import eval_formula
+from core.lots_plus.parser import extract_symbols
 
 
 @dataclass
@@ -48,20 +49,6 @@ class Sect:
     NIGHT = "night"
 
 
-def _extract_symbols(expr: str) -> Set[str]:
-    symbols: Set[str] = set()
-    for raw in expr.replace('+', ' ').replace('-', ' ').split():
-        token = raw.strip()
-        if not token:
-            continue
-        try:
-            float(token)
-        except ValueError:
-            if token.replace('_', '').isalnum():
-                symbols.add(token)
-    return symbols
-
-
 def compute_lot(name: str, pos: Dict[str, float], sect: str, _stack: Optional[Set[str]] = None) -> float:
     if sect not in (Sect.DAY, Sect.NIGHT):
         raise ValueError(f"Invalid sect: {sect}")
@@ -78,7 +65,7 @@ def compute_lot(name: str, pos: Dict[str, float], sect: str, _stack: Optional[Se
 
     # Prepare a working copy of positions so we can inject dependent lot values.
     working_pos = dict(pos)
-    for symbol in _extract_symbols(expr):
+    for symbol in extract_symbols(expr):
         if symbol in working_pos or symbol == name:
             continue
         if symbol in REGISTRY:

--- a/core/lots_plus/engine.py
+++ b/core/lots_plus/engine.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import Dict, List, Tuple, Union
+from typing import Dict
 
-Number = Union[int, float]
+from core.lots_plus.parser import Number, Term, parse_formula
 
 # --------------------------- Angle utils -----------------------------------
 
@@ -19,62 +18,11 @@ def deg_sub(a: float, b: float) -> float:
     return norm360(float(a) - float(b))
 
 
-# --------------------------- Formula parser --------------------------------
-# Minimal DSL: tokens separated by space. Allowed tokens:
-#   - Symbol names: [A-Za-z0-9_]+ (e.g., Asc, Sun, Moon, Lot_Foo)
-#   - Numbers: 0..360 (floats allowed)
-#   - Operators: '+' '-'
-# Grammar: Expr := Term { ('+'|'-') Term }*
-# Term  := Symbol | Number
-
-@dataclass
-class Term:
-    kind: str  # 'sym' or 'num'
-    value: Union[str, float]
-
-
-def _tokenize(expr: str) -> List[str]:
-    # Allow arbitrary whitespace
-    parts = expr.replace("\t", " ").strip().split()
-    if not parts:
-        raise ValueError("Empty formula expression")
-    return parts
-
-
-def _parse(expr: str) -> List[Tuple[str, Term]]:
-    toks = _tokenize(expr)
-    out: List[Tuple[str, Term]] = []
-    op = '+'  # implicit leading '+'
-    expect_term = True
-    for tk in toks:
-        if expect_term:
-            # term
-            try:
-                val = float(tk)
-                term = Term('num', float(val))
-            except ValueError:
-                # symbol
-                if not tk.replace('_', '').isalnum():
-                    raise ValueError(f"Invalid symbol: {tk}")
-                term = Term('sym', tk)
-            out.append((op, term))
-            expect_term = False
-        else:
-            # operator
-            if tk not in ('+', '-'):
-                raise ValueError(f"Expected operator '+/-', got: {tk}")
-            op = tk
-            expect_term = True
-    if expect_term:
-        raise ValueError("Formula ended with operator; missing term")
-    return out
-
-
 def eval_formula(expr: str, pos: Dict[str, float]) -> float:
     """Evaluate an expression at positions `pos`.
     Unknown symbols raise KeyError.
     """
-    seq = _parse(expr)
+    seq = parse_formula(expr)
     acc = 0.0
     for op, term in seq:
         if term.kind == 'num':

--- a/core/lots_plus/parser.py
+++ b/core/lots_plus/parser.py
@@ -1,0 +1,113 @@
+"""Parser for the Lots mini-DSL used by the sandbox and API."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Collection, List, Sequence, Tuple, Union
+
+Number = Union[int, float]
+
+
+class FormulaSyntaxError(ValueError):
+    """Raised when a formula cannot be parsed safely."""
+
+
+@dataclass(frozen=True)
+class Term:
+    """Single term in a Lots expression."""
+
+    kind: str  # ``"num"`` or ``"sym"``
+    value: Union[str, float]
+
+
+def _tokenize(expr: str) -> List[str]:
+    tokens = expr.replace("\t", " ").split()
+    if not tokens:
+        raise FormulaSyntaxError("Formula must not be empty")
+    return tokens
+
+
+def _is_symbol(token: str) -> bool:
+    return token.replace("_", "").isalnum()
+
+
+def parse_formula(expr: str) -> List[Tuple[str, Term]]:
+    """Parse ``expr`` into a sequence of ``(op, Term)`` pairs.
+
+    The parser only understands ``+`` and ``-`` operators and treats every
+    non-numeric token as an identifier consisting of alphanumeric characters
+    or underscores. Any other character results in :class:`FormulaSyntaxError`.
+    """
+
+    tokens = _tokenize(expr)
+    result: List[Tuple[str, Term]] = []
+    op = "+"
+    expect_term = True
+
+    for token in tokens:
+        if expect_term:
+            if token in {"+", "-"}:
+                raise FormulaSyntaxError("Formula cannot have consecutive operators")
+            try:
+                value = float(token)
+            except ValueError:
+                if not _is_symbol(token):
+                    raise FormulaSyntaxError(f"Invalid symbol '{token}'")
+                term = Term("sym", token)
+            else:
+                term = Term("num", value)
+            result.append((op, term))
+            expect_term = False
+        else:
+            if token not in {"+", "-"}:
+                raise FormulaSyntaxError("Expected '+' or '-' between terms")
+            op = token
+            expect_term = True
+
+    if expect_term:
+        raise FormulaSyntaxError("Formula cannot end with an operator")
+
+    return result
+
+
+def extract_symbols(expr: str) -> List[str]:
+    """Return symbol names referenced in ``expr`` preserving order."""
+
+    symbols: List[str] = []
+    for _, term in parse_formula(expr):
+        if term.kind == "sym":
+            symbols.append(str(term.value))
+    return symbols
+
+
+def validate_formula(expr: str, allowed_symbols: Collection[str] | None = None) -> Sequence[Tuple[str, Term]]:
+    """Parse ``expr`` and optionally ensure identifiers belong to ``allowed_symbols``.
+
+    ``allowed_symbols`` comparison is case-insensitive.
+    """
+
+    terms = parse_formula(expr)
+    if allowed_symbols is None:
+        return terms
+
+    normalized = {symbol.lower() for symbol in allowed_symbols}
+    invalid = {
+        str(term.value)
+        for _, term in terms
+        if term.kind == "sym" and term.value.lower() not in normalized
+    }
+    if invalid:
+        ordered = sorted(invalid)
+        raise FormulaSyntaxError(f"Unknown symbols: {', '.join(ordered)}")
+    return terms
+
+
+__all__ = [
+    "FormulaSyntaxError",
+    "Number",
+    "Term",
+    "extract_symbols",
+    "parse_formula",
+    "validate_formula",
+]
+

--- a/tests/test_lots_engine.py
+++ b/tests/test_lots_engine.py
@@ -1,5 +1,8 @@
+import pytest
+
 from core.lots_plus.engine import eval_formula, norm360
 from core.lots_plus.catalog import compute_lot, compute_lots, LotDef, register_lot, Sect
+from core.lots_plus.parser import FormulaSyntaxError, extract_symbols, parse_formula, validate_formula
 
 
 def test_eval_formula_basic_and_wrap():
@@ -7,6 +10,23 @@ def test_eval_formula_basic_and_wrap():
     # 350 + 20 - 10 = 360 → 0
     val = eval_formula("Asc + Moon - Sun", pos)
     assert abs(val - 0.0) < 1e-9
+
+
+def test_parse_formula_rejects_unknown_tokens():
+    with pytest.raises(FormulaSyntaxError):
+        parse_formula("Asc + Sun * Moon")
+
+
+def test_validate_formula_with_allowlist():
+    allowed = {"Asc", "Sun", "Moon"}
+    validate_formula("Asc + Moon - Sun", allowed_symbols=allowed)
+    with pytest.raises(FormulaSyntaxError):
+        validate_formula("Asc + Jupiter - Sun", allowed_symbols=allowed)
+
+
+def test_extract_symbols_preserves_order():
+    symbols = extract_symbols("Asc + Moon - Sun + Lot_Test")
+    assert symbols == ["Asc", "Moon", "Sun", "Lot_Test"]
 
 
 def test_fortune_and_spirit_day_night():


### PR DESCRIPTION
## Summary
- add a reusable parser module for the Lots DSL with strict token validation
- update evaluation, catalog, and API layers to consume the safe parser
- extend tests to cover parser behaviour and whitelist enforcement

## Testing
- `pytest tests/test_lots_engine.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2fcefb4b083249d8b51d95d97e60b