### PR TITLE
Update license metadata in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ description = "AstroEngine — modular transit engine and astrology toolkit"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "AstroEngine Maintainers" }]
-license = { text = "Proprietary" }
+license = "LicenseRef-Proprietary"
 keywords = ["astrology", "ephemeris", "transits", "astronomy"]
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -229,6 +229,7 @@ fallback_version = "0.0.0"
 # Install the real package directory (not the generated skeleton only)
 packages = { find = { where = ["."], include = ["astroengine*"] } }
 include-package-data = true
+license-files = ["LICENSE", "NOTICE*", "COPYING*"]
 # >>> AUTO-GEN END: packaging-and-extras v1.0
 
 # >>> AUTO-GEN BEGIN: ruff target py311 v1.1


### PR DESCRIPTION
## Summary
- switch the project license field to a simple SPDX identifier for proprietary distribution
- declare default license file patterns for setuptools packaging

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e339ab6b688324bdceac22a03c811c