### PR TITLE
Add repair shortcut and resilient Windows launcher behaviors

### DIFF
--- a/installer/AstroEngine.iss
+++ b/installer/AstroEngine.iss
@@ -36,6 +36,7 @@ Name: "{app}\var"; Flags: uninsalwaysuninstall
 Name: "{app}\logs"; Flags: uninsalwaysuninstall
 Name: "{app}\logs\install"; Flags: uninsalwaysuninstall
 Name: "{app}\installer\cache"; Flags: uninsalwaysuninstall
+Name: "{app}\config"; Flags: uninsalwaysuninstall
 
 [Files]
 Source: "..\app\*"; DestDir: "{app}\app"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -60,6 +61,9 @@ Source: "..\docs\module\developer_platform\submodules\installers\windows_one_cli
 Name: "{group}\Start AstroEngine"; Filename: "{app}\env\Scripts\python.exe"; Parameters: """{app}\installer\windows_portal_entry.py""" --launch both --wait"; WorkingDir: "{app}"
 Name: "{group}\Start API Only"; Filename: "{app}\env\Scripts\python.exe"; Parameters: """{app}\installer\windows_portal_entry.py""" --launch api --wait --no-browser"; WorkingDir: "{app}"
 Name: "{group}\Start UI Only"; Filename: "{app}\env\Scripts\python.exe"; Parameters: """{app}\installer\windows_portal_entry.py""" --launch ui --wait"; WorkingDir: "{app}"
+Name: "{group}\Repair AstroEngine"; Filename: "powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -File \"{app}\installer\scripts\astroengine_post_install.ps1\" -InstallRoot \"{app}\" -Mode \"{code:GetInstallMode}\" -Scope \"{code:GetInstallScope}\" -InstallPython -LogPath \"{app}\logs\install\repair.log\""; WorkingDir: "{app}"
+Name: "{group}\Open Logs Folder"; Filename: "explorer.exe"; Parameters: "\"{app}\\logs\""
+Name: "{group}\Open Data Folder"; Filename: "explorer.exe"; Parameters: "\"{app}\\var\""
 Name: "{group}\Uninstall AstroEngine"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\Start AstroEngine"; Filename: "{app}\env\Scripts\python.exe"; Parameters: """{app}\installer\windows_portal_entry.py""" --launch both"; WorkingDir: "{app}"; Tasks: desktopicon
 


### PR DESCRIPTION
## Summary
- add a dedicated Start menu repair entry plus quick links for logs and data while ensuring the installer lays down the config directory
- persist launcher port assignments with automatic conflict avoidance and clean up any orphaned API or UI processes before relaunching
- verify Python payload checksums in both online and offline modes and seed a default ports.json during post-install

## Testing
- pytest *(fails: pyswisseph not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e464b3d9888324877668ac67edd797