### PR TITLE
Add Streamlit error instrumentation with toast IDs

### DIFF
--- a/st_shim/__init__.py
+++ b/st_shim/__init__.py
@@ -21,6 +21,7 @@ __all__ = [
     "expander",
     "number_input",
     "plotly_chart",
+    "toast",
     "radio",
     "spinner",
     "set_runtime",
@@ -290,6 +291,18 @@ def warning(*_args: Any, **_kwargs: Any) -> None:
 
 def error(*_args: Any, **_kwargs: Any) -> None:
     pass
+
+
+class _ToastStub:
+    def caption(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def code(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+
+def toast(*_args: Any, **_kwargs: Any) -> _ToastStub:
+    return _ToastStub()
 
 
 def code(*_args: Any, **_kwargs: Any) -> None:

--- a/tests/streamlit/test_error_surface.py
+++ b/tests/streamlit/test_error_surface.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import streamlit as st
+import ui.streamlit  # noqa: F401 - trigger error instrumentation on import
+
+
+@pytest.mark.usefixtures("caplog")
+def test_streamlit_error_emits_toast_and_logs(monkeypatch, caplog):
+    recorded: dict[str, list[str] | str] = {}
+
+    class _ToastRecorder:
+        def __init__(self, message: str, icon: str | None) -> None:
+            recorded["message"] = message
+            recorded["icon"] = icon or ""
+            recorded.setdefault("captions", [])
+            recorded.setdefault("codes", [])
+
+        def caption(self, text: str) -> None:
+            assert isinstance(recorded.get("captions"), list)
+            recorded["captions"].append(text)
+
+        def code(self, text: str, *, language: str | None = None) -> None:  # noqa: ARG002 - API parity
+            assert isinstance(recorded.get("codes"), list)
+            recorded["codes"].append(text)
+
+    def fake_toast(message: str, *, icon: str | None = None) -> _ToastRecorder:
+        return _ToastRecorder(message, icon)
+
+    monkeypatch.setattr(st, "toast", fake_toast)
+    caplog.set_level(logging.ERROR)
+
+    result = st.error("Boom")
+
+    assert "message" in recorded and recorded["message"] == "Boom"
+    assert recorded.get("icon") == "⚠️"
+    assert recorded.get("captions") == ["Error ID (click to copy):"]
+    assert len(recorded.get("codes", [])) == 1
+
+    record = caplog.records[-1]
+    assert hasattr(record, "error_id")
+    error_id = getattr(record, "error_id")
+    assert isinstance(error_id, str)
+    assert len(error_id) == 12
+    assert error_id.isupper()
+    assert error_id == recorded["codes"][0]
+    assert record.message == f"Error {error_id}: Boom"
+
+    if result is not None:
+        assert getattr(result, "error_id", error_id) == error_id

--- a/ui/streamlit/__init__.py
+++ b/ui/streamlit/__init__.py
@@ -1,0 +1,87 @@
+"""Streamlit UI helpers and global configuration hooks."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+try:  # pragma: no cover - import guard for optional dependency
+    import streamlit as _st
+except ModuleNotFoundError as exc:  # pragma: no cover - defensive
+    raise RuntimeError("Streamlit must be available to use ui.streamlit") from exc
+
+_LOG = logging.getLogger("ui.streamlit.errors")
+
+
+def _render_error_id(container: Any, error_id: str) -> None:
+    """Attach a caption/code snippet with the error identifier to ``container``."""
+
+    if container is None:
+        return
+    try:
+        caption = getattr(container, "caption", None)
+        code = getattr(container, "code", None)
+        if callable(caption):
+            caption("Error ID (click to copy):")
+        if callable(code):
+            code(error_id, language=None)
+    except Exception:  # pragma: no cover - UI rendering best-effort
+        pass
+
+
+def _normalize_exc_info(exc_info: Any) -> Any:
+    """Convert ``exc_info`` into a ``logging``-friendly shape."""
+
+    if isinstance(exc_info, BaseException):
+        return (type(exc_info), exc_info, exc_info.__traceback__)
+    return exc_info
+
+
+def _install_error_wrapper() -> None:
+    """Wrap :func:`streamlit.error` with logging + toast instrumentation."""
+
+    if getattr(_st.error, "__astroengine_wrapped__", False):  # pragma: no cover - idempotent
+        return
+
+    original_error = _st.error
+
+    def error_with_tracking(
+        body: Any,
+        icon: str | None = None,
+        *,
+        logger: logging.Logger | logging.LoggerAdapter | None = None,
+        exc_info: Any | None = None,
+    ):
+        error_id = uuid.uuid4().hex[:12].upper()
+        message = "" if body is None else str(body)
+        log = logger or _LOG
+        log_kwargs = {"extra": {"error_id": error_id}}
+        normalized_exc = _normalize_exc_info(exc_info)
+
+        if normalized_exc:
+            log.error("Error %s: %s", error_id, message, exc_info=normalized_exc, **log_kwargs)
+        else:
+            log.error("Error %s: %s", error_id, message, **log_kwargs)
+
+        toast_func = getattr(_st, "toast", None)
+        if callable(toast_func):
+            toast = toast_func(message or "An unexpected error occurred.", icon=icon or "⚠️")
+            _render_error_id(toast, error_id)
+
+        result = original_error(body, icon=icon)
+        _render_error_id(result, error_id)
+
+        try:  # pragma: no cover - attribute may not exist on shim
+            setattr(result, "error_id", error_id)
+        except Exception:
+            pass
+
+        return result
+
+    error_with_tracking.__astroengine_wrapped__ = True  # type: ignore[attr-defined]
+    error_with_tracking.__wrapped__ = original_error  # type: ignore[attr-defined]
+    _st.error = error_with_tracking  # type: ignore[assignment]
+
+
+_install_error_wrapper()


### PR DESCRIPTION
## Summary
- wrap `streamlit.error` during UI initialization to log tagged error IDs and surface a toast with a copyable code
- extend the Streamlit test shim with a minimal `toast` implementation used by the new instrumentation
- add a regression test covering the logging/toast behavior when `st.error` is invoked

## Testing
- pytest tests/streamlit/test_error_surface.py

------
https://chatgpt.com/codex/tasks/task_e_68e2fd119f108324bb876ac04600fec2