### PR TITLE
Optimize Swiss ephemeris batch calls

### DIFF
--- a/astroengine/detectors/eclipses.py
+++ b/astroengine/detectors/eclipses.py
@@ -11,7 +11,7 @@ except Exception:  # pragma: no cover
     swe = None  # type: ignore
 
 from ..events import EclipseEvent
-from ..ephemeris.swisseph_adapter import swe_calc
+from ..ephemeris.cache import calc_ut_cached
 from .common import jd_to_iso, moon_lon, sun_lon
 
 __all__ = ["find_eclipses"]
@@ -25,9 +25,9 @@ def _moon_latitude(jd_ut: float) -> float:
     if swe is None:
         raise RuntimeError("Swiss ephemeris not available; install astroengine[ephem]")
     flag = swe.FLG_SWIEPH | swe.FLG_SPEED
-    xx, _, serr = swe_calc(jd_ut=jd_ut, planet_index=swe.MOON, flag=flag)
-    if serr:
-        raise RuntimeError(serr)
+    xx, ret_flag = calc_ut_cached(jd_ut, int(swe.MOON), flag)
+    if ret_flag < 0:
+        raise RuntimeError(f"Swiss ephemeris returned error code {ret_flag}")
     if len(xx) < 2:
         raise RuntimeError("Swiss ephemeris did not return latitude component")
     return float(xx[1])

--- a/astroengine/engine/minorplanets/builtins.py
+++ b/astroengine/engine/minorplanets/builtins.py
@@ -7,7 +7,8 @@ from datetime import datetime
 from typing import Final
 
 from astroengine.core.time import ensure_utc, julian_day
-from astroengine.ephemeris.swisseph_adapter import get_swisseph, swe_calc
+from astroengine.ephemeris.cache import calc_ut_cached
+from astroengine.ephemeris.swisseph_adapter import get_swisseph
 
 __all__ = [
     "CuratedMinorPlanet",
@@ -42,9 +43,9 @@ def _calc_apogee_longitude(moment: datetime, body: int) -> float:
     _ensure_swisseph_path()
     utc_moment = ensure_utc(moment)
     jd_ut = julian_day(utc_moment)
-    xx, _, serr = swe_calc(jd_ut=jd_ut, planet_index=body, flag=0)
-    if serr:
-        raise RuntimeError(serr)
+    xx, ret_flag = calc_ut_cached(jd_ut, int(body), 0)
+    if ret_flag < 0:
+        raise RuntimeError(f"Swiss ephemeris returned error code {ret_flag}")
     longitude = xx[0] % 360.0
     if longitude < 0.0:
         longitude += 360.0

--- a/astroengine/ephemeris/cache.py
+++ b/astroengine/ephemeris/cache.py
@@ -1,0 +1,16 @@
+"""Swiss Ephemeris call caches."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from .swe import swe
+
+__all__ = ["calc_ut_cached"]
+
+
+@lru_cache(maxsize=200_000)
+def calc_ut_cached(jd: float, ipl: int, flags: int = 0):
+    """Return cached :func:`swisseph.calc_ut` results for ``(jd, ipl, flags)``."""
+
+    return swe().calc_ut(jd, ipl, flags)

--- a/astroengine/ephemeris/swe.py
+++ b/astroengine/ephemeris/swe.py
@@ -1,0 +1,22 @@
+"""Shared Swiss Ephemeris import helpers."""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+from functools import lru_cache
+from types import ModuleType
+
+__all__ = ["swe"]
+
+
+@lru_cache(maxsize=1)
+def swe() -> ModuleType:
+    """Return the cached :mod:`swisseph` module, raising if unavailable."""
+
+    if importlib.util.find_spec("swisseph") is None:
+        raise ModuleNotFoundError(
+            "swisseph is required for Swiss Ephemeris calculations. Install the "
+            "'pyswisseph' extra to enable astroengine.ephemeris features."
+        )
+    return importlib.import_module("swisseph")

--- a/astroengine/providers/swisseph_adapter.py
+++ b/astroengine/providers/swisseph_adapter.py
@@ -19,7 +19,7 @@ except ImportError:
     swe = None
 
 from ..core.bodies import canonical_name
-from ..ephemeris.swisseph_adapter import swe_calc
+from ..ephemeris.cache import calc_ut_cached
 
 SE_SUN = getattr(swe, "SUN", 0) if swe else 0
 SE_MOON = getattr(swe, "MOON", 1) if swe else 1
@@ -56,10 +56,10 @@ def se_body_id_for(name: str, vc: VariantConfig) -> Tuple[int, bool]:
 def position_vec(body_id: int, jd_ut: float, *, flags: int = 0):
     if swe is None:
         raise RuntimeError("pyswisseph not available")
-    xx, _, serr = swe_calc(jd_ut=jd_ut, planet_index=body_id, flag=flags)
-    if serr:
-        raise RuntimeError(serr)
-    return xx
+    values, ret_flag = calc_ut_cached(jd_ut, body_id, flags)
+    if ret_flag < 0:
+        raise RuntimeError(f"Swiss ephemeris returned error code {ret_flag}")
+    return tuple(values)
 
 
 def position_with_variants(name: str, jd_ut: float, vc: VariantConfig, *, flags: int = 0):


### PR DESCRIPTION
## Summary
- add reusable Swiss Ephemeris module loader and cached `calc_ut` helper
- reuse the cached Swiss calls in vectorized body computations and detectors
- update providers and minor-planet helpers to share cached Swiss vectors

## Testing
- pytest *(fails: environment lacks pyswisseph and API dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e308c6b8f48324860a41bb7d8ed07e