### PR TITLE
Apply SQLite pragmas on connect

### DIFF
--- a/app/db/session.py
+++ b/app/db/session.py
@@ -14,9 +14,9 @@ DB_URL = os.getenv("DATABASE_URL", "sqlite:///./dev.db")
 engine = create_engine(DB_URL, echo=False, future=True)
 
 if engine.url.get_backend_name() == "sqlite":
-
-    @event.listens_for(engine, "connect")
-    def _sqlite_configure(dbapi_connection, connection_record):  # pragma: no cover - depends on driver
+    # Apply PRAGMAs on each connection (Windows-friendly performance tuning)
+    @event.listens_for(engine, "connect")  # pragma: no cover - driver dependent
+    def _sqlite_configure(dbapi_connection, connection_record):
         apply_default_pragmas(dbapi_connection)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, expire_on_commit=False, future=True)
 


### PR DESCRIPTION
## Summary
- ensure the SQLite engine applies the tuned default PRAGMAs on every connection via the SQLAlchemy connect event

## Testing
- pytest *(fails: skipped because pyswisseph not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e3308fea788324b0af9c20420950ca