### PR TITLE
Fix PyInstaller spec to bundle UI assets and correct launcher paths

### DIFF
--- a/packaging/windows/AstroEngineLauncher.py
+++ b/packaging/windows/AstroEngineLauncher.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 import os, sys, subprocess, threading, time, webbrowser, signal
 from pathlib import Path
 
-# Resolve app root whether frozen (PyInstaller) or source
+# Resolve paths both when frozen (PyInstaller) and from source
 if getattr(sys, "frozen", False):
-    BASE = Path(sys._MEIPASS)  # type: ignore[attr-defined]
-    ROOT = Path(sys.executable).parent  # dist/AstroEngine
+    APP_DIR = Path(sys.executable).parent  # dist/AstroEngine
+    BASE = APP_DIR  # app root (contains bundled files)
 else:
     BASE = Path(__file__).resolve().parents[2]
-    ROOT = BASE
+    APP_DIR = BASE
 
 # Default ports
 API_PORT = int(os.environ.get("ASTROENGINE_API_PORT", "8000"))
@@ -43,13 +43,13 @@ def start_api():
     global api_proc
     # Use uvicorn programmatically via module to avoid path issues
     cmd = [sys.executable, "-m", "uvicorn", API_APP, "--host", "127.0.0.1", "--port", str(API_PORT), "--log-level", "warning"]
-    api_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+    api_proc = subprocess.Popen(cmd, cwd=str(APP_DIR), env=env)
 
 
 def start_ui():
     global ui_proc
     cmd = [sys.executable, "-m", "streamlit", "run", str(STREAMLIT_ENTRY), "--server.port", str(UI_PORT), "--server.headless", "true"]
-    ui_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+    ui_proc = subprocess.Popen(cmd, cwd=str(APP_DIR), env=env)
 
 
 def open_browser():

--- a/packaging/windows/astroengine.spec
+++ b/packaging/windows/astroengine.spec
@@ -1,53 +1,54 @@
-# Build with: pyinstaller packaging/windows/astroengine.spec
+# Build with:
+#   pyinstaller packaging/windows/astroengine.spec --noconfirm
 import os
 from PyInstaller.utils.hooks import collect_submodules, collect_data_files
+from PyInstaller.building.build_main import Analysis, PYZ, EXE, COLLECT
+from PyInstaller.compat import is_win
 
-block_cipher = None
+root = os.path.abspath(".")
+launcher = os.path.join(root, "packaging", "windows", "AstroEngineLauncher.py")
 
-project_root = os.path.abspath(".")
+# Hidden imports: we run `-m streamlit` and `-m uvicorn` as subprocesses,
+# so explicitly include their packages in the frozen app.
+hidden = []
+hidden += collect_submodules("streamlit")
+hidden += collect_submodules("uvicorn")
+hidden += collect_submodules("anyio")
+hidden += collect_submodules("pkg_resources")  # quiets altgraph/pkg_resources warning
 
-ui_data = collect_data_files(
-    "ui",
-    includes=[
-        "streamlit/**/*.py",
-        "streamlit/**/*.json",
-        "streamlit/**/*.yaml",
-        "streamlit/**/*.toml",
-        "streamlit/**/*.txt",
-    ],
-    excludes=["**/__pycache__/**"],
-)
+# Data files from our own package
 astro_data = collect_data_files(
     "astroengine",
     includes=["**/*.yaml", "**/*.yml", "**/*.json", "**/*.csv", "**/*.toml"],
     excludes=["**/__pycache__/**"],
 )
 
-datas = []
-datas += ui_data
-datas += astro_data
-datas += [(".streamlit", ".streamlit")]
+# Copy the UI source tree as plain files so Streamlit can run them by path
+def tree(src, dst_prefix):
+    # (src, dst) tuples for COLLECT
+    res = []
+    for dirpath, _, files in os.walk(src):
+        for f in files:
+            full = os.path.join(dirpath, f)
+            rel = os.path.relpath(full, src)
+            res.append((full, os.path.join(dst_prefix, rel)))
+    return res
 
-hiddenimports = []
-for pkg in ("pkg_resources", "streamlit", "uvicorn", "anyio"):
-    hiddenimports += collect_submodules(pkg)
+ui_tree = tree(os.path.join(root, "ui"), "ui")
+streamlit_cfg = tree(os.path.join(root, ".streamlit"), ".streamlit") if os.path.isdir(".streamlit") else []
 
+datas = astro_data + ui_tree + streamlit_cfg
 
 a = Analysis(
-    ["packaging/windows/AstroEngineLauncher.py"],
-    pathex=[project_root],
-    binaries=[],
+    [launcher],
+    pathex=[root],
+    hiddenimports=hidden,
     datas=datas,
-    hiddenimports=hiddenimports,
-    hookspath=["packaging/hooks"],
-    runtime_hooks=[],
-    excludes=[],
-    win_no_prefer_redirects=False,
-    win_private_assemblies=False,
-    cipher=block_cipher,
+    binaries=[],
     noarchive=False,
 )
-pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+pyz = PYZ(a.pure)
 exe = EXE(
     pyz,
     a.scripts,
@@ -55,24 +56,14 @@ exe = EXE(
     a.zipfiles,
     a.datas,
     name="AstroEngine",
-    debug=False,
-    bootloader_ignore_signals=False,
-    strip=False,
-    upx=False,
-    console=False,
-    disable_windowed_traceback=False,
-    target_arch=None,
-    codesign_identity=None,
-    entitlements_file=None,
-    icon="packaging/windows/icon.ico" if os.path.exists("packaging/windows/icon.ico") else None,
+    console=False,  # flip True if you want a debug console
+    icon=os.path.join(root, "packaging", "windows", "icon.ico") if os.path.exists(os.path.join(root, "packaging", "windows", "icon.ico")) else None,
 )
+
 coll = COLLECT(
     exe,
     a.binaries,
     a.zipfiles,
     a.datas,
-    strip=False,
-    upx=False,
-    upx_exclude=[],
     name="AstroEngine",
 )


### PR DESCRIPTION
## Summary
- replace the PyInstaller spec with one that freezes the Streamlit/uvicorn modules, copies the UI tree, and resolves the launcher from the correct root
- adjust the Windows launcher to derive the base directory consistently when frozen or from source

## Testing
- pytest *(fails: pyswisseph not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e33bb9cd048324acfef503de615611