### PR TITLE
Ensure Windows packaging uses timezonefinder wheels

### DIFF
--- a/packaging/windows/make.bat
+++ b/packaging/windows/make.bat
@@ -6,9 +6,14 @@ py -3.11 -m venv .venv
 call .venv\Scripts\activate.bat
 python -m pip install --upgrade pip wheel setuptools
 
-REM Install app + extras
+REM Install app + deps (Windows-friendly)
 pip install -e .
-pip install -r requirements.txt
+if exist packaging\windows\requirements-win.txt (
+  pip install -r packaging\windows\requirements-win.txt
+) else (
+  pip install -r requirements.txt
+  pip install pyinstaller==6.10.*
+)
 if exist requirements-optional.txt pip install -r requirements-optional.txt
 
 REM Build launcher

--- a/packaging/windows/requirements-win.txt
+++ b/packaging/windows/requirements-win.txt
@@ -1,0 +1,4 @@
+--only-binary :all:
+-r requirements.txt
+timezonefinder==6.2.*
+pyinstaller==6.10.*


### PR DESCRIPTION
## Summary
- add a Windows-specific requirements file that forces binary wheels for timezonefinder and pins PyInstaller
- update the Windows packaging script to consume the Windows requirements when present

## Testing
- pytest *(fails: Skipped: pyswisseph not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e33997e2588324ab0ceb30bcf8e36f