### PR TITLE
Pin PyInstaller dependencies for Windows builds

### DIFF
--- a/docs/module/release_ops.md
+++ b/docs/module/release_ops.md
@@ -47,8 +47,12 @@ comparison artefacts.
   `ubuntu-latest` and `windows-latest` whenever a `v*` tag is pushed. Each job
   installs the provider extras, runs the pytest suite, builds the sdist/wheel
   set, and (on Windows) packages the new PyInstaller portal bundle that targets
-  `ui/streamlit/main_portal.py` with bundled ephemeris data. The resulting
-  artifacts are published to a draft GitHub release for review.
+  `ui/streamlit/main_portal.py` with bundled ephemeris data. Windows builds pin
+  `pyinstaller==6.10.*`, mirroring the local scripts (`scripts/build_windows.ps1`
+  and `packaging/windows/make.bat`). When running the packaging flow manually,
+  install that version explicitly to avoid "pyinstaller is not recognized"
+  errors. The resulting artifacts are published to a draft GitHub release for
+  review.
 - `.github/workflows/nightly-smoke-bench.yml` runs daily and records the timing
   of deterministic electional searches and forecast stack builds using the
   Swiss ephemeris stub. The JSON trend file is stored under

--- a/packaging/windows/make.bat
+++ b/packaging/windows/make.bat
@@ -12,6 +12,8 @@ pip install -r requirements.txt
 if exist requirements-optional.txt pip install -r requirements-optional.txt
 
 REM Build launcher
+REM Ensure the expected PyInstaller toolchain is available.
+pip install "pyinstaller==6.10.*"
 pyinstaller packaging\windows\astroengine.spec --noconfirm
 if errorlevel 1 goto :error
 

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -15,7 +15,8 @@ if ($WithObs) { $extras = "$extras,obs" }
 pip install -e ".[${extras}]"
 
 # 3) PyInstaller
-pip install pyinstaller
+# Pin to the vetted 6.10 series so the build finds the CLI entry points.
+pip install 'pyinstaller==6.10.*'
 
 # 4) Build EXEs
 pyinstaller packaging/astroengine_cli.spec --noconfirm


### PR DESCRIPTION
## Summary
- pin the Windows packaging scripts to install PyInstaller 6.10 to avoid missing executable errors
- document the pinned PyInstaller requirement in the release operations guide so manual builds follow the same steps

## Testing
- not run (script and documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e3399f43fc8324b587aabd44784ba8