### PR TITLE
Extend diagnostics doctor with infrastructure checks

### DIFF
--- a/astroengine/diagnostics.py
+++ b/astroengine/diagnostics.py
@@ -4,6 +4,8 @@ AstroEngine Diagnostics ("doctor"):
 - Verifies Python version, core imports, optional deps, timezone libs
 - Checks Swiss Ephemeris (pyswisseph) presence and SE_EPHE_PATH contents (if set)
 - Confirms public API types import cleanly
+- Pings the configured database and validates Alembic migration state
+- Reports cache footprint, disk free capacity, and Swiss ephemeris path sanity
 - Optional smoketest against Swiss Ephemeris (Sun..Saturn) if available
 - Outputs human text or JSON; returns non-zero exit on FAIL (and WARN if --strict)
 
@@ -21,13 +23,25 @@ import json
 import os
 import pathlib
 import platform
+import shutil
 import sys
 from dataclasses import asdict, dataclass
 from datetime import UTC
-from typing import Any
+from typing import Any, Iterable
+
+from alembic.config import Config
+from alembic.runtime.migration import MigrationContext
+from alembic.script import ScriptDirectory
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.pool import NullPool
 
 from astroengine.ephemeris import EphemerisAdapter
 from astroengine.ephemeris.swisseph_adapter import swe_calc
+from astroengine.ephemeris.utils import DEFAULT_ENV_KEYS, get_se_ephe_path
+from astroengine.infrastructure.home import ae_home
+from astroengine.infrastructure.paths import project_root
 
 
 @dataclass
@@ -150,6 +164,20 @@ def check_optional_deps() -> list[Check]:
     return out
 
 
+def _format_bytes(num_bytes: int) -> str:
+    if num_bytes <= 0:
+        return "0 B"
+    units: tuple[str, ...] = ("B", "KB", "MB", "GB", "TB", "PB")
+    value = float(num_bytes)
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(value)} {unit}"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} PB"
+
+
 def check_timezone_libs() -> list[Check]:
     out: list[Check] = []
     # zoneinfo (stdlib 3.9+)
@@ -241,6 +269,50 @@ def check_swisseph() -> list[Check]:
     return out
 
 
+def check_ephemeris_path_sanity() -> Check:
+    env_bindings = {
+        key: os.environ.get(key)
+        for key in DEFAULT_ENV_KEYS
+        if os.environ.get(key)
+    }
+    resolved = get_se_ephe_path()
+    data: dict[str, Any] = {"env": env_bindings, "resolved": resolved}
+    if not resolved:
+        return Check(
+            name="Ephemeris path",
+            status="WARN",
+            detail="no Swiss ephemeris path resolved; using built-in fallbacks",
+            data=data,
+        )
+
+    path = pathlib.Path(resolved)
+    data["path"] = str(path)
+    if not path.exists():
+        return Check(
+            name="Ephemeris path",
+            status="FAIL",
+            detail=f"resolved path missing: {path}",
+            data=data,
+        )
+
+    swiss_files = list(path.glob("*.se*"))
+    data["files"] = len(swiss_files)
+    if swiss_files:
+        data["examples"] = [f.name for f in swiss_files[:5]]
+        return Check(
+            name="Ephemeris path",
+            status="PASS",
+            detail=f"{path} ({len(swiss_files)} Swiss ephemeris file(s))",
+            data=data,
+        )
+    return Check(
+        name="Ephemeris path",
+        status="WARN",
+        detail=f"{path} present but no Swiss ephemeris files detected",
+        data=data,
+    )
+
+
 def check_ephemeris_config() -> Check:
     try:
         adapter = EphemerisAdapter()
@@ -262,6 +334,220 @@ def check_ephemeris_config() -> Check:
         status="PASS",
         detail=detail,
         data=summary,
