### PR TITLE
Add validation for advanced API coordinates and options

### DIFF
--- a/astroengine/api/routers/natals.py
+++ b/astroengine/api/routers/natals.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Path, Response, status
 from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...userdata.vault import BASE as NATAL_BASE
 from ...userdata.vault import Natal, list_natals, load_natal, save_natal
@@ -47,8 +48,12 @@ class NatalPayload(BaseModel):
 
     name: str | None = Field(default=None, description="Display name for the chart owner.")
     utc: datetime = Field(description="Moment of birth in ISO-8601 UTC.")
-    lat: float = Field(description="Latitude in decimal degrees.")
-    lon: float = Field(description="Longitude in decimal degrees.")
+    lat: float = Field(
+        description="Latitude in decimal degrees.", ge=-90.0, le=90.0
+    )
+    lon: float = Field(
+        description="Longitude in decimal degrees.", ge=-180.0, le=180.0
+    )
     tz: str | None = Field(default=None, description="Original timezone identifier, if known.")
     place: str | None = Field(default=None, description="Birth location description.")
 
@@ -68,6 +73,22 @@ class NatalPayload(BaseModel):
                 raise ValueError("coordinate must not be empty")
             return float(value)
         raise TypeError("coordinate must be numeric or numeric string")
+
+    @field_validator("tz", mode="before")
+    @classmethod
+    def _validate_timezone(cls, value: Any) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, ZoneInfo):
+            return value.key
+        tz = str(value).strip()
+        if not tz:
+            return None
+        try:
+            ZoneInfo(tz)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(f"unrecognized timezone '{tz}'") from exc
+        return tz
 
     @field_serializer("utc")
     def _serialize_utc(self, value: datetime) -> str:

--- a/astroengine/api/schemas_synastry.py
+++ b/astroengine/api/schemas_synastry.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
 
 
 class NatalInline(BaseModel):
     """Lightweight natal chart descriptor for inline usage."""
 
     ts: str
-    lat: float
-    lon: float
+    lat: float = Field(..., ge=-90.0, le=90.0)
+    lon: float = Field(..., ge=-180.0, le=180.0)
+
+    @field_validator("lat", "lon", mode="before")
+    @classmethod
+    def _coerce_coordinate(cls, value: Any) -> float:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                raise ValueError("coordinate must not be empty")
+            return float(candidate)
+        raise TypeError("coordinate must be numeric or numeric string")
 
 
 class SynastryRequest(BaseModel):
@@ -19,7 +33,7 @@ class SynastryRequest(BaseModel):
     subject: NatalInline
     partner: NatalInline
     aspects: list[int] = Field(default_factory=lambda: [0, 60, 90, 120, 180])
-    orb_deg: float = 2.0
+    orb_deg: float = Field(2.0, ge=0.0, le=15.0)
     subject_bodies: list[str] | None = None
     partner_bodies: list[str] | None = None
 

--- a/astroengine/api/schemas_transit_overlay.py
+++ b/astroengine/api/schemas_transit_overlay.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, Dict
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ._time import UtcDateTime
 
@@ -22,9 +22,44 @@ __all__ = [
 
 
 class GeoPointModel(BaseModel):
-    lat: float
-    lon: float
-    alt_m: float | None = 0.0
+    lat: float = Field(..., ge=-90.0, le=90.0)
+    lon: float = Field(..., ge=-180.0, le=180.0)
+    alt_m: float | None = Field(default=0.0)
+
+    @field_validator("lat", "lon", mode="before")
+    @classmethod
+    def _coerce_coordinate(cls, value: Any) -> float:
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                raise ValueError("coordinate must not be empty")
+            return float(candidate)
+        raise TypeError("coordinate must be numeric or numeric string")
+
+    @field_validator("alt_m", mode="before")
+    @classmethod
+    def _coerce_altitude(cls, value: Any) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+        if isinstance(value, str):
+            candidate = value.strip()
+            if not candidate:
+                return None
+            return float(candidate)
+        raise TypeError("altitude must be numeric")
+
+    @field_validator("alt_m")
+    @classmethod
+    def _validate_altitude(cls, value: float | None) -> float | None:
+        if value is None:
+            return None
+        if not -2000.0 <= value <= 12000.0:
+            raise ValueError("altitude must be between -2000 and 12000 meters")
+        return value
 
 
 class TransitOverlayOptionsModel(BaseModel):
@@ -38,6 +73,23 @@ class TransitOverlayOptionsModel(BaseModel):
     lilith_variant: str | None = None
     orbs_deg: Dict[str, float] | None = None
     orb_overrides: Dict[str, float] | None = None
+
+    @field_validator("orbs_deg", "orb_overrides", mode="before")
+    @classmethod
+    def _normalize_orb_maps(
+        cls, value: Dict[str, Any] | None
+    ) -> Dict[str, float] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise TypeError("orb overrides must be provided as a mapping")
+        normalized: Dict[str, float] = {}
+        for key, raw in value.items():
+            numeric = float(raw)
+            if not 0.0 <= numeric <= 20.0:
+                raise ValueError("orb values must be between 0 and 20 degrees")
+            normalized[str(key)] = numeric
+        return normalized
 
 
 class TransitOverlayPositionRequest(BaseModel):
@@ -84,9 +136,26 @@ class TransitAspectModel(BaseModel):
 class TransitAspectRequest(BaseModel):
     natal: OverlayFrameModel
     transit: OverlayFrameModel
-    conj_override: float | None = None
-    opp_override: float | None = None
+    conj_override: float | None = Field(default=None, ge=0.0, le=20.0)
+    opp_override: float | None = Field(default=None, ge=0.0, le=20.0)
     orb_overrides: Dict[str, float] | None = None
+
+    @field_validator("orb_overrides", mode="before")
+    @classmethod
+    def _validate_orb_overrides(
+        cls, value: Dict[str, Any] | None
+    ) -> Dict[str, float] | None:
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise TypeError("orb_overrides must be a mapping of aspect -> degrees")
+        normalized: Dict[str, float] = {}
+        for key, raw in value.items():
+            numeric = float(raw)
+            if not 0.0 <= numeric <= 20.0:
+                raise ValueError("orb override values must be between 0 and 20 degrees")
+            normalized[str(key)] = numeric
+        return normalized
 
 
 class TransitAspectResponse(BaseModel):


### PR DESCRIPTION
## Summary
- enforce latitude/longitude and altitude validation on API coordinate payloads
- require IANA timezone identifiers and sane ranges when persisting natal records
- bound advanced overlay orb overrides and synastry orb tolerances to realistic values

## Testing
- pytest *(fails: ImportError: cannot import name 'apply_narrative_profile_overlay' from 'astroengine.config')*


------
https://chatgpt.com/codex/tasks/task_e_68e2fcea2f3c8324a05f13411da2c6fc