### PR TITLE
Record natal chart configuration metadata

### DIFF
--- a/astroengine/api/routers/analysis.py
+++ b/astroengine/api/routers/analysis.py
@@ -82,17 +82,19 @@ def _parse_longitudes_payload(value: str | None) -> dict[str, float]:
     return parsed
 
 
-def _chart_config_from_settings(include_nodes: bool) -> tuple[ChartConfig, dict[str, int]]:
+def _chart_config_from_settings(
+    include_nodes: bool, base_config: ChartConfig | None = None
+) -> tuple[ChartConfig, dict[str, int]]:
     settings = get_midpoint_settings()
-    base_config = ChartConfig()
+    chart_config = base_config or ChartConfig()
     bodies = dict(DEFAULT_BODIES)
     if include_nodes:
-        node_variant = base_config.nodes_variant
+        node_variant = chart_config.nodes_variant
         node_code = SE_TRUE_NODE if node_variant == "true" else SE_MEAN_NODE
         label = "True Node" if node_variant == "true" else "Mean Node"
         bodies.setdefault(label, node_code)
         bodies.setdefault("South Node", node_code)
-    return base_config, bodies
+    return chart_config, bodies
 
 
 def _load_natal_longitudes(natal_id: str, include_nodes: bool) -> dict[str, float]:
