### PR TITLE
Harden Windows desktop bundle asset coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,14 @@ diagnostics inside a WebView2-powered desktop window. Launch it locally with:
 python -m app.desktop.launch_desktop
 ```
 
+To build the Windows 11 installer, run `packaging\windows\make.bat` from a
+Developer Command Prompt. The script creates `dist\AstroEngine\AstroEngine.exe`
+using PyInstaller (pointing at the native desktop shell) and, if Inno Setup is
+available, emits an installer at `packaging\windows\Output` that places
+shortcuts in the Start menu and on the desktop. Double-clicking the bundled
+`AstroEngine.exe` brings up the self-contained desktop app—no browser is opened
+and the FastAPI/Streamlit processes are orchestrated by the embedded shell.
+
 Key behaviour:
 
 * **Native menus & tray.** Start/stop the API, reopen the embedded UI, tail
@@ -100,9 +108,13 @@ Key behaviour:
   viewers are available from the menus, and a one-click issue report bundles an
   anonymised diagnostics snapshot for support.
 * **Bundled portal launcher.** CI publishes a PyInstaller build generated from
-  `packaging/astroengine_portal.spec`. The executable ships the Streamlit
-  `main_portal.py` experience with the Swiss ephemeris stub baked in and keeps
-  user data under `%LOCALAPPDATA%/AstroEngine`.
+  `packaging/windows/astroengine.spec`. The executable ships the Streamlit
+  `main_portal.py` experience inside the desktop shell with the Swiss ephemeris
+  stub baked in and keeps user data under `%LOCALAPPDATA%/AstroEngine`.
+* **Ruleset parity.** The PyInstaller spec now copies every packaged ruleset,
+  dataset, schema, and HTML asset so the desktop API uses the same
+  data-backed modules as source installs—no functionality is lost in the
+  Windows bundle.
 * **ChatGPT copilot.** The dockable copilot panel can tail logs, run
   diagnostics, summarise API errors, and explain endpoints. Provide an OpenAI
   API key and model in Settings to enable remote completions; otherwise the

--- a/astroengine/ux/desktop/chat.html
+++ b/astroengine/ux/desktop/chat.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>AstroEngine Copilot</title>
+<style>
+body { font-family: 'Segoe UI', sans-serif; margin: 0; padding: 1rem; background: #0f1224; color: #f5f6fa; }
+#messages { max-height: 520px; overflow-y: auto; padding: 0.5rem; border: 1px solid #272a4b; border-radius: 8px; background: #141836; }
+.message { margin-bottom: 1rem; padding: 0.6rem 0.75rem; border-radius: 6px; }
+.message.user { background: #1e2344; border-left: 3px solid #c9973b; }
+.message.assistant { background: #16294f; border-left: 3px solid #0f9960; }
+#composer { display: flex; gap: 0.5rem; margin-top: 1rem; }
+#composer textarea { flex: 1; min-height: 60px; border-radius: 6px; border: 1px solid #2d3256; background: #1b2040; color: #f5f6fa; padding: 0.5rem; }
+#composer button { padding: 0.6rem 1rem; border: none; border-radius: 6px; background: #c9973b; color: #101321; font-weight: 600; cursor: pointer; }
+#status { margin-top: 0.5rem; font-size: 0.85rem; color: #9aa5ff; }
+</style>
+</head>
+<body>
+<h1>AstroEngine Copilot</h1>
+<div id="messages"></div>
+<div id="status"></div>
+<form id="composer">
+  <textarea id="prompt" placeholder="Ask the copilot to run diagnostics, tail logs, or explain an endpoint..."></textarea>
+  <button>Send</button>
+</form>
+<script>
+const messagesEl = document.getElementById('messages');
+const statusEl = document.getElementById('status');
+const composer = document.getElementById('composer');
+const promptEl = document.getElementById('prompt');
+
+function append(role, text) {
+  const div = document.createElement('div');
+  div.className = 'message ' + role;
+  div.innerHTML = '<strong>' + role + '</strong><br />' + text.replace(/\n/g, '<br />');
+  messagesEl.appendChild(div);
+  messagesEl.scrollTop = messagesEl.scrollHeight;
+}
+
+async function refreshStatus() {
+  const stats = await window.pywebview.api.copilot_status();
+  statusEl.textContent = `Tokens today: ${stats.tokens_used_today}/${stats.daily_limit} · API ${stats.client_available ? 'ready' : 'not configured'}`;
+}
+
+composer.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const text = promptEl.value.trim();
+  if (!text) return;
+  append('user', text);
+  promptEl.value = '';
+  append('assistant', '… running tools / awaiting response …');
+  const nodes = messagesEl.querySelectorAll('.message.assistant');
+  const placeholder = nodes[nodes.length - 1];
+  const result = await window.pywebview.api.copilot_send(text);
+  placeholder.innerHTML = '<strong>assistant</strong><br />' + result.response.replace(/\n/g, '<br />');
+  refreshStatus();
+});
+
+window.AstroEngine = window.AstroEngine || {};
+window.AstroEngine.setApiStatus = function(online) {
+  statusEl.style.borderBottom = online ? '3px solid #0f9960' : '3px solid #ff6b6b';
+};
+
+refreshStatus();
+</script>
+</body>
+</html>

--- a/astroengine/ux/desktop/settings.html
+++ b/astroengine/ux/desktop/settings.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>AstroEngine Settings</title>
+<style>
+body { font-family: 'Segoe UI', sans-serif; margin: 0; padding: 1.5rem; background: #0f1224; color: #f5f6fa; }
+form { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+.field { display: flex; flex-direction: column; gap: 0.4rem; padding: 0.75rem; border-radius: 8px; background: #181c36; border: 1px solid #24294b; }
+label { font-weight: 600; }
+input, select { padding: 0.6rem; border-radius: 6px; border: 1px solid #31375c; background: #1c2142; color: #f5f6fa; }
+.actions { grid-column: 1 / -1; display: flex; gap: 0.75rem; margin-top: 1rem; }
+button { padding: 0.7rem 1.2rem; border: none; border-radius: 6px; background: #c9973b; color: #101321; font-weight: 600; cursor: pointer; }
+button.secondary { background: #1e2344; color: #f5f6fa; border: 1px solid #31375c; }
+#status { margin-top: 1rem; font-size: 0.85rem; color: #9aa5ff; grid-column: 1 / -1; }
+small { color: #9aa5ff; }
+</style>
+</head>
+<body>
+<h1>AstroEngine Desktop Settings</h1>
+<form id="settings">
+  <div class="field">
+    <label for="database_url">Database URL</label>
+    <input id="database_url" name="database_url" placeholder="sqlite:///astroengine-desktop.db" />
+    <small>Must be reachable. The Verify button runs a live connection check.</small>
+  </div>
+  <div class="field">
+    <label for="se_ephe_path">Swiss Ephemeris Path</label>
+    <input id="se_ephe_path" name="se_ephe_path" placeholder="C:\\AstroEngine\\ephe" />
+    <small>Optional: leave blank to use bundled fallback.</small>
+  </div>
+  <div class="field">
+    <label for="api_host">API Host</label>
+    <input id="api_host" name="api_host" />
+  </div>
+  <div class="field">
+    <label for="api_port">API Port</label>
+    <input id="api_port" name="api_port" type="number" min="1" max="65535" />
+  </div>
+  <div class="field">
+    <label for="streamlit_port">Streamlit Port</label>
+    <input id="streamlit_port" name="streamlit_port" type="number" min="1" max="65535" />
+  </div>
+  <div class="field">
+    <label for="logging_level">Logging Level</label>
+    <select id="logging_level" name="logging_level">
+      <option value="CRITICAL">CRITICAL</option>
+      <option value="ERROR">ERROR</option>
+      <option value="WARNING">WARNING</option>
+      <option value="INFO">INFO</option>
+      <option value="DEBUG">DEBUG</option>
+      <option value="NOTSET">NOTSET</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="theme">Theme</label>
+    <select id="theme" name="theme">
+      <option value="system">System</option>
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="high_contrast">High Contrast</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="qcache_sec">Query Cache Window (seconds)</label>
+    <input id="qcache_sec" name="qcache_sec" type="number" min="0.1" step="0.1" />
+  </div>
+  <div class="field">
+    <label for="qcache_size">Query Cache Size</label>
+    <input id="qcache_size" name="qcache_size" type="number" min="128" step="128" />
+  </div>
+  <div class="field">
+    <label for="openai_api_key">OpenAI API Key</label>
+    <input id="openai_api_key" name="openai_api_key" type="password" />
+    <small>Stored locally. Leave blank to disable GPT integrations.</small>
+  </div>
+  <div class="field">
+    <label for="openai_model">OpenAI Model</label>
+    <input id="openai_model" name="openai_model" placeholder="gpt-4o-mini" />
+  </div>
+  <div class="field">
+    <label for="openai_base_url">OpenAI Base URL</label>
+    <input id="openai_base_url" name="openai_base_url" placeholder="https://api.openai.com/v1" />
+  </div>
+  <div class="field">
+    <label for="copilot_daily_limit">Copilot Daily Token Limit</label>
+    <input id="copilot_daily_limit" name="copilot_daily_limit" type="number" min="0" />
+  </div>
+  <div class="field">
+    <label for="copilot_session_limit">Copilot Session Token Limit</label>
+    <input id="copilot_session_limit" name="copilot_session_limit" type="number" min="0" />
+  </div>
+  <div class="field">
+    <label for="autostart">Autostart</label>
+    <select id="autostart" name="autostart">
+      <option value="false">Disabled</option>
+      <option value="true">Launch at login</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="issue_report_dir">Issue Bundle Directory</label>
+    <input id="issue_report_dir" name="issue_report_dir" />
+    <small>Change where diagnostics bundles are stored.</small>
+  </div>
+  <div class="actions">
+    <button type="submit">Save</button>
+    <button type="button" id="verify_db" class="secondary">Verify Database</button>
+    <button type="button" id="verify_ephe" class="secondary">Verify Ephemeris Path</button>
+    <button type="button" id="issue_bundle" class="secondary">Create Issue Bundle</button>
+  </div>
+  <div id="status"></div>
+</form>
+<script>
+const form = document.getElementById('settings');
+const statusEl = document.getElementById('status');
+const dbBtn = document.getElementById('verify_db');
+const epheBtn = document.getElementById('verify_ephe');
+const bundleBtn = document.getElementById('issue_bundle');
+
+function setValue(id, value) {
+  const el = document.getElementById(id);
+  if (!el) return;
+  if (el.tagName === 'SELECT') {
+    el.value = String(value ?? '').toLowerCase();
+  } else {
+    el.value = value ?? '';
+  }
+}
+
+function formData() {
+  const data = new FormData(form);
+  const payload = Object.fromEntries(data.entries());
+  payload.autostart = payload.autostart === 'true';
+  return payload;
+}
+
+function showStatus(message, ok = true) {
+  statusEl.textContent = message;
+  statusEl.style.color = ok ? '#9aa5ff' : '#ff9aa2';
+}
+
+async function load() {
+  const result = await window.pywebview.api.get_config();
+  const config = result;
+  for (const [key, value] of Object.entries(config)) {
+    setValue(key, value);
+  }
+  showStatus('Loaded configuration.');
+}
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const payload = formData();
+  const result = await window.pywebview.api.save_config(payload);
+  if (result.ok) {
+    showStatus('Saved. Services restarting with new configuration.');
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+dbBtn.addEventListener('click', async () => {
+  const payload = formData();
+  const result = await window.pywebview.api.validate_database(payload.database_url);
+  if (result.ok) {
+    showStatus('Database connection succeeded.');
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+epheBtn.addEventListener('click', async () => {
+  const payload = formData();
+  const result = await window.pywebview.api.check_ephemeris(payload.se_ephe_path);
+  if (result.ok) {
+    showStatus('Swiss Ephemeris path verified.');
+  } else {
+    showStatus('Swiss Ephemeris path not found.', false);
+  }
+});
+
+bundleBtn.addEventListener('click', async () => {
+  const result = await window.pywebview.api.issue_bundle();
+  if (result.ok) {
+    showStatus('Issue bundle created at ' + result.path);
+  } else {
+    showStatus(result.error, false);
+  }
+});
+
+window.AstroEngine = window.AstroEngine || {};
+window.AstroEngine.setApiStatus = function(online) {
+  document.body.style.borderTop = online ? '4px solid #0f9960' : '4px solid #ff6b6b';
+};
+
+load();
+</script>
+</body>
+</html>

--- a/packaging/windows/AstroEngineLauncher.py
+++ b/packaging/windows/AstroEngineLauncher.py
@@ -1,138 +1,48 @@
+"""Frozen-entry launcher for the Windows desktop shell.
+
+This thin wrapper exists so the PyInstaller bundle can resolve the
+desktop experience defined in :mod:`app.desktop.launch_desktop`.  It
+does not perform any orchestration itself—the heavy lifting lives in
+the shared desktop module which keeps the FastAPI service, embedded
+Streamlit portal, pywebview shell, and tray automation consistent with
+the rest of the codebase.
+"""
+
 from __future__ import annotations
-import os, sys, subprocess, threading, time, signal, socket
-from pathlib import Path
 
-try:
-    import urllib.request, urllib.error
-except Exception:
-    urllib = None  # type: ignore
+import runpy
+from importlib import import_module
 
-# -------- Paths --------
-if getattr(sys, "frozen", False):
-    BASE = Path(sys.executable).parent   # dist/AstroEngine
-    ROOT = BASE
-else:
-    BASE = Path(__file__).resolve().parents[2]
-    ROOT = BASE
 
-API_PORT = int(os.environ.get("ASTROENGINE_API_PORT", "8000"))
-UI_PORT = int(os.environ.get("ASTROENGINE_UI_PORT", "8501"))
-AUTO_OPEN = os.environ.get("ASTROENGINE_NO_BROWSER", "0") not in ("1", "true", "TRUE")
-APPDATA = Path(os.environ.get("LOCALAPPDATA", str(Path.home() / ".astroengine"))) / "AstroEngine"
-APPDATA.mkdir(parents=True, exist_ok=True)
+def _bootstrap() -> None:
+    """Execute the packaged desktop launcher.
 
-env = os.environ.copy()
-env.setdefault("ASTROENGINE_HOME", str(APPDATA))
-env.setdefault("ASTROENGINE_API", f"http://127.0.0.1:{API_PORT}")
-env.setdefault("STREAMLIT_SERVER_PORT", str(UI_PORT))
-env.setdefault("STREAMLIT_SERVER_HEADLESS", "true")
-env.setdefault("STREAMLIT_BROWSER_GATHERUSAGESTATS", "false")
-env.setdefault("STREAMLIT_CONFIG_DIR", str(BASE / ".streamlit"))
+    We delegate to :func:`app.desktop.launch_desktop.main` so the same
+    code path is exercised whether developers run ``python -m`` during
+    development or the PyInstaller-built executable on Windows 11.
+    ``runpy`` is used as a fallback for environments where the module
+    import succeeds but ``main`` is not directly exposed (for example if
+    packaging adjustments stub it out in the future).  This keeps the
+    frozen entry point resilient without duplicating logic here.
+    """
 
-API_APP = "app.main:app"
-STREAMLIT_ENTRY = BASE / "ui" / "streamlit" / "main_portal.py"
-
-api_proc: subprocess.Popen | None = None
-ui_proc: subprocess.Popen | None = None
-
-# -------- Helpers --------
-def _port_open(port: int) -> bool:
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.settimeout(0.2)
-        return s.connect_ex(("127.0.0.1", port)) == 0
-
-def _wait_http(url: str, timeout: float = 25.0) -> bool:
-    if not urllib:
-        # best effort fallback to TCP port check
-        start = time.time()
-        while time.time() - start < timeout:
-            if _port_open(UI_PORT):
-                return True
-            time.sleep(0.2)
-        return False
-    deadline = time.time() + timeout
-    while time.time() < deadline:
-        try:
-            with urllib.request.urlopen(url, timeout=2) as _:
-                return True
-        except Exception:
-            time.sleep(0.3)
-    return False
-
-def _open_browser_once():
-    import webbrowser
     try:
-        webbrowser.open(f"http://127.0.0.1:{UI_PORT}")
-    except Exception:
-        pass
+        module = import_module("app.desktop.launch_desktop")
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to import AstroEngine desktop launcher") from exc
 
-# -------- Launchers --------
-def start_api():
-    global api_proc
-    if _port_open(API_PORT):
+    main = getattr(module, "main", None)
+    if callable(main):
+        main()
         return
-    cmd = [sys.executable, "-m", "uvicorn", API_APP, "--host", "127.0.0.1", "--port", str(API_PORT), "--log-level", "warning"]
-    api_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
 
-def start_ui():
-    global ui_proc
-    if _port_open(UI_PORT):
-        return
-    cmd = [
-        sys.executable, "-m", "streamlit", "run", str(STREAMLIT_ENTRY),
-        "--server.port", str(UI_PORT),
-        "--server.headless", "true",
-        "--server.fileWatcherType", "poll",   # more stable in frozen envs
-        "--browser.gatherUsageStats", "false",
-    ]
-    ui_proc = subprocess.Popen(cmd, cwd=str(ROOT), env=env)
+    # Fallback to executing the module as a script if ``main`` vanished
+    runpy.run_module("app.desktop.launch_desktop", run_name="__main__")
 
-def main():
-    # If UI already running, just open a single tab and exit.
-    if _port_open(UI_PORT):
-        if AUTO_OPEN:
-            _open_browser_once()
-        sys.exit(0)
 
-    # Start API if needed
-    start_api()
-    # Give API a head start (UI talks to it on load)
-    time.sleep(0.8)
+def main() -> None:
+    _bootstrap()
 
-    # Start UI (if port free)
-    start_ui()
-
-    # Open one tab after the UI is ready
-    if AUTO_OPEN:
-        def waiter():
-            if _wait_http(f"http://127.0.0.1:{UI_PORT}"):
-                _open_browser_once()
-        threading.Thread(target=waiter, daemon=True).start()
-
-    # Graceful shutdown
-    def shutdown(*_):
-        for p in (ui_proc, api_proc):
-            try:
-                if p and p.poll() is None:
-                    p.terminate()
-            except Exception:
-                pass
-
-    signal.signal(signal.SIGINT, shutdown)
-    signal.signal(signal.SIGTERM, shutdown)
-
-    code = 0
-    try:
-        if ui_proc:
-            code = ui_proc.wait()
-    finally:
-        if api_proc and api_proc.poll() is None:
-            try:
-                api_proc.terminate()
-                api_proc.wait(timeout=5)
-            except Exception:
-                pass
-    sys.exit(code)
 
 if __name__ == "__main__":
     main()

--- a/packaging/windows/astroengine.spec
+++ b/packaging/windows/astroengine.spec
@@ -15,11 +15,29 @@ hidden += collect_submodules("streamlit")
 hidden += collect_submodules("uvicorn")
 hidden += collect_submodules("anyio")
 hidden += collect_submodules("pkg_resources")  # quiets altgraph/pkg_resources warning
+hidden += collect_submodules("pywebview")
+hidden += collect_submodules("pystray")
+hidden += collect_submodules("PIL")
 
 # Data files from our own package
 astro_data = collect_data_files(
     "astroengine",
-    includes=["**/*.yaml", "**/*.yml", "**/*.json", "**/*.csv", "**/*.toml"],
+    includes=[
+        "**/*.yaml",
+        "**/*.yml",
+        "**/*.json",
+        "**/*.csv",
+        "**/*.toml",
+        "**/*.html",
+        "**/*.md",
+        "**/*.txt",
+    ],
+    excludes=["**/__pycache__/**"],
+)
+
+desktop_data = collect_data_files(
+    "app.desktop",
+    includes=["**/*.yaml", "**/*.json"],
     excludes=["**/__pycache__/**"],
 )
 
@@ -37,7 +55,7 @@ def tree(src, dst_prefix):
 ui_tree = tree(os.path.join(root, "ui"), "ui")
 streamlit_cfg = tree(os.path.join(root, ".streamlit"), ".streamlit") if os.path.isdir(".streamlit") else []
 
-datas = astro_data + ui_tree + streamlit_cfg
+datas = astro_data + desktop_data + ui_tree + streamlit_cfg
 
 a = Analysis(
     [launcher],

--- a/packaging/windows/requirements-win.txt
+++ b/packaging/windows/requirements-win.txt
@@ -2,3 +2,6 @@
 -r requirements.txt
 timezonefinder==6.2.*
 pyinstaller==6.10.*
+pywebview>=4.4
+pystray>=0.19
+Pillow>=10.0

--- a/packaging/windows/run-portable.bat
+++ b/packaging/windows/run-portable.bat
@@ -1,10 +1,6 @@
 @echo off
 setlocal
-set ASTROENGINE_API=http://127.0.0.1:8000
-set STREAMLIT_SERVER_HEADLESS=true
-set STREAMLIT_BROWSER_GATHERUSAGESTATS=false
-
 REM Optional: set ephemeris path if known
 REM set SE_EPHE_PATH=D:\Ephemeris
 
-start "AstroEngine API+UI" "AstroEngine.exe"
+start "AstroEngine Desktop" "AstroEngine.exe"

--- a/tests/desktop/test_desktop_packaging.py
+++ b/tests/desktop/test_desktop_packaging.py
@@ -1,0 +1,72 @@
+"""Tests for desktop packaging affordances."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from astroengine.ux.desktop.app import StreamlitController, _load_embedded_asset
+from astroengine.ux.desktop.config import DesktopConfigModel
+
+
+@pytest.fixture()
+def desktop_config() -> DesktopConfigModel:
+    """Return a config model with defaults suitable for tests."""
+
+    return DesktopConfigModel(database_url="sqlite:///test.db")
+
+
+def test_load_embedded_asset_falls_back(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.html"
+    result = _load_embedded_asset(missing, "fallback")
+    assert result == "fallback"
+
+
+def test_load_embedded_asset_reads_file(tmp_path: Path) -> None:
+    asset = tmp_path / "asset.html"
+    asset.write_text("<html>hi</html>", encoding="utf-8")
+    result = _load_embedded_asset(asset, "fallback")
+    assert result == "<html>hi</html>"
+
+
+def test_streamlit_prefers_meipass_main_portal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, desktop_config: DesktopConfigModel
+) -> None:
+    bundle = tmp_path / "bundle"
+    entry = bundle / "ui" / "streamlit" / "main_portal.py"
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.write_text("# main portal", encoding="utf-8")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+
+    controller = StreamlitController(desktop_config, tmp_path)
+
+    assert controller._entry == entry
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+
+def test_streamlit_falls_back_to_vedic_app(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, desktop_config: DesktopConfigModel
+) -> None:
+    bundle = tmp_path / "bundle"
+    entry = bundle / "ui" / "streamlit" / "vedic_app.py"
+    entry.parent.mkdir(parents=True, exist_ok=True)
+    entry.write_text("# vedic", encoding="utf-8")
+    monkeypatch.setattr(sys, "_MEIPASS", str(bundle), raising=False)
+
+    controller = StreamlitController(desktop_config, tmp_path)
+
+    assert controller._entry == entry
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+
+def test_streamlit_falls_back_to_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, desktop_config: DesktopConfigModel
+) -> None:
+    monkeypatch.delattr(sys, "_MEIPASS", raising=False)
+
+    controller = StreamlitController(desktop_config, tmp_path)
+
+    repo_entry = Path(__file__).resolve().parents[2] / "ui" / "streamlit" / "main_portal.py"
+    assert controller._entry == repo_entry


### PR DESCRIPTION
## Summary
- embed the desktop settings and copilot HTML alongside the UX module with a safe loader fallback
- expand the PyInstaller spec to ship rulesets, text metadata, and desktop config assets with the Windows bundle
- document Windows bundle parity and add packaging smoke tests for the Streamlit entry resolver and asset loader

## Testing
- pytest tests/desktop/test_desktop_packaging.py


------
https://chatgpt.com/codex/tasks/task_e_68e3c41c351883248bfc18524429471c