### PR TITLE
Fix pytest module collisions by packaging tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,10 @@
+"""Test suite package marker to ensure deterministic module names."""
+
+# Enabling package semantics avoids module name collisions when pytest collects
+# similarly named modules from nested directories (e.g. ``test_returns`` in both
+# ``tests`` and ``tests.analysis``). Without this marker pytest can import a
+# nested module as ``test_returns`` and later refuse to load the top-level test
+# module with the same basename. By making the ``tests`` directory a proper
+# package we guarantee fully qualified names such as ``tests.analysis.test_returns``
+# and ``tests.test_returns`` coexist without shadowing each other.
+

--- a/tests/analysis/__init__.py
+++ b/tests/analysis/__init__.py
@@ -1,0 +1,2 @@
+"""Analysis-focused regression tests for AstroEngine."""
+


### PR DESCRIPTION
## Summary
- add an explicit package marker for the top-level test suite to stop pytest module collisions
- mark the analysis tests directory as a package so similarly named tests receive unique module paths

## Testing
- pytest tests/test_returns.py


------
https://chatgpt.com/codex/tasks/task_e_68e315b919c083248b9d0eb764c6cf1b