### PR TITLE
Add Windows packaging scripts and launcher

### DIFF
--- a/packaging/windows/AstroEngineLauncher.py
+++ b/packaging/windows/AstroEngineLauncher.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+import os, sys, subprocess, threading, time, webbrowser, signal
+from pathlib import Path
+
+# Resolve app root whether frozen (PyInstaller) or source
+if getattr(sys, "frozen", False):
+    BASE = Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    ROOT = Path(sys.executable).parent  # dist/AstroEngine
+else:
+    BASE = Path(__file__).resolve().parents[2]
+    ROOT = BASE
+
+# Default ports
+API_PORT = int(os.environ.get("ASTROENGINE_API_PORT", "8000"))
+UI_PORT = int(os.environ.get("ASTROENGINE_UI_PORT", "8501"))
+
+# Ensure a writable workspace for user data
+APPDATA = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / ".astroengine"))) / "AstroEngine"
+APPDATA.mkdir(parents=True, exist_ok=True)
+
+# Environment for child processes
+env = os.environ.copy()
+env.setdefault("ASTROENGINE_HOME", str(APPDATA))
+env.setdefault("ASTROENGINE_API", f"http://127.0.0.1:{API_PORT}")
+# Respect pre-set SE_EPHE_PATH if user configured; otherwise leave empty and Doctor will guide
+
+# Resolve entry files
+API_APP = "app.main:app"
+STREAMLIT_ENTRY = BASE / "ui" / "streamlit" / "main_portal.py"
+STREAMLIT_CONFIG_DIR = BASE / ".streamlit"
+
+# When frozen, streamlit should read config.toml from a real dir
+env.setdefault("STREAMLIT_SERVER_PORT", str(UI_PORT))
+env.setdefault("STREAMLIT_SERVER_HEADLESS", "true")
+env.setdefault("STREAMLIT_BROWSER_GATHERUSAGESTATS", "false")
+env.setdefault("STREAMLIT_CONFIG_DIR", str(STREAMLIT_CONFIG_DIR))
+
+api_proc: subprocess.Popen | None = None
+ui_proc: subprocess.Popen | None = None
+
+
+def start_api():
+    global api_proc
+    # Use uvicorn programmatically via module to avoid path issues
+    cmd = [sys.executable, "-m", "uvicorn", API_APP, "--host", "127.0.0.1", "--port", str(API_PORT), "--log-level", "warning"]
+    api_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+
+
+def start_ui():
+    global ui_proc
+    cmd = [sys.executable, "-m", "streamlit", "run", str(STREAMLIT_ENTRY), "--server.port", str(UI_PORT), "--server.headless", "true"]
+    ui_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+
+
+def open_browser():
+    time.sleep(1.5)
+    try:
+        webbrowser.open(f"http://127.0.0.1:{UI_PORT}")
+    except Exception:
+        pass
+
+
+def main():
+    start_api()
+    # Wait a beat so UI can connect to API reliably
+    time.sleep(0.8)
+    start_ui()
+    threading.Thread(target=open_browser, daemon=True).start()
+
+    def shutdown(*_):
+        if ui_proc and ui_proc.poll() is None:
+            ui_proc.terminate()
+        if api_proc and api_proc.poll() is None:
+            api_proc.terminate()
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    # Wait for UI to exit; if it dies early, also kill API
+    code = 0
+    try:
+        code = ui_proc.wait() if ui_proc else 0
+    finally:
+        if api_proc and api_proc.poll() is None:
+            api_proc.terminate()
+        if api_proc:
+            api_proc.wait(timeout=5)
+    sys.exit(code)
+
+
+if __name__ == "__main__":
+    main()

--- a/packaging/windows/astroengine.spec
+++ b/packaging/windows/astroengine.spec
@@ -1,0 +1,78 @@
+# Build with: pyinstaller packaging/windows/astroengine.spec
+import os
+from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+
+block_cipher = None
+
+project_root = os.path.abspath(".")
+
+ui_data = collect_data_files(
+    "ui",
+    includes=[
+        "streamlit/**/*.py",
+        "streamlit/**/*.json",
+        "streamlit/**/*.yaml",
+        "streamlit/**/*.toml",
+        "streamlit/**/*.txt",
+    ],
+    excludes=["**/__pycache__/**"],
+)
+astro_data = collect_data_files(
+    "astroengine",
+    includes=["**/*.yaml", "**/*.yml", "**/*.json", "**/*.csv", "**/*.toml"],
+    excludes=["**/__pycache__/**"],
+)
+
+datas = []
+datas += ui_data
+datas += astro_data
+datas += [(".streamlit", ".streamlit")]
+
+hiddenimports = []
+for pkg in ("pkg_resources", "streamlit", "uvicorn", "anyio"):
+    hiddenimports += collect_submodules(pkg)
+
+
+a = Analysis(
+    ["packaging/windows/AstroEngineLauncher.py"],
+    pathex=[project_root],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=["packaging/hooks"],
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    name="AstroEngine",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon="packaging/windows/icon.ico" if os.path.exists("packaging/windows/icon.ico") else None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="AstroEngine",
+)

