### PR TITLE
Harden developer-mode endpoints with PIN gate

### DIFF
--- a/app/devmode/api.py
+++ b/app/devmode/api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 import time
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from .gitops import GitOps
@@ -19,10 +19,15 @@ from .backups import (
     schedule_status,
 )
 from astroengine.infrastructure import retention
-from .security import is_allowed, is_blocked, is_protected
+from .security import is_allowed, is_blocked, is_protected, require_dev_pin
 from .validate import pipeline
 
-router = APIRouter(prefix="/v1/dev", tags=["dev"], include_in_schema=False)
+router = APIRouter(
+    prefix="/v1/dev",
+    tags=["dev"],
+    include_in_schema=False,
+    dependencies=[Depends(require_dev_pin)],
+)
 
 CONFIRM_PHRASE = os.environ.get(
     "DEV_CORE_EDIT_CONFIRM", "I UNDERSTAND THIS MAY BREAK THE APP"


### PR DESCRIPTION
## Summary
- require the developer PIN for every /v1/dev API call via a FastAPI dependency
- extend the integration tests to configure the PIN and cover missing-header failures
- update the Streamlit dev mode UI to prompt for the PIN and send it with each request

## Testing
- pytest tests/app/devmode/test_api_integration.py


------
https://chatgpt.com/codex/tasks/task_e_68e308d9c56c8324a51337cfe3259793