### PR TITLE
Improve Windows launcher stability

### DIFF
--- a/packaging/windows/AstroEngineLauncher.py
+++ b/packaging/windows/AstroEngineLauncher.py
@@ -1,92 +1,138 @@
 from __future__ import annotations
-import os, sys, subprocess, threading, time, webbrowser, signal
+import os, sys, subprocess, threading, time, signal, socket
 from pathlib import Path
 
-# Resolve paths both when frozen (PyInstaller) and from source
+try:
+    import urllib.request, urllib.error
+except Exception:
+    urllib = None  # type: ignore
+
+# -------- Paths --------
 if getattr(sys, "frozen", False):
-    APP_DIR = Path(sys.executable).parent  # dist/AstroEngine
-    BASE = APP_DIR  # app root (contains bundled files)
+    BASE = Path(sys.executable).parent   # dist/AstroEngine
+    ROOT = BASE
 else:
     BASE = Path(__file__).resolve().parents[2]
-    APP_DIR = BASE
+    ROOT = BASE
 
-# Default ports
 API_PORT = int(os.environ.get("ASTROENGINE_API_PORT", "8000"))
 UI_PORT = int(os.environ.get("ASTROENGINE_UI_PORT", "8501"))
-
-# Ensure a writable workspace for user data
+AUTO_OPEN = os.environ.get("ASTROENGINE_NO_BROWSER", "0") not in ("1", "true", "TRUE")
 APPDATA = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / ".astroengine"))) / "AstroEngine"
 APPDATA.mkdir(parents=True, exist_ok=True)
 
-# Environment for child processes
 env = os.environ.copy()
 env.setdefault("ASTROENGINE_HOME", str(APPDATA))
 env.setdefault("ASTROENGINE_API", f"http://127.0.0.1:{API_PORT}")
-# Respect pre-set SE_EPHE_PATH if user configured; otherwise leave empty and Doctor will guide
-
-# Resolve entry files
-API_APP = "app.main:app"
-STREAMLIT_ENTRY = BASE / "ui" / "streamlit" / "main_portal.py"
-STREAMLIT_CONFIG_DIR = BASE / ".streamlit"
-
-# When frozen, streamlit should read config.toml from a real dir
 env.setdefault("STREAMLIT_SERVER_PORT", str(UI_PORT))
 env.setdefault("STREAMLIT_SERVER_HEADLESS", "true")
 env.setdefault("STREAMLIT_BROWSER_GATHERUSAGESTATS", "false")
-env.setdefault("STREAMLIT_CONFIG_DIR", str(STREAMLIT_CONFIG_DIR))
+env.setdefault("STREAMLIT_CONFIG_DIR", str(BASE / ".streamlit"))
+
+API_APP = "app.main:app"
+STREAMLIT_ENTRY = BASE / "ui" / "streamlit" / "main_portal.py"
 
 api_proc: subprocess.Popen | None = None
 ui_proc: subprocess.Popen | None = None
 
+# -------- Helpers --------
+def _port_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.2)
+        return s.connect_ex(("127.0.0.1", port)) == 0
 
-def start_api():
-    global api_proc
-    # Use uvicorn programmatically via module to avoid path issues
-    cmd = [sys.executable, "-m", "uvicorn", API_APP, "--host", "127.0.0.1", "--port", str(API_PORT), "--log-level", "warning"]
-    api_proc = subprocess.Popen(cmd, cwd=str(APP_DIR), env=env)
+def _wait_http(url: str, timeout: float = 25.0) -> bool:
+    if not urllib:
+        # best effort fallback to TCP port check
+        start = time.time()
+        while time.time() - start < timeout:
+            if _port_open(UI_PORT):
+                return True
+            time.sleep(0.2)
+        return False
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as _:
+                return True
+        except Exception:
+            time.sleep(0.3)
+    return False
 
-
-def start_ui():
-    global ui_proc
-    cmd = [sys.executable, "-m", "streamlit", "run", str(STREAMLIT_ENTRY), "--server.port", str(UI_PORT), "--server.headless", "true"]
-    ui_proc = subprocess.Popen(cmd, cwd=str(APP_DIR), env=env)
-
-
-def open_browser():
-    time.sleep(1.5)
+def _open_browser_once():
+    import webbrowser
     try:
         webbrowser.open(f"http://127.0.0.1:{UI_PORT}")
     except Exception:
         pass
 
+# -------- Launchers --------
+def start_api():
+    global api_proc
+    if _port_open(API_PORT):
+        return
+    cmd = [sys.executable, "-m", "uvicorn", API_APP, "--host", "127.0.0.1", "--port", str(API_PORT), "--log-level", "warning"]
+    api_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+
+def start_ui():
+    global ui_proc
+    if _port_open(UI_PORT):
+        return
+    cmd = [
+        sys.executable, "-m", "streamlit", "run", str(STREAMLIT_ENTRY),
+        "--server.port", str(UI_PORT),
+        "--server.headless", "true",
+        "--server.fileWatcherType", "poll",   # more stable in frozen envs
+        "--browser.gatherUsageStats", "false",
+    ]
+    ui_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
 
 def main():
-    start_api()
-    # Wait a beat so UI can connect to API reliably
-    time.sleep(0.8)
-    start_ui()
-    threading.Thread(target=open_browser, daemon=True).start()
+    # If UI already running, just open a single tab and exit.
+    if _port_open(UI_PORT):
+        if AUTO_OPEN:
+            _open_browser_once()
+        sys.exit(0)
 
+    # Start API if needed
+    start_api()
+    # Give API a head start (UI talks to it on load)
+    time.sleep(0.8)
+
+    # Start UI (if port free)
+    start_ui()
+
+    # Open one tab after the UI is ready
+    if AUTO_OPEN:
+        def waiter():
+            if _wait_http(f"http://127.0.0.1:{UI_PORT}"):
+                _open_browser_once()
+        threading.Thread(target=waiter, daemon=True).start()
+
+    # Graceful shutdown
     def shutdown(*_):
-        if ui_proc and ui_proc.poll() is None:
-            ui_proc.terminate()
-        if api_proc and api_proc.poll() is None:
-            api_proc.terminate()
+        for p in (ui_proc, api_proc):
+            try:
+                if p and p.poll() is None:
+                    p.terminate()
+            except Exception:
+                pass
 
     signal.signal(signal.SIGINT, shutdown)
     signal.signal(signal.SIGTERM, shutdown)
 
-    # Wait for UI to exit; if it dies early, also kill API
     code = 0
     try:
-        code = ui_proc.wait() if ui_proc else 0
+        if ui_proc:
+            code = ui_proc.wait()
     finally:
         if api_proc and api_proc.poll() is None:
-            api_proc.terminate()
-        if api_proc:
-            api_proc.wait(timeout=5)
+            try:
+                api_proc.terminate()
+                api_proc.wait(timeout=5)
+            except Exception:
+                pass
     sys.exit(code)
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- replace the Windows launcher with a safer version that checks for running API/UI ports before spawning new processes
- wait for the Streamlit UI to respond before opening a browser tab and honor ASTROENGINE_NO_BROWSER
- force Streamlit to use the poll-based file watcher for better reliability in frozen builds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3bcdc92188324b1ff28fec464fe4b