--- a/packaging/windows/installer.iss
+++ b/packaging/windows/installer.iss
@@ -1,0 +1,53 @@
+; Build with: iscc packaging\windows\installer.iss
+[Setup]
+AppName=AstroEngine
+AppVersion={#GetFileVersion("..\..\dist\AstroEngine\AstroEngine.exe")}
+DefaultDirName={pf}\AstroEngine
+DefaultGroupName=AstroEngine
+OutputDir=packaging\windows\Output
+OutputBaseFilename=AstroEngine-Setup
+DisableDirPage=no
+DisableProgramGroupPage=no
+Compression=lzma2
+SolidCompression=yes
+ArchitecturesInstallIn64BitMode=x64
+UninstallDisplayIcon={app}\AstroEngine.exe
+WizardStyle=modern
+
+[Languages]
+Name: "en"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: env; Description: "Set SE_EPHE_PATH environment variable"; GroupDescription: "Environment"; Flags: unchecked
+
+[Files]
+Source: "..\..\dist\AstroEngine\*"; DestDir: "{app}"; Flags: recursesubdirs createallsubdirs
+
+[Icons]
+Name: "{group}\AstroEngine"; Filename: "{app}\AstroEngine.exe"; WorkingDir: "{app}"
+Name: "{commondesktop}\AstroEngine"; Filename: "{app}\AstroEngine.exe"; Tasks:
+
+[Run]
+Filename: "{app}\AstroEngine.exe"; Description: "Launch AstroEngine"; Flags: nowait postinstall skipifsilent
+
+[Registry]
+; Optionally set a user-level environment variable for ephemeris path
+Root: HKCU; Subkey: "Environment"; ValueType: string; ValueName: "SE_EPHE_PATH"; ValueData: "{code:GetEphemerisPath}"; Flags: preservestringtype; Tasks: env
+
+[Code]
+var
+  EphePage: TInputDirWizardPage;
+
+function GetEphemerisPath(Value: string): string;
+begin
+  if WizardIsTaskSelected('env') then
+    Result := EphePage.Values[0]
+  else
+    Result := GetEnv('SE_EPHE_PATH');
+end;
+
+procedure InitializeWizard;
+begin
+  EphePage := CreateInputDirPage(wpSelectTasks, 'Swiss Ephemeris Data', 'Optional: select your ephemeris data folder', 'If you have Swiss Ephemeris .se1/.se2 files, choose the folder so the app can find them. You can also set this later in the app under Doctor.', False, 'Folder containing ephemeris files:');
+  EphePage.Add('');
+end;

--- a/packaging/windows/make.bat
+++ b/packaging/windows/make.bat
@@ -1,0 +1,35 @@
+@echo off
+setlocal EnableDelayedExpansion
+
+REM Python 3.11 venv
+py -3.11 -m venv .venv
+call .venv\Scripts\activate.bat
+python -m pip install --upgrade pip wheel setuptools
+
+REM Install app + extras
+pip install -e .
+pip install -r requirements.txt
+if exist requirements-optional.txt pip install -r requirements-optional.txt
+
+REM Build launcher
+pyinstaller packaging\windows\astroengine.spec --noconfirm
+if errorlevel 1 goto :error
+
+echo ===== Portable onedir at dist\AstroEngine =====
+
+echo ===== Building Inno Setup installer (optional) =====
+where iscc.exe >nul 2>&1
+if %errorlevel%==0 (
+  iscc packaging\windows\installer.iss
+  if errorlevel 1 goto :error
+  echo Installer built under: packaging\windows\Output
+) else (
+  echo Inno Setup not found (iscc.exe). Skipping installer step.
+)
+
+echo DONE
+exit /b 0
+
+:error
+echo Build failed. See errors above.
+exit /b 1

--- a/packaging/windows/run-portable.bat
+++ b/packaging/windows/run-portable.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+set ASTROENGINE_API=http://127.0.0.1:8000
+set STREAMLIT_SERVER_HEADLESS=true
+set STREAMLIT_BROWSER_GATHERUSAGESTATS=false
+
+REM Optional: set ephemeris path if known
+REM set SE_EPHE_PATH=D:\Ephemeris
+
+start "AstroEngine API+UI" "AstroEngine.exe"


### PR DESCRIPTION
## Summary
- add a Windows launcher that boots the FastAPI backend and Streamlit UI together
- provide a PyInstaller spec plus helper batch scripts for portable and installer builds
- include an Inno Setup script and portable runner for distributing AstroEngine on Windows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3349f217c832492ec8de97094fda8