### PR TITLE
Update Windows packaging to bundle ephemeris data

### DIFF
--- a/packaging/astroengine_cli.spec
+++ b/packaging/astroengine_cli.spec
@@ -14,9 +14,11 @@ hiddenimports += collect_submodules("pyswisseph")
 
 datas = []
 datas += collect_data_files("alembic")
+datas += collect_data_files("astroengine", includes=["py.typed"])
 datas += [("alembic.ini", "alembic.ini", "DATA")]
 datas += [("migrations", "migrations")]
 datas += [("ui/streamlit", "ui/streamlit")]
+datas += [("datasets/swisseph_stub", "resources/ephemeris")]
 
 
 a = Analysis(
@@ -27,8 +29,8 @@ a = Analysis(
     binaries=[],
     datas=datas,
     hiddenimports=hiddenimports,
-    hookspath=[],
-    runtime_hooks=[],
+    hookspath=["packaging/hooks"],
+    runtime_hooks=["packaging/hooks/rthook-astroengine-portal.py"],
     excludes=[],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/packaging/astroengine_gui.spec
+++ b/packaging/astroengine_gui.spec
@@ -13,9 +13,11 @@ hiddenimports += collect_submodules("pyswisseph")
 
 
 datas = []
+datas += collect_data_files("astroengine", includes=["py.typed"])
 datas += [("alembic.ini", "alembic.ini", "DATA")]
 datas += [("migrations", "migrations")]
 datas += [("ui/streamlit", "ui/streamlit")]
+datas += [("datasets/swisseph_stub", "resources/ephemeris")]
 
 
 a = Analysis(
@@ -26,8 +28,8 @@ a = Analysis(
     binaries=[],
     datas=datas,
     hiddenimports=hiddenimports,
-    hookspath=[],
-    runtime_hooks=[],
+    hookspath=["packaging/hooks"],
+    runtime_hooks=["packaging/hooks/rthook-astroengine-portal.py"],
     excludes=[],
     win_no_prefer_redirects=False,
     win_private_assemblies=False,

--- a/packaging/hooks/rthook-astroengine-portal.py
+++ b/packaging/hooks/rthook-astroengine-portal.py
@@ -24,16 +24,19 @@ def _ensure_dir(path: Path) -> Path:
 def _configure_user_space(root: Path) -> None:
     local_appdata = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
     user_root = _ensure_dir(local_appdata / "AstroEngine")
-    os.environ.setdefault("ASTROENGINE_HOME", str(user_root))
-    os.environ.setdefault("ASTROENGINE_DATA_ROOT", str(_ensure_dir(user_root / "data")))
+    if not os.environ.get("ASTROENGINE_HOME"):
+        os.environ["ASTROENGINE_HOME"] = str(user_root)
+    data_root = _ensure_dir(user_root / "data")
+    if not os.environ.get("ASTROENGINE_DATA_ROOT"):
+        os.environ["ASTROENGINE_DATA_ROOT"] = str(data_root)
     _ensure_dir(user_root / "logs")
     os.environ.setdefault("STREAMLIT_BROWSER_GATHER_USAGE_STATS", "0")
 
 
 def _configure_ephemeris(root: Path) -> None:
     candidate = root / "resources" / "ephemeris"
-    if candidate.exists():
-        os.environ.setdefault("SE_EPHE_PATH", str(candidate))
+    if candidate.exists() and not os.environ.get("SE_EPHE_PATH"):
+        os.environ["SE_EPHE_PATH"] = str(candidate)
 
 
 def configure_environment() -> None:


### PR DESCRIPTION
## Summary
- bundle the Swiss ephemeris resources and Streamlit assets in the Windows GUI/CLI PyInstaller specs
- wire the shared runtime hook so bundled apps default to %LOCALAPPDATA%\AstroEngine and set SE_EPHE_PATH when available

## Testing
- pytest --maxfail=1 *(fails: astrocartography API expects seeded data in test fixtures)*

------
https://chatgpt.com/codex/tasks/task_e_68e308e6e66083248dca1dde184c665d