### PR TITLE
Add simple rate limiting to heavy API endpoints

### DIFF
--- a/astroengine/api/rate_limit.py
+++ b/astroengine/api/rate_limit.py
@@ -1,0 +1,151 @@
+"""Lightweight rate limiting helpers for public API endpoints."""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Deque, Dict
+
+from fastapi import HTTPException, Request, Response, status
+
+
+@dataclass
+class RateLimitStatus:
+    """Result describing whether a request is allowed."""
+
+    allowed: bool
+    remaining: int
+    reset_seconds: float
+
+
+class SimpleRateLimiter:
+    """In-memory token bucket keyed by caller identity."""
+
+    def __init__(self, limit: int, window_seconds: float) -> None:
+        self.limit = int(limit)
+        self.window = float(window_seconds)
+        self._hits: Dict[str, Deque[float]] = {}
+        self._lock = asyncio.Lock()
+
+    async def check(self, identity: str) -> RateLimitStatus:
+        """Record a request for ``identity`` and return the quota status."""
+
+        async with self._lock:
+            now = time.monotonic()
+            bucket = self._hits.get(identity)
+            if bucket is None:
+                bucket = deque()
+                self._hits[identity] = bucket
+
+            while bucket and now - bucket[0] >= self.window:
+                bucket.popleft()
+
+            if not bucket:
+                # Release memory for identities that have aged out.
+                self._hits.pop(identity, None)
+                bucket = deque()
+                self._hits[identity] = bucket
+
+            if len(bucket) >= self.limit:
+                reset = self.window - (now - bucket[0])
+                return RateLimitStatus(False, 0, max(reset, 0.0))
+
+            bucket.append(now)
+            remaining = max(0, self.limit - len(bucket))
+            reset = self.window - (now - bucket[0]) if bucket else self.window
+            return RateLimitStatus(True, remaining, max(reset, 0.0))
+
+
+def _resolve_identity(request: Request) -> str:
+    user_headers = [
+        "x-api-user",
+        "x-user-id",
+        "x-user",
+    ]
+    for header in user_headers:
+        value = request.headers.get(header)
+        if value:
+            return value.strip()
+
+    trust_proxy = getattr(request.app.state, "trust_proxy", False)
+    if trust_proxy:
+        x_real = request.headers.get("x-real-ip")
+        if x_real:
+            return x_real.strip()
+        xff = request.headers.get("x-forwarded-for")
+        if xff:
+            return xff.split(",")[0].strip()
+
+    client = request.client
+    if client and client.host:
+        return client.host
+    return "anonymous"
+
+
+def _limiter_registry(request: Request) -> Dict[str, SimpleRateLimiter]:
+    registry = getattr(request.app.state, "_simple_rate_limiters", None)
+    if registry is None:
+        registry = {}
+        setattr(request.app.state, "_simple_rate_limiters", registry)
+    return registry
+
+
+def _get_limiter(
+    request: Request, scope: str, limit: int, window_seconds: int | float
+) -> SimpleRateLimiter:
+    registry = _limiter_registry(request)
+    limiter = registry.get(scope)
+    if limiter is None or limiter.limit != limit or limiter.window != float(window_seconds):
+        limiter = SimpleRateLimiter(limit=limit, window_seconds=float(window_seconds))
+        registry[scope] = limiter
+    return limiter
+
+
+def heavy_endpoint_rate_limiter(
+    scope: str,
+    *,
+    limit: int = 10,
+    window_seconds: int = 60,
+    message: str | None = None,
+) -> Callable[[Request, Response], Awaitable[None]]:
+    """Return a dependency enforcing a simple rate limit for ``scope``."""
+
+    friendly = message or "This endpoint is receiving a high volume of requests."
+
+    async def _dependency(request: Request, response: Response) -> None:
+        limiter = _get_limiter(request, scope, limit, window_seconds)
+        identity = _resolve_identity(request)
+        status_info = await limiter.check(identity)
+        reset_seconds = max(0, math.ceil(status_info.reset_seconds))
+        headers = {
+            "X-RateLimit-Limit": str(limit),
+            "X-RateLimit-Remaining": str(max(0, status_info.remaining)),
+            "X-RateLimit-Reset": str(reset_seconds),
+        }
+
+        if not status_info.allowed:
+            detail = {
+                "code": "rate_limited",
+                "message": f"{friendly} Please try again in {reset_seconds} seconds.",
+            }
+            raise HTTPException(
+                status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+                detail=detail,
+                headers={**headers, "Retry-After": str(reset_seconds)},
+            )
+
+        for key, value in headers.items():
+            response.headers.setdefault(key, value)
+
+    return _dependency
+
+
+__all__ = [
+    "RateLimitStatus",
+    "SimpleRateLimiter",
+    "heavy_endpoint_rate_limiter",
+]
+

--- a/tests/test_api_electional.py
+++ b/tests/test_api_electional.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta, timezone
+
 from fastapi import FastAPI
 from fastapi.responses import ORJSONResponse
 from fastapi.testclient import TestClient
@@ -86,3 +87,40 @@ def test_electional_search_forbidden_penalty_and_voc_toggle():
     assert r.status_code == 200
     data = r.json()
     assert len(data["windows"]) == 1
+
+
+def test_electional_search_rate_limit(monkeypatch):
+    t0 = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    eph = LinearEphemeris(
+        t0,
+        base={"Sun": 0.0, "Moon": 0.0},
+        rates={"Sun": 0.0, "Moon": 13.0},
+    )
+    app = build_app(eph)
+    client = TestClient(app)
+
+    monkeypatch.setattr("app.routers.electional.search_best_windows", lambda *args, **kwargs: [])
+
+    payload = {
+        "window": {"start": t0.isoformat(), "end": (t0 + timedelta(days=1)).isoformat()},
+        "window_minutes": 60,
+        "step_minutes": 60,
+        "top_k": 1,
+        "avoid_voc_moon": False,
+        "allowed_weekdays": None,
+        "allowed_utc_ranges": None,
+        "orb_policy_inline": {"per_aspect": {}},
+        "required_aspects": [],
+        "forbidden_aspects": [],
+    }
+
+    for _ in range(10):
+        ok = client.post("/electional/search", json=payload)
+        assert ok.status_code == 200
+
+    limited = client.post("/electional/search", json=payload)
+    assert limited.status_code == 429
+    detail = limited.json()["detail"]
+    assert detail["code"] == "rate_limited"
+    assert "please try again" in detail["message"].lower()
+    assert int(limited.headers["Retry-After"]) >= 0


### PR DESCRIPTION
## Summary
- add a reusable in-memory rate limiting helper for FastAPI routers
- enforce rate caps on the electional search and astrocartography endpoints with friendly 429s
- extend the API test suite with coverage for the new rate limit behaviour

## Testing
- pytest tests/test_api_electional.py tests/api/test_astrocartography_api.py

------
https://chatgpt.com/codex/tasks/task_e_68e2fcfa3fa88324a02f4754474d9ca6