@@ -121,7 +123,7 @@ def _load_natal_longitudes(natal_id: str, include_nodes: bool) -> dict[str, floa
     else:
         moment = moment.astimezone(timezone.utc)
 
-    config, body_map = _chart_config_from_settings(include_nodes)
+    config, body_map = _chart_config_from_settings(include_nodes, record.chart_config())
     chart = compute_natal_chart(
         moment,
         ChartLocation(latitude=float(record.lat), longitude=float(record.lon)),

--- a/astroengine/api/routers/forecast.py
+++ b/astroengine/api/routers/forecast.py
@@ -103,13 +103,17 @@ def get_forecast_stack(
             detail={"code": "NATAL_NOT_FOUND", "message": f"Natal '{natal_id}' was not found."},
         ) from exc
 
-    location = ChartLocation(latitude=natal.lat, longitude=natal.lon)
+    location = ChartLocation(latitude=float(natal.lat), longitude=float(natal.lon))
     natal_moment = datetime.fromisoformat(natal.utc.replace("Z", "+00:00"))
     if natal_moment.tzinfo is None:
         natal_moment = natal_moment.replace(tzinfo=UTC)
     natal_moment = natal_moment.astimezone(UTC)
 
-    natal_chart = compute_natal_chart(natal_moment, location)
+    natal_chart = compute_natal_chart(
+        natal_moment,
+        location,
+        config=natal.chart_config(),
+    )
     window = ForecastWindow(start=start, end=end)
     chart = ForecastChart(natal_chart=natal_chart, window=window)
 

--- a/astroengine/userdata/vault.py
+++ b/astroengine/userdata/vault.py
@@ -6,6 +6,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 
 from ..infrastructure.home import ae_home
+from ..chart.config import ChartConfig
 
 BASE = ae_home() / "natals"
 BASE.mkdir(parents=True, exist_ok=True)
@@ -20,6 +21,18 @@ class Natal:
     lon: float
     tz: str | None = None
     place: str | None = None
+    house_system: str = "placidus"
+    zodiac: str = "tropical"
+    ayanamsa: str | None = None
+
+    def chart_config(self) -> ChartConfig:
+        """Return a normalized :class:`ChartConfig` for this natal record."""
+
+        return ChartConfig(
+            zodiac=self.zodiac,
+            ayanamsha=self.ayanamsa,
+            house_system=self.house_system,
+        )
 
 
 def _path(natal_id: str) -> Path:
@@ -29,7 +42,13 @@ def _path(natal_id: str) -> Path:
 def save_natal(n: Natal) -> Path:
     p = _path(n.natal_id)
     with open(p, "w", encoding="utf-8") as f:
-        json.dump(asdict(n), f, indent=2)
+        data = asdict(n)
+        data["houses"] = {"system": n.house_system}
+        zodiac_payload: dict[str, object] = {"type": n.zodiac}
+        if n.ayanamsa is not None:
+            zodiac_payload["ayanamsa"] = n.ayanamsa
+        data["zodiac"] = zodiac_payload
+        json.dump(data, f, indent=2)
     return p
 
 
@@ -37,6 +56,19 @@ def load_natal(natal_id: str) -> Natal:
     p = _path(natal_id)
     with open(p, encoding="utf-8") as f:
         data = json.load(f)
+    houses_payload = data.pop("houses", None)
+    if isinstance(houses_payload, dict):
+        system = houses_payload.get("system")
+        if system is not None:
+            data.setdefault("house_system", system)
+    zodiac_payload = data.pop("zodiac", None)
+    if isinstance(zodiac_payload, dict):
+        zodiac_type = zodiac_payload.get("type")
+        if zodiac_type is not None:
+            data.setdefault("zodiac", zodiac_type)
+        if "ayanamsa" in zodiac_payload:
+            ayanamsa_value = zodiac_payload.get("ayanamsa")
+            data.setdefault("ayanamsa", ayanamsa_value)
     return Natal(**data)
 
 

--- a/tests/api/test_natals_endpoint.py
+++ b/tests/api/test_natals_endpoint.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import importlib
+import json
+import os
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+os.environ.setdefault("ASTROENGINE_ENABLE_HTTP_TESTS", "1")
+
+
+@pytest.fixture()
+def client(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> TestClient:
+    monkeypatch.setenv("ASTROENGINE_HOME", str(tmp_path))
+    monkeypatch.setenv("ASTROENGINE_ENABLE_HTTP_TESTS", "1")
+
+    import astroengine.userdata.vault as vault
+
+    importlib.reload(vault)
+    globals()["vault"] = vault
+
+    import astroengine.api.routers.natals as natals_router
+
+    importlib.reload(natals_router)
+
+    from astroengine.api import create_app
+
+    app = create_app()
+    return TestClient(app)
+
+
+def test_upsert_persists_configuration_and_returns_snapshot(client: TestClient, tmp_path: Path) -> None:
+    payload = {
+        "name": "Configurable Chart",
+        "utc": "2000-01-01T00:00:00Z",
+        "lat": 12.34,
+        "lon": 56.78,
+        "tz": "UTC",
+        "place": "Test Location",
+        "houses": {"system": "W"},
+        "zodiac": {"type": "SIDEREAL", "ayanamsa": "Krishnamurti"},
+    }
+
+    response = client.put("/v1/natals/test-subject", json=payload)
+    assert response.status_code == 201
+    body = response.json()
+
+    assert body["houses"]["system"] == "whole_sign"
+    assert body["zodiac"]["type"] == "sidereal"
+    assert body["zodiac"]["ayanamsa"] == "krishnamurti"
+
+    fetch = client.get("/v1/natals/test-subject")
+    assert fetch.status_code == 200
+    fetched = fetch.json()
+    assert fetched["houses"] == body["houses"]
+    assert fetched["zodiac"] == body["zodiac"]
+
+    saved = tmp_path / "natals" / "test-subject.json"
+    assert saved.exists()
+    snapshot = json.loads(saved.read_text(encoding="utf-8"))
+    assert snapshot["houses"]["system"] == "whole_sign"
+    assert snapshot["zodiac"]["type"] == "sidereal"
+    assert snapshot["zodiac"]["ayanamsa"] == "krishnamurti"
+


### PR DESCRIPTION
## Summary
- persist house system and zodiac configuration alongside stored natal charts and expose them in the natals API schema
- normalize natal configuration when computing midpoints and forecast charts so downstream services honor the saved settings
- add an HTTP regression test to verify the persisted snapshot includes the requested configuration metadata

## Testing
- pytest *(fails: ImportError from app.routers.narrative_profiles looking for apply_narrative_profile_overlay)*
- ASTROENGINE_ENABLE_HTTP_TESTS=1 pytest tests/api/test_natals_endpoint.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e2fc81e648832480ea7f48452107a4