### PR TITLE
Add configuration defaults and API safeguards

### DIFF
--- a/astroengine/api/routers/scan.py
+++ b/astroengine/api/routers/scan.py
@@ -448,9 +448,9 @@ def api_scan_progressions(
     request = TransitScanRequest(**request_data)
     if stream:
         if request.export is not None:
-            raise HTTPException(
+            return json_response(
+                {"detail": "streaming responses do not support export payloads"},
                 status_code=400,
-                detail="streaming responses do not support export payloads",
             )
         return _stream_scan_hits(
             "progressions",
@@ -503,9 +503,9 @@ def api_scan_directions(
     request = TransitScanRequest(**request_data)
     if stream:
         if request.export is not None:
-            raise HTTPException(
+            return json_response(
+                {"detail": "streaming responses do not support export payloads"},
                 status_code=400,
-                detail="streaming responses do not support export payloads",
             )
         return _stream_scan_hits(
             "directions",
@@ -561,9 +561,9 @@ def api_scan_transits(
         raise HTTPException(status_code=501, detail="Transit scans are not yet available")
     if stream:
         if request.export is not None:
-            raise HTTPException(
+            return json_response(
+                {"detail": "streaming responses do not support export payloads"},
                 status_code=400,
-                detail="streaming responses do not support export payloads",
             )
         return _stream_scan_hits(
             "transits",
@@ -619,9 +619,9 @@ def api_scan_returns(
     request = ReturnsScanRequest(**request_data)
     if stream:
         if request.export is not None:
-            raise HTTPException(
+            return json_response(
+                {"detail": "streaming responses do not support export payloads"},
                 status_code=400,
-                detail="streaming responses do not support export payloads",
             )
         return _stream_scan_hits(
             "returns",

--- a/astroengine/config/settings.py
+++ b/astroengine/config/settings.py
@@ -378,6 +378,10 @@ class AstroCartoCfg(BaseModel):
 
     enabled: bool = False
     show_parans: bool = False
+    line_types: list[str] = Field(
+        default_factory=lambda: ["ASC", "DSC", "MC", "IC"],
+        description="Default astrocartography line kinds to render.",
+    )
 
 
 class AstrocartographyCfg(AstroCartoCfg):
@@ -396,6 +400,7 @@ class MidpointsCfg(BaseModel):
 
     enabled: bool = True
     tree: MidpointTreeCfg = Field(default_factory=MidpointTreeCfg)
+    include_nodes: bool = False
 
 
 class FixedStarsCfg(BaseModel):
@@ -655,6 +660,13 @@ class ReportsCfg(BaseModel):
 
     pdf_enabled: bool = False
     template: Literal["classic", "minimal"] = "classic"
+    disclaimers: list[str] = Field(
+        default_factory=lambda: [
+            "Astrological insights support personal reflection and should not replace qualified professional advice.",
+            "All chart positions are computed from provided birth data using the Swiss Ephemeris; verify source accuracy before applying results.",
+        ],
+        description="Default legal disclaimers appended to generated reports.",
+    )
 
 
 class AtlasCfg(BaseModel):


### PR DESCRIPTION
## Summary
- add default astrocartography line types, a midpoint node toggle, and report disclaimers to the settings defaults
- return JSON error bodies for streaming scan export conflicts to match FastAPI error expectations
- make the Swiss Ephemeris doctor check tolerant of non-callable swisseph stubs while still verifying julday availability

## Testing
- pytest tests/test_analysis_midpoints.py tests/api/test_scan_endpoints.py tests/api/test_timeline_endpoint.py tests/observability/test_doctor.py

------
https://chatgpt.com/codex/tasks/task_e_68e31860ca408324b359ad9cae908c36