### PR TITLE
Improve diagnostics dependency checks and registry tooling

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,7 @@ from astroengine.ephemeris.adapter import EphemerisAdapter, EphemerisConfig
 
 from app.db.session import engine
 from app.observability import configure_observability
-from app.telemetry import setup_tracing
+from app.telemetry import resolve_observability_config, setup_tracing
 from astroengine.web.middleware import configure_compression
 
 LOGGER = logging.getLogger(__name__)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,5 +1,4 @@
-"""API routers for AstroEngine Plus services."""
-
+"""Lazy router imports for the AstroEngine Plus API."""
 
 from __future__ import annotations
 
@@ -13,13 +12,11 @@ __all__ = [
     "configure_position_provider",
     "data_router",
     "declinations_router",
+    "doctor_router",
     "electional_router",
     "events_router",
-
-    "declinations_router",
-    "doctor_router",
-
-    "policies_router",
+    "health_router",
+    "interpret_router",
     "lots_router",
     "narrative_mix_router",
     "narrative_profiles_router",
@@ -30,14 +27,7 @@ __all__ = [
     "rel_router",
     "reports_router",
     "settings_router",
-    "notes_router",
-    "data_router",
-    "charts_router",
-    "profiles_router",
-    "narrative_profiles_router",
-    "narrative_mix_router",
-    "configure_position_provider",
-    "clear_position_provider",
+    "transits_router",
 ]
 
 _LAZY_ATTRS: dict[str, tuple[str, str]] = {
@@ -47,6 +37,7 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "configure_position_provider": ("aspects", "configure_position_provider"),
     "data_router": ("data_io", "router"),
     "declinations_router": ("declinations", "router"),
+    "doctor_router": ("doctor", "router"),
     "electional_router": ("electional", "router"),
     "events_router": ("events", "router"),
     "health_router": ("health", "router"),
@@ -64,70 +55,8 @@ _LAZY_ATTRS: dict[str, tuple[str, str]] = {
     "transits_router": ("transits", "router"),
 }
 
-def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampoline
-    if name == "aspects_router":
-        from .aspects import router as aspects_router
 
-        return aspects_router
-    if name in {"configure_position_provider", "clear_position_provider"}:
-        from .aspects import (
-            clear_position_provider,
-            configure_position_provider,
-        )
-
-        return (
-            configure_position_provider
-            if name == "configure_position_provider"
-            else clear_position_provider
-        )
-    if name == "electional_router":
-        from .electional import router as electional_router
-
-        return electional_router
-    if name == "events_router":
-        from .events import router as events_router
-
-        return events_router
-    if name == "declinations_router":
-        from .declinations import router as declinations_router
-
-        return declinations_router
-    if name == "health_router":
-        from .health import router as health_router
-
-        return health_router
-    if name == "doctor_router":
-        from .doctor import router as doctor_router
-
-        return doctor_router
-    if name == "interpret_router":
-        from .interpret import router as interpret_router
-
-        return interpret_router
-    if name == "lots_router":
-        from .lots import router as lots_router
-
-        return lots_router
-    if name == "relationship_router":
-        from .relationship import router as relationship_router
-
-        return relationship_router
-    if name == "profiles_router":
-        from .profiles import router as profiles_router
-
-        return profiles_router
-    if name == "narrative_profiles_router":
-        from .narrative_profiles import router as narrative_profiles_router
-
-        return narrative_profiles_router
-    if name == "narrative_mix_router":
-        from .narrative_mix import router as narrative_mix_router
-
-        return narrative_mix_router
-    if name == "reports_router":
-        from .reports import router as reports_router
-
-def __getattr__(name: str) -> Any:  # pragma: no cover - simple import trampoline
+def __getattr__(name: str) -> Any:  # pragma: no cover - import trampoline
     try:
         module_name, attr_name = _LAZY_ATTRS[name]
     except KeyError as exc:  # pragma: no cover - defensive branch

--- a/astroengine/observability/metrics.py
+++ b/astroengine/observability/metrics.py
@@ -7,12 +7,40 @@ from typing import Iterable
 from prometheus_client import CollectorRegistry, Counter, Gauge, Histogram, REGISTRY
 
 __all__ = [
+    "ASPECT_COMPUTE_DURATION",
+    "COMPUTE_ERRORS",
+    "DIRECTION_COMPUTE_DURATION",
+    "EPHEMERIS_BODY_COMPUTE_DURATION",
     "EPHEMERIS_CACHE_HITS",
     "EPHEMERIS_CACHE_MISSES",
     "EPHEMERIS_CACHE_COMPUTE_DURATION",
     "EPHEMERIS_SWE_CACHE_HIT_RATIO",
     "ensure_metrics_registered",
 ]
+
+
+ASPECT_COMPUTE_DURATION = Histogram(
+    "aspect_compute_duration_seconds",
+    "Duration of progressed and directed aspect computations.",
+    ("method",),
+    registry=None,
+)
+
+
+DIRECTION_COMPUTE_DURATION = Histogram(
+    "direction_compute_duration_seconds",
+    "Duration of direction timeline calculations.",
+    ("method",),
+    registry=None,
+)
+
+
+EPHEMERIS_BODY_COMPUTE_DURATION = Histogram(
+    "ephemeris_body_compute_duration_seconds",
+    "Duration of Swiss ephemeris body position lookups.",
+    ("adapter", "operation"),
+    registry=None,
+)
 
 EPHEMERIS_CACHE_HITS = Counter(
     "ephemeris_cache_hits_total",
@@ -42,11 +70,23 @@ EPHEMERIS_SWE_CACHE_HIT_RATIO = Gauge(
 )
 
 
+COMPUTE_ERRORS = Counter(
+    "astroengine_compute_errors_total",
+    "Count of runtime failures across compute-heavy routines.",
+    ("component", "error"),
+    registry=None,
+)
+
+
 def _iter_metrics() -> Iterable[Counter | Gauge | Histogram]:
+    yield ASPECT_COMPUTE_DURATION
+    yield DIRECTION_COMPUTE_DURATION
+    yield EPHEMERIS_BODY_COMPUTE_DURATION
     yield EPHEMERIS_CACHE_HITS
     yield EPHEMERIS_CACHE_MISSES
     yield EPHEMERIS_CACHE_COMPUTE_DURATION
     yield EPHEMERIS_SWE_CACHE_HIT_RATIO
+    yield COMPUTE_ERRORS
 
 
 def ensure_metrics_registered(

--- a/astroengine/utils/dependencies.py
+++ b/astroengine/utils/dependencies.py
@@ -1,0 +1,185 @@
+"""Runtime dependency probing utilities.
+
+The helpers defined here keep AstroEngine's diagnostics lightweight while
+ensuring that every module required for Solar Fire aligned workflows is
+available.  Each dependency probe records the originating requirement as
+well as the import name so higher layers can provide actionable guidance
+without inventing synthetic data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module, metadata
+from importlib.metadata import PackageNotFoundError
+from packaging.requirements import Requirement
+from packaging.version import InvalidVersion, Version
+from typing import Iterable, Literal, Sequence
+
+__all__ = [
+    "DependencySpec",
+    "DependencyStatus",
+    "inspect_dependencies",
+]
+
+
+Status = Literal["PASS", "WARN", "FAIL"]
+
+
+@dataclass(frozen=True, slots=True)
+class DependencySpec:
+    """Describe a runtime dependency that should be present."""
+
+    requirement: str
+    """The canonical requirement string (e.g. ``"numpy>=1.26"``)."""
+
+    import_name: str | None = None
+    """Override for the module import name when it differs from the distribution."""
+
+    required: bool = True
+    """Whether a missing dependency should be treated as a failure."""
+
+    min_version: str | None = None
+    """Minimum acceptable version of the installed distribution."""
+
+    note: str | None = None
+    """Additional context included in diagnostic payloads."""
+
+    def distribution(self) -> str:
+        """Return the normalized distribution name."""
+
+        return Requirement(self.requirement).name
+
+    def module(self) -> str:
+        """Return the module import path associated with the spec."""
+
+        target = self.import_name or self.distribution()
+        return target.replace("-", "_")
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyStatus:
+    """Result of probing a dependency's availability."""
+
+    spec: DependencySpec
+    status: Status
+    detail: str
+    module_version: str | None = None
+    distribution_version: str | None = None
+    error: str | None = None
+
+    def data(self) -> dict[str, object]:
+        """Return structured metadata for diagnostics reporting."""
+
+        payload: dict[str, object] = {
+            "requirement": self.spec.requirement,
+            "import_name": self.spec.module(),
+            "required": self.spec.required,
+        }
+        if self.module_version:
+            payload["module_version"] = self.module_version
+        if self.distribution_version:
+            payload["distribution_version"] = self.distribution_version
+        if self.spec.note:
+            payload["note"] = self.spec.note
+        if self.error:
+            payload["error"] = self.error
+        return payload
+
+
+def _format_exception(exc: Exception) -> str:
+    return f"{type(exc).__name__}: {exc}".strip()
+
+
+def _version_satisfies(current: str | None, minimum: str) -> tuple[bool, str | None]:
+    """Check whether ``current`` meets the ``minimum`` semantic version."""
+
+    if current is None:
+        return False, None
+    try:
+        current_version = Version(current)
+        minimum_version = Version(minimum)
+    except InvalidVersion as exc:
+        return False, _format_exception(exc)
+    return current_version >= minimum_version, str(current_version)
+
+
+def _inspect_dependency(spec: DependencySpec) -> DependencyStatus:
+    module_name = spec.module()
+    try:
+        module = import_module(module_name)
+    except Exception as exc:  # pragma: no cover - exercised via CLI diagnostics
+        status: Status = "FAIL" if spec.required else "WARN"
+        detail = f"import failed for {module_name}"
+        return DependencyStatus(
+            spec=spec,
+            status=status,
+            detail=detail,
+            error=_format_exception(exc),
+        )
+
+    module_version = getattr(module, "__version__", None)
+    dist_name = spec.distribution()
+    dist_version: str | None
+    dist_error: str | None = None
+    try:
+        dist_version = metadata.version(dist_name)
+    except PackageNotFoundError as exc:
+        dist_version = None
+        dist_error = _format_exception(exc)
+
+    if dist_version is None and dist_error:
+        status = "WARN" if not spec.required else "WARN"
+        detail = f"distribution metadata for {dist_name} unavailable"
+        return DependencyStatus(
+            spec=spec,
+            status=status,
+            detail=detail,
+            module_version=module_version,
+            distribution_version=dist_version,
+            error=dist_error,
+        )
+
+    if spec.min_version:
+        candidate_version = dist_version or module_version
+        meets, failure_detail = _version_satisfies(candidate_version, spec.min_version)
+        if not meets:
+            status = "FAIL" if spec.required else "WARN"
+            detail = (
+                failure_detail
+                or f"missing version metadata; requires >= {spec.min_version}"
+            )
+            return DependencyStatus(
+                spec=spec,
+                status=status,
+                detail=detail,
+                module_version=module_version,
+                distribution_version=dist_version,
+                error=dist_error,
+            )
+
+    detail_parts: list[str] = ["available"]
+    if not spec.required:
+        detail_parts.append("optional")
+    if dist_version:
+        detail_parts.append(f"version {dist_version}")
+    elif module_version:
+        detail_parts.append(f"module version {module_version}")
+    if spec.note:
+        detail_parts.append(spec.note)
+    detail = "; ".join(detail_parts)
+    return DependencyStatus(
+        spec=spec,
+        status="PASS",
+        detail=detail,
+        module_version=module_version,
+        distribution_version=dist_version,
+        error=dist_error,
+    )
+
+
+def inspect_dependencies(specs: Sequence[DependencySpec] | Iterable[DependencySpec]) -> list[DependencyStatus]:
+    """Evaluate all provided dependency specs."""
+
+    return [_inspect_dependency(spec) for spec in specs]
+

--- a/docs/module/developer_platform/devportal.md
+++ b/docs/module/developer_platform/devportal.md
@@ -41,6 +41,7 @@
 
 - Playground logs segregated with anonymised identifiers; telemetry includes dataset hash references ensuring reproducibility.
 - Docs build includes automated link checker and sample execution harness that verifies each code block using mock server seeded with real data.
+- CLI tooling (`astroengine diagnose`) audits runtime dependencies against the locked requirement set so operators notice missing Solar Fire ingest prerequisites before deployment.
 - Version switcher exposes historical docs tied to previous `openapi/v*.json` schemas; ensures developers can reference legacy behaviour without module loss.
 - Accessibility guidelines follow WCAG 2.1 AA; colour palettes validated for charts that visualise astrological cycles.
 

--- a/tests/test_dependencies_utils.py
+++ b/tests/test_dependencies_utils.py
@@ -1,0 +1,24 @@
+from astroengine.utils.dependencies import DependencySpec, inspect_dependencies
+
+
+def test_inspect_dependencies_pass() -> None:
+    spec = DependencySpec("packaging>=20", min_version="20")
+    status = inspect_dependencies([spec])[0]
+
+    assert status.status == "PASS"
+    data = status.data()
+    assert data["requirement"].startswith("packaging")
+    assert "version" in status.detail
+
+
+def test_inspect_dependencies_optional_missing() -> None:
+    spec = DependencySpec(
+        "astroengine-missing-dep",
+        import_name="astroengine_missing_dep",
+        required=False,
+    )
+    status = inspect_dependencies([spec])[0]
+
+    assert status.status == "WARN"
+    assert "import failed" in status.detail
+    assert status.data()["required"] is False

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,19 @@
+from astroengine.modules.registry import AstroRegistry
+
+
+def test_registry_resolve_path() -> None:
+    registry = AstroRegistry()
+    module = registry.register_module("natal")
+    submodule = module.register_submodule("charts")
+    channel = submodule.register_channel("core")
+    subchannel = channel.register_subchannel("radix")
+
+    assert registry.resolve("natal") is module
+    assert registry.resolve("natal", submodule="charts") is submodule
+    assert registry.resolve("natal", submodule="charts", channel="core") is channel
+    assert (
+        registry.resolve(
+            "natal", submodule="charts", channel="core", subchannel="radix"
+        )
+        is subchannel
+    )


### PR DESCRIPTION
## Summary
- add a reusable dependency inspection helper and wire it into the diagnostics command to report missing runtime packages alongside sqlite3 availability
- harden the FastAPI bootstrap by fixing router exports, importing the observability resolver, and adding registry traversal helpers and metrics for compute-heavy pipelines
- document the new diagnostics behaviour and cover the helpers with focused unit tests to guard the module hierarchy

## Testing
- `pytest tests/test_registry.py tests/test_dependencies_utils.py tests/observability/test_doctor.py`
- `pytest tests/test_timelords_systems.py::test_vimshottari_known_dates` *(fails: requires swisseph/pyswisseph extra)*

------
https://chatgpt.com/codex/tasks/task_e_68e303df79108324a1b9aebcb0a68ed9