### PR TITLE
Add Streamlit caching for catalog datasets

### DIFF
--- a/ui/streamlit/data_cache.py
+++ b/ui/streamlit/data_cache.py
@@ -1,0 +1,45 @@
+"""Shared Streamlit cache helpers for heavy catalog datasets."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, is_dataclass
+from typing import Any, Dict, List
+
+import streamlit as st
+
+
+def _to_dict(entry: Any) -> Dict[str, Any]:
+    """Return a dictionary representation for dataclass-like ``entry``."""
+
+    if is_dataclass(entry):
+        return asdict(entry)
+    if hasattr(entry, "_asdict"):
+        return dict(entry._asdict())  # type: ignore[no-untyped-call]
+    if isinstance(entry, dict):
+        return dict(entry)
+    if hasattr(entry, "__dict__"):
+        return {key: value for key, value in vars(entry).items()}
+    raise TypeError(f"Unsupported catalog entry type: {type(entry)!r}")
+
+
+@st.cache_data(show_spinner=False)
+def load_fixed_star_catalog(catalog: str = "robson") -> List[Dict[str, Any]]:
+    """Load the fixed-star catalog identified by ``catalog`` with caching."""
+
+    from astroengine.analysis.fixed_stars import load_catalog
+
+    stars = load_catalog(catalog)
+    return [_to_dict(star) for star in stars]
+
+
+@st.cache_data(show_spinner=False)
+def load_dignities_table() -> List[Dict[str, Any]]:
+    """Load the essential dignities table with caching for Streamlit apps."""
+
+    from astroengine.scoring import load_dignities
+
+    records = load_dignities()
+    return [_to_dict(record) for record in records]
+
+
+__all__ = ["load_fixed_star_catalog", "load_dignities_table"]

--- a/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
+++ b/ui/streamlit/pages/09_Chart_Wheel_Aspectarian.py
@@ -11,6 +11,7 @@ from core.viz_plus.wheel_svg import WheelOptions, build_aspect_hits, render_char
 from core.viz_plus.aspect_grid import aspect_grid_symbols, render_aspect_grid
 from core.aspects_plus.harmonics import BASE_ASPECTS
 from ui.streamlit.api import APIClient
+from ui.streamlit.data_cache import load_fixed_star_catalog
 
 st.set_page_config(page_title="Chart Wheel & Aspectarian", page_icon="🎡", layout="wide")
 st.title("Chart Wheel & Aspectarian 🎡")
@@ -394,3 +395,19 @@ with aspectarian_tab:
 
         if not grid and not symbol_grid:
             st.caption("Grid empty — no aspects matched.")
+
+    with st.expander("Fixed star catalog (cached)", expanded=False):
+        catalog_rows = load_fixed_star_catalog()
+        if catalog_rows:
+            star_df = (
+                pd.DataFrame(catalog_rows)
+                .sort_values("mag")
+                .reset_index(drop=True)
+            )
+            cols = [col for col in ("name", "lon_deg", "lat_deg", "mag") if col in star_df.columns]
+            st.dataframe(star_df[cols], use_container_width=True, hide_index=True)
+            st.caption(
+                "Catalog results are cached with st.cache_data to keep large CSV reads fast during reruns."
+            )
+        else:
+            st.info("Fixed star catalog unavailable.")

--- a/ui/streamlit/pages/10_Dignities_Condition.py
+++ b/ui/streamlit/pages/10_Dignities_Condition.py
@@ -6,6 +6,7 @@ import pandas as pd
 import streamlit as st
 
 from ui.streamlit.api import APIClient
+from ui.streamlit.data_cache import load_dignities_table
 
 st.set_page_config(page_title="Dignities & Condition", page_icon="⚖️", layout="wide")
 st.title("Dignities & Planetary Condition ⚖️")
@@ -101,3 +102,27 @@ for planet, info in planets.items():
             st.dataframe(acc_df, use_container_width=True, hide_index=True)
         if not essential_components and not accidental_components:
             st.write("No dignity data available for this body.")
+
+with st.expander("Essential dignities catalog (cached)", expanded=False):
+    records = load_dignities_table()
+    if records:
+        table = (
+            pd.DataFrame(records)
+            .sort_values(["planet", "sign", "dignity_type", "start_deg"], na_position="last")
+            .reset_index(drop=True)
+        )
+        columns = [
+            "planet",
+            "sign",
+            "dignity_type",
+            "sect",
+            "start_deg",
+            "end_deg",
+            "modifier",
+            "source",
+        ]
+        display_cols = [col for col in columns if col in table.columns]
+        st.dataframe(table[display_cols], use_container_width=True, hide_index=True)
+        st.caption("Loaded once per session via st.cache_data to avoid repeated disk reads.")
+    else:
+        st.info("Dignities table unavailable.")


### PR DESCRIPTION
## Summary
- add a shared Streamlit cache helper module for heavy catalog datasets (fixed stars and dignities)
- expose cached dignities table preview on the Dignities & Condition Streamlit page
- expose cached fixed-star catalog preview on the Chart Wheel & Aspectarian Streamlit page

## Testing
- pytest *(fails: missing optional astroengine.config.apply_narrative_profile_overlay import when loading API routers)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fcc330188324a87d1e5d64f506bf