### PR TITLE
Add devmode backup scheduling and retention management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+- 2025-10-05 — Added developer-mode backup scheduling, ZIP restore flow, and retention policy controls.

--- a/app/devmode/backups.py
+++ b/app/devmode/backups.py
@@ -1,0 +1,311 @@
+"""Utilities supporting developer-mode backup and restore workflows."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+import zipfile
+from pathlib import Path
+from typing import Iterable, Iterator, Sequence
+
+from astroengine.infrastructure.home import ae_home
+from astroengine.scheduler.queue import cancel, enqueue, get
+from astroengine.scheduler.db import now as queue_now
+from astroengine.infrastructure import retention
+
+BACKUP_GLOB_TARGETS: Sequence[Path] = (
+    Path("profiles"),
+    Path("astroengine/config"),
+    Path("astroengine/chart"),
+    Path("astroengine/profiles"),
+)
+
+HOME_TARGETS: Sequence[Path] = (
+    Path("natals"),
+)
+
+BACKUP_PREFIXES: tuple[str, ...] = (
+    "profiles",
+    "astroengine/config",
+    "astroengine/chart",
+    "astroengine/profiles",
+    ".astroengine",
+)
+
+
+def _backup_root() -> Path:
+    root = ae_home() / "backups"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _schedule_path() -> Path:
+    path = ae_home() / "backup_schedule.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _retention_summary_path() -> Path:
+    return ae_home() / "backup_retention_summary.json"
+
+
+def _iter_files(base: Path) -> Iterator[Path]:
+    for path in base.rglob("*"):
+        if path.is_file():
+            yield path
+
+
+def _arcname_for(path: Path, *, project_root: Path, home_root: Path) -> Path:
+    try:
+        relative_home = path.relative_to(home_root)
+        return Path(".astroengine") / relative_home
+    except ValueError:
+        pass
+    try:
+        relative = path.relative_to(project_root)
+        return relative
+    except ValueError:
+        pass
+    raise ValueError(f"Path {path} is outside backup roots")
+
+
+def _targets(project_root: Path, home_root: Path) -> Iterable[Path]:
+    for rel in BACKUP_GLOB_TARGETS:
+        candidate = project_root / rel
+        if candidate.exists():
+            yield candidate
+    for rel in HOME_TARGETS:
+        candidate = home_root / rel
+        if candidate.exists():
+            yield candidate
+
+
+def _iso(ts: float | int | None) -> str | None:
+    if ts is None:
+        return None
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(ts))
+
+
+def create_backup_zip(
+    root: str | Path = ".",
+    *,
+    timestamp: float | None = None,
+) -> Path:
+    """Create a zip archive of key charts/config/profile artefacts."""
+
+    project_root = Path(root).resolve()
+    home_root = ae_home().resolve()
+    backup_root = _backup_root()
+    ts_struct = time.gmtime(timestamp or time.time())
+    label = time.strftime("%Y%m%d_%H%M%S", ts_struct)
+    archive_path = backup_root / f"astroengine_backup_{label}.zip"
+
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for target in _targets(project_root, home_root):
+            for file_path in _iter_files(target):
+                arcname = _arcname_for(
+                    file_path, project_root=project_root, home_root=home_root
+                )
+                archive.write(file_path, arcname.as_posix())
+    return archive_path
+
+
+def list_backups(limit: int = 50) -> list[dict[str, object]]:
+    root = _backup_root()
+    items: list[tuple[float, Path]] = []
+    for path in root.glob("*.zip"):
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        items.append((mtime, path))
+    items.sort(reverse=True, key=lambda x: x[0])
+    result: list[dict[str, object]] = []
+    for _, path in items[:limit]:
+        stat = path.stat()
+        result.append(
+            {
+                "name": path.name,
+                "path": str(path),
+                "size": stat.st_size,
+                "modified": stat.st_mtime,
+                "modified_iso": _iso(stat.st_mtime),
+            }
+        )
+    return result
+
+
+def load_schedule() -> dict:
+    path = _schedule_path()
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+
+
+def save_schedule(data: dict) -> None:
+    path = _schedule_path()
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def cancel_backup_schedule() -> dict[str, object]:
+    schedule = load_schedule()
+    job_id = schedule.get("job_id")
+    if job_id:
+        try:
+            cancel(str(job_id))
+        except Exception:
+            pass
+    path = _schedule_path()
+    if path.exists():
+        path.unlink()
+    return {"status": "canceled"}
+
+
+def schedule_backups(
+    *,
+    interval_hours: float,
+    root: str | Path = ".",
+    start_at: float | None = None,
+    now_ts: float | None = None,
+) -> dict[str, object]:
+    if interval_hours <= 0:
+        return cancel_backup_schedule()
+
+    schedule = load_schedule()
+    if "job_id" in schedule:
+        try:
+            cancel(str(schedule["job_id"]))
+        except Exception:
+            pass
+
+    project_root = Path(root).resolve()
+    current = now_ts if now_ts is not None else queue_now()
+    interval_seconds = int(interval_hours * 3600)
+    first_run = int(start_at if start_at is not None else current + interval_seconds)
+    payload = {"root": str(project_root)}
+    job_id = enqueue("backup:zip", payload, run_at=first_run)
+    schedule.update(
+        {
+            "interval_seconds": interval_seconds,
+            "next_run": first_run,
+            "job_id": job_id,
+            "root": str(project_root),
+        }
+    )
+    save_schedule(schedule)
+    return schedule
+
+
+def restore_backup_zip(archive: str | Path, root: str | Path = ".") -> list[str]:
+    archive_path = Path(archive)
+    if not archive_path.exists():
+        raise FileNotFoundError(f"Backup archive not found: {archive_path}")
+
+    project_root = Path(root).resolve()
+    home_root = ae_home().resolve()
+    restored: list[str] = []
+
+    with zipfile.ZipFile(archive_path, "r") as zf:
+        for info in zf.infolist():
+            name = info.filename
+            if not name or name.endswith("/"):
+                continue
+            arc = Path(name)
+            if any(part == ".." for part in arc.parts):
+                raise ValueError(f"Unsafe archive member: {name}")
+            if not any(
+                arc == Path(prefix) or str(arc).startswith(f"{prefix}/")
+                for prefix in BACKUP_PREFIXES
+            ):
+                continue
+            if arc.parts[0] == ".astroengine":
+                destination = home_root / Path(*arc.parts[1:])
+            else:
+                destination = project_root / arc
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info, "r") as src, open(destination, "wb") as dst:
+                shutil.copyfileobj(src, dst)
+            restored.append(str(destination))
+    return restored
+
+
+def schedule_status() -> dict[str, object]:
+    schedule = load_schedule()
+    if not schedule:
+        return {}
+
+    result = dict(schedule)
+    for key in ("next_run", "last_run"):
+        if key in result and result[key] is not None:
+            result[f"{key}_iso"] = _iso(result[key])
+    job_id = result.get("job_id")
+    if job_id:
+        job = get(str(job_id))
+        if job:
+            result["job_state"] = job.get("state")
+    return result
+
+
+def run_backup_job(payload: dict[str, object]) -> dict[str, object]:
+    project_root = Path(str(payload.get("root", "."))).resolve()
+    archive_path = create_backup_zip(project_root)
+    stat = archive_path.stat()
+    now_ts = queue_now()
+    schedule = load_schedule()
+    schedule.update(
+        {
+            "last_run": now_ts,
+            "last_backup": str(archive_path),
+            "last_backup_size": stat.st_size,
+        }
+    )
+
+    retention_summary = retention.purge_temporary_derivatives()
+    if retention_summary:
+        (_retention_summary_path()).write_text(
+            json.dumps(retention_summary, indent=2), encoding="utf-8"
+        )
+        schedule["last_retention"] = retention_summary
+
+    interval = int(schedule.get("interval_seconds" or 0))
+    new_job_id = None
+    if interval > 0:
+        next_run = now_ts + interval
+        new_job_id = enqueue(
+            "backup:zip", {"root": str(project_root)}, run_at=int(next_run)
+        )
+        schedule["next_run"] = int(next_run)
+        schedule["job_id"] = new_job_id
+    else:
+        schedule.pop("job_id", None)
+        schedule.pop("next_run", None)
+
+    save_schedule(schedule)
+    return {
+        "archive": str(archive_path),
+        "size": stat.st_size,
+        "timestamp": now_ts,
+        "retention": retention_summary,
+        "next_job": new_job_id,
+    }
+
+
+__all__ = [
+    "BACKUP_GLOB_TARGETS",
+    "BACKUP_PREFIXES",
+    "HOME_TARGETS",
+    "cancel_backup_schedule",
+    "create_backup_zip",
+    "list_backups",
+    "load_schedule",
+    "restore_backup_zip",
+    "run_backup_job",
+    "save_schedule",
+    "schedule_backups",
+    "schedule_status",
+]
+

--- a/astroengine/infrastructure/retention.py
+++ b/astroengine/infrastructure/retention.py
@@ -1,0 +1,109 @@
+"""Retention policy utilities for AstroEngine derived artefacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+from .home import ae_home
+
+POLICY_FILE_NAME = "retention_policy.json"
+DERIVATIVE_DIR = "derivatives"
+
+
+def _policy_path() -> Path:
+    path = ae_home() / POLICY_FILE_NAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _derivative_root() -> Path:
+    root = ae_home() / DERIVATIVE_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def load_policy() -> dict[str, Any]:
+    path = _policy_path()
+    if not path.exists():
+        return {"temporary_derivatives_days": 7}
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"temporary_derivatives_days": 7}
+
+
+def save_policy(policy: dict[str, Any]) -> None:
+    path = _policy_path()
+    path.write_text(json.dumps(policy, indent=2), encoding="utf-8")
+
+
+def _remove_empty_dirs(root: Path) -> int:
+    removed = 0
+    for dirpath, _, _ in os.walk(root, topdown=False):
+        dir_path = Path(dirpath)
+        if dir_path == root:
+            continue
+        try:
+            dir_path.rmdir()
+            removed += 1
+        except OSError:
+            continue
+    return removed
+
+
+def purge_temporary_derivatives(
+    *,
+    now: float | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    policy = load_policy()
+    retention_days = policy.get("temporary_derivatives_days")
+    result: dict[str, Any] = {
+        "policy_days": retention_days,
+        "dry_run": dry_run,
+        "eligible": 0,
+        "deleted": 0,
+        "scanned": 0,
+        "root": str(_derivative_root()),
+        "cutoff": None,
+    }
+
+    if not retention_days or retention_days <= 0:
+        return result
+
+    root = _derivative_root()
+    current_time = now if now is not None else time.time()
+    cutoff = current_time - (float(retention_days) * 86400)
+    result["cutoff"] = cutoff
+
+    for path in sorted(root.rglob("*")):
+        if path.is_dir():
+            continue
+        result["scanned"] += 1
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        if mtime < cutoff:
+            result["eligible"] += 1
+            if not dry_run:
+                try:
+                    path.unlink()
+                    result["deleted"] += 1
+                except OSError:
+                    continue
+
+    if not dry_run:
+        result["directories_removed"] = _remove_empty_dirs(root)
+    else:
+        result["directories_removed"] = 0
+
+    return result
+
+
+__all__ = ["load_policy", "save_policy", "purge_temporary_derivatives"]
+

--- a/astroengine/scheduler/worker.py
+++ b/astroengine/scheduler/worker.py
@@ -10,10 +10,12 @@ from typing import Any, Callable
 from .queue import claim_one, done, fail, heartbeat
 from ..detectors.directed_aspects import solar_arc_natal_aspects
 from ..detectors.progressed_aspects import progressed_natal_aspects
+from app.devmode.backups import run_backup_job
 
 HANDLERS: dict[str, Callable[[dict[str, Any]], Any]] = {
     "scan:progressions": lambda payload: progressed_natal_aspects(**payload),
     "scan:directions": lambda payload: solar_arc_natal_aspects(**payload),
+    "backup:zip": run_backup_job,
 }
 
 

--- a/tests/app/devmode/test_api_integration.py
+++ b/tests/app/devmode/test_api_integration.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import importlib
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def devmode_app(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("ASTROENGINE_HOME", str(home))
+    monkeypatch.setenv("DEV_MODE", "1")
+    monkeypatch.setenv("DEV_VALIDATE_COMMANDS", "echo ok")
+
+    import app.devmode.backups as backups_mod
+    import astroengine.infrastructure.retention as retention_mod
+    import app.devmode.api as api_mod
+
+    importlib.reload(retention_mod)
+    importlib.reload(backups_mod)
+    importlib.reload(api_mod)
+
+    app = FastAPI()
+    app.include_router(api_mod.router)
+    client = TestClient(app)
+    return client, tmp_path
+
+
+def test_dev_apply_records_history(devmode_app):
+    client, root = devmode_app
+    (root / "app/devmode").mkdir(parents=True, exist_ok=True)
+
+    diff = textwrap.dedent(
+        """
+        diff --git a/app/devmode/sample.txt b/app/devmode/sample.txt
+        new file mode 100644
+        index 0000000..e69de29
+        --- /dev/null
+        +++ b/app/devmode/sample.txt
+        @@ -0,0 +1 @@
+        +hello world
+        """
+    )
+
+    payload = {
+        "diff": diff,
+        "message": "test patch",
+        "user": "tester",
+    }
+
+    response = client.post("/v1/dev/apply", json=payload)
+    assert response.status_code == 200, response.json()
+
+    history_path = root / ".astroengine/version_history.json"
+    changelog_path = root / "CHANGELOG.md"
+    assert history_path.exists()
+    assert changelog_path.exists()
+
+    history = json.loads(history_path.read_text(encoding="utf-8"))
+    assert history
+    latest = history[-1]
+    assert latest["message"] == "test patch"
+    assert latest["commit"]
+
+    changelog = changelog_path.read_text(encoding="utf-8")
+    assert "test patch" in changelog
+
+
+def test_backup_endpoints(devmode_app):
+    client, root = devmode_app
+    (root / "profiles").mkdir(parents=True, exist_ok=True)
+    (root / "profiles" / "runtime.yaml").write_text("ok: 1", encoding="utf-8")
+
+    run_resp = client.post("/v1/dev/backups/run")
+    assert run_resp.status_code == 200, run_resp.text
+    archive_path = Path(run_resp.json()["archive"])
+    assert archive_path.exists()
+
+    schedule_resp = client.post(
+        "/v1/dev/backups/schedule", json={"interval_hours": 0}
+    )
+    assert schedule_resp.status_code == 200
+    assert schedule_resp.json().get("status") == "canceled"
+
+    list_resp = client.get("/v1/dev/backups")
+    assert list_resp.status_code == 200
+    payload = list_resp.json()
+    assert payload["backups"]
+
+    restore_resp = client.post(
+        "/v1/dev/backups/restore", json={"archive_path": str(archive_path)}
+    )
+    assert restore_resp.status_code == 200
+
+    retention_resp = client.post(
+        "/v1/dev/retention",
+        json={"temporary_derivatives_days": 5, "run_purge": True},
+    )
+    assert retention_resp.status_code == 200
+    assert retention_resp.json()["policy"]["temporary_derivatives_days"] == 5

--- a/tests/app/devmode/test_backups.py
+++ b/tests/app/devmode/test_backups.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+import zipfile
+from pathlib import Path
+
+import importlib
+import pytest
+
+
+@pytest.fixture()
+def devmode_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("ASTROENGINE_HOME", str(home))
+    monkeypatch.setenv("DEV_MODE", "1")
+    yield tmp_path
+
+
+def _reload_modules():
+    import app.devmode.backups as backups_mod
+    import astroengine.infrastructure.retention as retention_mod
+
+    importlib.reload(retention_mod)
+    importlib.reload(backups_mod)
+    return backups_mod, retention_mod
+
+
+def test_create_and_restore_backup(devmode_env):
+    root = devmode_env
+    home = Path(os.environ["ASTROENGINE_HOME"])
+    backups, _ = _reload_modules()
+
+    (root / "profiles").mkdir(parents=True)
+    (root / "astroengine/config").mkdir(parents=True)
+    (root / "astroengine/chart").mkdir(parents=True)
+    (root / "astroengine/profiles").mkdir(parents=True)
+    (home / "natals").mkdir(parents=True, exist_ok=True)
+
+    (root / "profiles" / "default.yaml").write_text("profile: default", encoding="utf-8")
+    (root / "astroengine/config" / "settings.json").write_text(
+        json.dumps({"k": "v"}), encoding="utf-8"
+    )
+    (root / "astroengine/chart" / "template.txt").write_text("chart", encoding="utf-8")
+    (home / "natals" / "user.json").write_text("{}", encoding="utf-8")
+
+    archive = backups.create_backup_zip(root, timestamp=1_700_000_000)
+    assert archive.exists()
+
+    with zipfile.ZipFile(archive, "r") as zf:
+        names = set(zf.namelist())
+    assert "profiles/default.yaml" in names
+    assert "astroengine/config/settings.json" in names
+    assert ".astroengine/natals/user.json" in names
+
+    # Remove files and restore from archive
+    for path in [
+        root / "profiles" / "default.yaml",
+        root / "astroengine/config" / "settings.json",
+        root / "astroengine/chart" / "template.txt",
+        home / "natals" / "user.json",
+    ]:
+        path.unlink()
+
+    restored = backups.restore_backup_zip(archive, root)
+    assert any("default.yaml" in r for r in restored)
+    assert (root / "profiles" / "default.yaml").exists()
+    assert (home / "natals" / "user.json").exists()
+
+
+def test_schedule_and_run_backup_job(devmode_env):
+    root = devmode_env
+    backups, retention_mod = _reload_modules()
+
+    (root / "profiles").mkdir()
+    (root / "profiles" / "snap.txt").write_text("data", encoding="utf-8")
+
+    retention_mod.save_policy({"temporary_derivatives_days": 7})
+    derivatives = Path(os.environ["ASTROENGINE_HOME"]) / "derivatives"
+    derivatives.mkdir(parents=True, exist_ok=True)
+    old_file = derivatives / "old.txt"
+    old_file.write_text("old", encoding="utf-8")
+    old_age = time.time() - (10 * 86400)
+    os.utime(old_file, (old_age, old_age))
+
+    schedule = backups.schedule_backups(interval_hours=1, root=root, now_ts=1_000_000)
+    job_id = schedule.get("job_id")
+    assert job_id
+
+    result = backups.run_backup_job({"root": str(root)})
+    assert Path(result["archive"]).exists()
+    assert result["retention"]["deleted"] >= 1
+    assert not old_file.exists()
+
+    updated_schedule = backups.load_schedule()
+    assert "last_backup" in updated_schedule
+    assert updated_schedule.get("job_id")
+
+
+def test_retention_module_purge(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    home = tmp_path / "home"
+    monkeypatch.setenv("ASTROENGINE_HOME", str(home))
+
+    import astroengine.infrastructure.retention as retention_mod
+
+    importlib.reload(retention_mod)
+
+    policy = {"temporary_derivatives_days": 3}
+    retention_mod.save_policy(policy)
+    root = home / "derivatives"
+    root.mkdir(parents=True, exist_ok=True)
+    old_file = root / "old.bin"
+    new_file = root / "new.bin"
+    old_file.write_text("old", encoding="utf-8")
+    new_file.write_text("new", encoding="utf-8")
+
+    reference = 2_000_000
+    old_age = reference - (5 * 86400)
+    new_age = reference - (1 * 86400)
+    os.utime(old_file, (old_age, old_age))
+    os.utime(new_file, (new_age, new_age))
+
+    preview = retention_mod.purge_temporary_derivatives(now=reference, dry_run=True)
+    assert preview["eligible"] == 1
+    assert old_file.exists()
+
+    result = retention_mod.purge_temporary_derivatives(now=reference)
+    assert result["deleted"] == 1
+    assert not old_file.exists()
+    assert new_file.exists()
+


### PR DESCRIPTION
## Summary
- add developer-mode backup utilities to create, schedule, and restore ZIP archives while integrating retention cleanup
- expose new FastAPI endpoints and Streamlit UI controls for managing backups, schedules, and derivative retention
- cover the workflow with scheduler hooks plus integration and unit tests

## Testing
- pytest tests/app/devmode/test_backups.py tests/app/devmode/test_api_integration.py
- pytest *(fails: missing optional astroengine.config.apply_narrative_profile_overlay import in baseline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fd5f83688324a3ec163db2ff1d00