### PR TITLE
Fix Swiss ephemeris provisioning metadata probe

### DIFF
--- a/astroengine/pipeline/provision.py
+++ b/astroengine/pipeline/provision.py
@@ -2,29 +2,64 @@
 from __future__ import annotations
 
 import json
+import math
 import time
 from pathlib import Path
 from typing import Any
 
 from ..detectors.common import _ensure_swiss
+from ..ephemeris.swe import swe
+from ..config.settings import load_settings
 
 PROVISION_HOME = Path.home() / ".astroengine"
 PROVISION_META = PROVISION_HOME / "provision.json"
 
 
 def get_ephemeris_meta() -> dict[str, Any]:
-    ok = _ensure_swiss()
-    meta: dict[str, Any] = {"ok": bool(ok)}
-    if not ok:
-        return meta
-from astroengine.ephemeris.swe import swe
+    """
+    Probe Swiss Ephemeris availability and capability at the configured year caps.
+    Returns a JSON-serializable dict for UI/doctor pages and provisioning storage.
+    """
+    installed = False
+    min_ok = False
+    max_ok = False
+    error: str | None = None
+    ephe_path: str | None = None
 
-    meta.update(
-        {
-            "swe_version": getattr(swe, "version", lambda: "unknown")(),
-            "ephe_path": getattr(swe, "get_ephe_path", lambda: None)(),
-        }
-    )
+    try:
+        _ensure_swiss()
+        _ = swe()  # lazy import
+        installed = True
+        s = load_settings()
+        # Try to detect current ephemeris path if set
+        try:
+            # If your utils expose a getter, use it; else rely on swe.get_library_path()
+            ephe_path = getattr(swe(), "get_library_path", lambda: None)() or None
+        except Exception:
+            ephe_path = None
+
+        def _can(year: int) -> bool:
+            try:
+                jd = swe().julday(year, 1, 1, 12.0)
+                pos = swe().calc_ut(jd, swe().SUN)[0]  # (lon, lat, dist, lon_speed, lat_speed, dist_speed)
+                return all(not math.isnan(x) for x in pos)
+            except Exception:
+                return False
+
+        min_ok = _can(s.swiss_caps.min_year)
+        max_ok = _can(s.swiss_caps.max_year)
+
+    except Exception as e:
+        error = str(e)
+
+    meta = {
+        "installed": installed,
+        "ephemeris_path": ephe_path,
+        "min_year_ok": bool(min_ok),
+        "max_year_ok": bool(max_ok),
+        "error": error,
+        "ts": int(time.time()),
+    }
     return meta
 
 
@@ -39,6 +74,4 @@ def provision_ephemeris() -> dict[str, Any]:
 
 def is_provisioned() -> bool:
     return PROVISION_META.is_file()
-
-
 # >>> AUTO-GEN END: pipeline-provision v1.0


### PR DESCRIPTION
## Summary
- replace the provisioning helper with the new auto-generated implementation
- probe configured Swiss ephemeris year caps and capture diagnostic metadata during provisioning

## Testing
- pytest *(fails: pyswisseph not installed; suite skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68e3131d1660832487ab140bd9fe75a5