+    )
+
+
+def _resolve_database_url(explicit: str | None = None) -> str:
+    if explicit:
+        return explicit
+    return os.environ.get("DATABASE_URL", "sqlite:///./dev.db")
+
+
+def _mask_database_url(url: str) -> str:
+    try:
+        return make_url(url).render_as_string(hide_password=True)
+    except Exception:  # pragma: no cover - defensive for unparsable URLs
+        return url
+
+
+def check_database_ping(url: str | None = None) -> Check:
+    database_url = _resolve_database_url(url)
+    safe_url = _mask_database_url(database_url)
+    try:
+        engine = create_engine(database_url, future=True, poolclass=NullPool)
+    except Exception as exc:  # pragma: no cover - configuration surface only
+        return Check(
+            name="Database ping",
+            status="FAIL",
+            detail=f"engine creation failed: {exc}",
+            data={"url": safe_url},
+        )
+
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        return Check(
+            name="Database ping",
+            status="PASS",
+            detail=f"connected to {safe_url}",
+            data={"url": safe_url},
+        )
+    except SQLAlchemyError as exc:
+        return Check(
+            name="Database ping",
+            status="FAIL",
+            detail=f"connection failed: {exc}",
+            data={"url": safe_url},
+        )
+    finally:
+        engine.dispose()
+
+
+def _alembic_config(database_url: str) -> Config | None:
+    ini_path = project_root() / "alembic.ini"
+    if not ini_path.exists():
+        return None
+    cfg = Config(str(ini_path))
+    cfg.set_main_option("sqlalchemy.url", database_url)
+    return cfg
+
+
+def check_migrations_current(url: str | None = None) -> Check:
+    database_url = _resolve_database_url(url)
+    safe_url = _mask_database_url(database_url)
+    cfg = _alembic_config(database_url)
+    if cfg is None:
+        return Check(
+            name="Migrations",
+            status="WARN",
+            detail="alembic.ini not found; cannot verify migration state",
+            data={"url": safe_url},
+        )
+
+    script = ScriptDirectory.from_config(cfg)
+    heads = list(script.get_heads())
+    head = script.get_current_head()
+    try:
+        engine = create_engine(database_url, future=True, poolclass=NullPool)
+    except Exception as exc:  # pragma: no cover - configuration surface only
+        return Check(
+            name="Migrations",
+            status="FAIL",
+            detail=f"engine creation failed: {exc}",
+            data={"url": safe_url, "heads": heads},
+        )
+
+    try:
+        with engine.connect() as conn:
+            context = MigrationContext.configure(conn)
+            current = context.get_current_revision()
+    except Exception as exc:
+        return Check(
+            name="Migrations",
+            status="FAIL",
+            detail=f"unable to inspect revision: {exc}",
+            data={"url": safe_url, "heads": heads},
+        )
+    finally:
+        engine.dispose()
+
+    data = {"url": safe_url, "current": current, "head": head, "heads": heads}
+    if not heads:
+        return Check(
+            name="Migrations",
+            status="WARN",
+            detail="no Alembic heads found in migrations directory",
+            data=data,
+        )
+    if current is None:
+        return Check(
+            name="Migrations",
+            status="WARN",
+            detail=f"database not stamped; latest head {head}",
+            data=data,
+        )
+    if current not in heads:
+        return Check(
+            name="Migrations",
+            status="FAIL",
+            detail=f"database at {current}; expected {head}",
+            data=data,
+        )
+    return Check(
+        name="Migrations",
+        status="PASS",
+        detail=f"database revision {current} matches head {head}",
+        data=data,
+    )
+
+
+def _cache_directory() -> pathlib.Path:
+    return ae_home() / "cache"
+
+
+def check_cache_sizes() -> Check:
+    cache_dir = _cache_directory()
+    if not cache_dir.exists():
+        return Check(
+            name="Cache usage",
+            status="PASS",
+            detail="cache directory not initialised",
+            data={"path": str(cache_dir), "files": 0, "total_bytes": 0},
+        )
+
+    total = 0
+    file_entries: list[tuple[str, int]] = []
+    for path in cache_dir.rglob("*"):
+        if path.is_file():
+            size = path.stat().st_size
+            total += size
+            file_entries.append((str(path.relative_to(cache_dir)), size))
+
+    file_entries.sort(key=lambda item: item[1], reverse=True)
+    top_entries = file_entries[:5]
+    detail = (
+        f"{_format_bytes(total)} across {len(file_entries)} file(s) under {cache_dir}"
+    )
+    data = {
+        "path": str(cache_dir),
+        "files": len(file_entries),
+        "total_bytes": total,
+        "top": top_entries,
+    }
+    return Check(name="Cache usage", status="PASS", detail=detail, data=data)
+
+
+def check_disk_free(path: pathlib.Path | None = None) -> Check:
+    target = path or ae_home()
+    target.mkdir(parents=True, exist_ok=True)
+    usage = shutil.disk_usage(target)
+    free = usage.free
+    used_pct = (usage.used / usage.total * 100) if usage.total else 0.0
+    threshold = 512 * 1024 * 1024  # 512 MiB
+    status = "PASS" if free >= threshold else "WARN"
+    detail = (
+        f"{_format_bytes(free)} free ({used_pct:.1f}% used) on volume hosting {target}"
+    )
+    data = {
+        "path": str(target),
+        "total_bytes": usage.total,
+        "used_bytes": usage.used,
+        "free_bytes": free,
+        "threshold_bytes": threshold,
+    }
+    return Check(name="Disk space", status=status, detail=detail, data=data)
+
+
+def _trim_probe_rows(rows: Iterable[dict[str, Any]], limit: int = 5) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for idx, row in enumerate(rows):
+        if idx >= limit:
+            break
+        out.append(row)
+    return out
+
+
+def check_swiss_probes(iso_utc: str = "2025-01-01T00:00:00Z") -> Check:
+    rows = smoketest_positions(iso_utc)
+    sample = _trim_probe_rows(rows)
+    errors = [r for r in rows if r.get("body") == "ERROR"]
+    successes = [r for r in rows if "lon_deg" in r]
+    infos = [r for r in rows if r.get("body") == "INFO"]
+    data = {"timestamp": iso_utc, "sample": sample}
+    if errors:
+        detail = errors[0].get("detail", "Swiss probe failed")
+        return Check(name="Swiss probes", status="FAIL", detail=detail, data=data)
+    if successes:
+        detail = f"computed {len(successes)} Swiss ephemeris position(s)"
+        return Check(name="Swiss probes", status="PASS", detail=detail, data=data)
+    if infos:
+        detail = infos[0].get("detail", "Swiss ephemeris unavailable")
+        return Check(name="Swiss probes", status="WARN", detail=detail, data=data)
+    return Check(
+        name="Swiss probes",
+        status="WARN",
+        detail="no Swiss ephemeris data returned",
+        data=data,
     )
 
 
@@ -299,7 +585,13 @@ def collect_diagnostics(strict: bool = False) -> dict[str, Any]:
     checks.extend(check_optional_deps())
     checks.extend(check_timezone_libs())
     checks.extend(check_swisseph())
+    checks.append(check_ephemeris_path_sanity())
     checks.append(check_ephemeris_config())
+    checks.append(check_database_ping())
+    checks.append(check_migrations_current())
+    checks.append(check_cache_sizes())
+    checks.append(check_disk_free())
+    checks.append(check_swiss_probes())
     checks.append(check_profiles_presence())
     # summarize
     worst = max((c.status for c in checks), key=_status_order, default="PASS")


### PR DESCRIPTION
## Summary
- add database connectivity and Alembic migration status checks to the diagnostics doctor
- surface cache usage, disk capacity, and Swiss ephemeris path sanity in the report alongside new Swiss probe results
- refresh the module documentation to describe the expanded system doctor coverage

## Testing
- pytest *(fails: existing ImportError for astroengine.config overlay imports during test collection)*
- python -m astroengine.diagnostics --json

------
https://chatgpt.com/codex/tasks/task_e_68e2fd0c0d2c8324a0d81d5e637c391b