### PR TITLE
Restore astroengine.api transit exports for diagnostics

### DIFF
--- a/astroengine/api/__init__.py
+++ b/astroengine/api/__init__.py
@@ -1,13 +1,73 @@
-
-"""FastAPI application factory for AstroEngine services."""
+"""FastAPI application factory and legacy transit helpers."""
 
 from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import ORJSONResponse
 
+if TYPE_CHECKING:  # pragma: no cover - runtime side effects avoided during typing
+    from astroengine.core.api import TransitEvent, TransitScanConfig
+    from astroengine.core.transit_engine import TransitEngine, TransitEngineConfig
+
 _APP_INSTANCE: FastAPI | None = None
+
+
+def _load_transit_engine() -> tuple[type["TransitEngine"], type["TransitEngineConfig"]]:
+    """Import transit engine helpers lazily to avoid heavy dependencies."""
+
+    from astroengine.core.transit_engine import TransitEngine, TransitEngineConfig
+
+    return TransitEngine, TransitEngineConfig
+
+
+def _load_transit_api() -> tuple[type["TransitEvent"], type["TransitScanConfig"]]:
+    """Import public dataclasses exposed for backwards compatibility."""
+
+    from astroengine.core.api import TransitEvent, TransitScanConfig
+
+    return TransitEvent, TransitScanConfig
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - invoked via diagnostics
+    """Preserve legacy re-exports from :mod:`astroengine.api`.
+
+    Older integrations imported :class:`TransitEngine` and its related
+    dataclasses directly from :mod:`astroengine.api`.  The FastAPI module was
+    recently split out and those aliases were lost, breaking diagnostics and
+    downstream tooling.  We restore the symbols here while keeping imports
+    lazy so environments without Swiss Ephemeris support do not fail at import
+    time.
+    """
+
+    if name in {"TransitEngine", "TransitEngineConfig"}:
+        TransitEngine, TransitEngineConfig = _load_transit_engine()
+        globals().update(
+            {
+                "TransitEngine": TransitEngine,
+                "TransitEngineConfig": TransitEngineConfig,
+            }
+        )
+        return globals()[name]
+    if name in {"TransitEvent", "TransitScanConfig"}:
+        TransitEvent, TransitScanConfig = _load_transit_api()
+        globals().update(
+            {
+                "TransitEvent": TransitEvent,
+                "TransitScanConfig": TransitScanConfig,
+            }
+        )
+        return globals()[name]
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - used for tooling hints only
+    return sorted(
+        set(globals())
+        | {"TransitEngine", "TransitEngineConfig", "TransitEvent", "TransitScanConfig"}
+    )
 
 
 def create_app() -> FastAPI:
@@ -70,6 +130,14 @@ app = get_app()
 
 
 
-__all__ = ["app", "create_app", "get_app"]
+__all__ = [
+    "app",
+    "create_app",
+    "get_app",
+    "TransitEngine",
+    "TransitEngineConfig",
+    "TransitEvent",
+    "TransitScanConfig",
+]
 
 


### PR DESCRIPTION
## Summary
- restore the legacy TransitEngine, TransitEvent, and related dataclasses on astroengine.api using lazy imports so downstream consumers regain the expected public API
- extend __all__ and __dir__ to advertise the restored exports while keeping the FastAPI application factory unchanged

## Testing
- python -m astroengine.cli diagnose --json
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e466ff724083248b91e87b2bd95e9a