### PR TITLE
Add sandbox validation for user plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -100,6 +100,18 @@ astroengine plugins --entrypoints --detectors --score-extensions
 The command prints loaded entry points, detector names, score extension
 namespaces, and UI panels. ``--json`` produces a machine-readable summary.
 
+## User plugin sandboxing
+
+AstroEngine loads user-supplied aspect and lot definitions from the
+``ASTROENGINE_PLUGIN_DIR`` directory (``~/.astroengine/plugins`` by default).
+Each ``.py`` file is parsed before execution to enforce a conservative
+import allow list: standard-library modules and the public ``astroengine``
+package hierarchy are permitted, while third-party imports are rejected.
+Disallowed imports or runtime errors are recorded and exposed through
+``astroengine.plugins.registry.get_user_plugin_errors()`` so callers and the
+Streamlit settings panel can surface a warning banner. Plugins that fail to
+load are skipped and remain inactive until their issues are corrected.
+
 ## Scan entrypoints
 
 Graphical clients such as ``apps/streamlit_transit_scanner.py`` discover

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -1,10 +1,18 @@
 from __future__ import annotations
 
 import math
+import sys
+from pathlib import Path
+import textwrap
 
 import pytest
 
-from astroengine.plugins import DetectorContext, PluginRuntime, set_plugin_manager
+from astroengine.plugins import (
+    DetectorContext,
+    PluginRuntime,
+    hookimpl,
+    set_plugin_manager,
+)
 from astroengine.plugins.examples import fixed_star_hits
 from astroengine.scoring import ScoreInputs, compute_score
 
@@ -24,6 +32,29 @@ def reset_plugins():
     set_plugin_manager(None)
     yield
     set_plugin_manager(None)
+
+
+@pytest.fixture()
+def user_plugin_workspace(tmp_path, monkeypatch):
+    from astroengine.plugins import registry as plugin_registry
+
+    plugin_dir = tmp_path / "plugins"
+    plugin_dir.mkdir()
+    monkeypatch.setenv("ASTROENGINE_PLUGIN_DIR", str(plugin_dir))
+    original_directory = plugin_registry.PLUGIN_DIRECTORY
+    plugin_registry.PLUGIN_DIRECTORY = plugin_dir
+    plugin_registry._USER_PLUGINS_IMPORTED = False
+    plugin_registry._USER_PLUGIN_MODULES[:] = []
+    plugin_registry._USER_PLUGIN_ERRORS[:] = []
+    yield plugin_dir
+
+    for name in list(sys.modules):
+        if name.startswith(plugin_registry._USER_PLUGIN_NAMESPACE):
+            sys.modules.pop(name, None)
+    plugin_registry._USER_PLUGINS_IMPORTED = False
+    plugin_registry._USER_PLUGIN_MODULES[:] = []
+    plugin_registry._USER_PLUGIN_ERRORS[:] = []
+    plugin_registry.PLUGIN_DIRECTORY = original_directory
 
 
 def _score_inputs() -> ScoreInputs:
@@ -77,3 +108,72 @@ def test_plugin_isolation_between_runtimes():
     set_plugin_manager(runtime_without_plugin)
     score_without = compute_score(_score_inputs())
     assert "fixed_star.bonus" not in score_without.components
+
+
+def test_user_plugin_allowlist_blocks_disallowed_imports(user_plugin_workspace):
+    from astroengine.plugins import registry as plugin_registry
+
+    good_path = user_plugin_workspace / "good.py"
+    good_path.write_text(
+        textwrap.dedent(
+            """
+            import math
+
+            VALUE = math.pi
+            """
+        )
+    )
+    bad_path = user_plugin_workspace / "bad.py"
+    bad_path.write_text("import requests\n")
+
+    modules = plugin_registry.load_user_plugins(force=True)
+    assert f"{plugin_registry._USER_PLUGIN_NAMESPACE}.good" in modules
+    assert all("bad" not in name for name in modules)
+
+    errors = plugin_registry.get_user_plugin_errors()
+    assert errors, "bad plugin should record an error"
+    error_paths = [Path(path) for path, _ in errors]
+    assert bad_path in error_paths
+    assert any("requests" in message for _, message in errors)
+
+
+def test_user_plugin_errors_reset(user_plugin_workspace):
+    from astroengine.plugins import registry as plugin_registry
+
+    bad_path = user_plugin_workspace / "bad.py"
+    bad_path.write_text("import requests\n")
+    plugin_registry.load_user_plugins(force=True)
+    assert plugin_registry.get_user_plugin_errors()
+
+    bad_path.write_text(
+        textwrap.dedent(
+            """
+            import math
+
+            VALUE = 42
+            """
+        )
+    )
+    modules = plugin_registry.load_user_plugins(force=True)
+    assert plugin_registry.get_user_plugin_errors() == ()
+    assert f"{plugin_registry._USER_PLUGIN_NAMESPACE}.bad" in modules
+
+
+def test_score_extension_exceptions_are_isolated():
+    runtime = PluginRuntime(autoload_entrypoints=False)
+
+    class _BadScorePlugin:
+        ASTROENGINE_PLUGIN_API = "1.0"
+
+        @hookimpl
+        def extend_scoring(self, registry):
+            def _boom(inputs, result):
+                raise RuntimeError("boom")
+
+            registry.register("bad_bonus", _boom)
+
+    runtime.register_plugin(_BadScorePlugin())
+    set_plugin_manager(runtime)
+
+    score = compute_score(_score_inputs())
+    assert "bad_bonus.bonus" not in score.components

--- a/ui/streamlit/settings_panel.py
+++ b/ui/streamlit/settings_panel.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import streamlit as st
 
 from astroengine.config import (
@@ -14,6 +16,7 @@ from astroengine.config import (
 from astroengine.plugins.registry import (
     PLUGIN_DIRECTORY,
     ensure_user_plugins_loaded,
+    get_user_plugin_errors,
     iter_aspect_plugins,
     iter_lot_plugins,
 )
@@ -28,6 +31,16 @@ current_settings = load_settings()
 st.sidebar.success(f"Profile: {config_path()}")
 
 ensure_user_plugins_loaded()
+plugin_errors = get_user_plugin_errors()
+if plugin_errors:
+    warning_lines = [
+        "⚠️ Some plugins failed to load. They will remain disabled until the issues are resolved:",
+    ]
+    warning_lines.extend(
+        f"- {Path(path).name}: {message}" for path, message in plugin_errors
+    )
+    warning_lines.append(f"Check {PLUGIN_DIRECTORY} for the affected files.")
+    st.warning("\n".join(warning_lines), icon="⚠️")
 aspect_plugins = list(iter_aspect_plugins())
 lot_plugins = list(iter_lot_plugins())
 


### PR DESCRIPTION
## Summary
- enforce allowlisted imports when loading user plugins and record failures
- guard scoring and post-export hooks against plugin exceptions
- surface plugin load warnings in the Streamlit settings UI and document the sandbox

## Testing
- pytest tests/test_plugins.py

------
https://chatgpt.com/codex/tasks/task_e_68e2fcf50acc8324b3880a1691234f1d