### PR TITLE
Align Windows installer script with SPEC-02

### DIFF
--- a/installer/AstroEngine.iss
+++ b/installer/AstroEngine.iss
@@ -1,11 +1,11 @@
-; AstroEngine Windows Installer Script aligned with SPEC-02
+; AstroEngine Windows Installer Script aligned with SPEC-02 
 
 #define AppName "AstroEngine"
 #define AppVersion "1.0.0"
 #define AppPublisher "AstroEngine Project"
 
 [Setup]
-AppId={{9F4D9B43-4C19-41D1-A3F9-5A0FE2D7B6F1}
+AppId={{9F4D9B43-4C19-41D1-A3F9-5A0FE2D7B6F1}}   ; <- fixed: balanced braces
 AppName={#AppName}
 AppVersion={#AppVersion}
 AppPublisher={#AppPublisher}
@@ -32,11 +32,11 @@ Name: "desktopicon"; Description: "Create a desktop shortcut"; GroupDescription:
 Name: "firewall"; Description: "Allow AstroEngine through Windows Defender Firewall (ports 8000 & 8501)"; GroupDescription: "Networking:"; Flags: unchecked
 
 [Dirs]
-Name: "{app}\var"; Flags: uninsalwaysuninstall
-Name: "{app}\logs"; Flags: uninsalwaysuninstall
-Name: "{app}\logs\install"; Flags: uninsalwaysuninstall
-Name: "{app}\installer\cache"; Flags: uninsalwaysuninstall
-Name: "{app}\config"; Flags: uninsalwaysuninstall
+Name: "{app}\var"
+Name: "{app}\logs"
+Name: "{app}\logs\install"
+Name: "{app}\installer\cache"
+Name: "{app}\config"
 
 [Files]
 Source: "..\app\*"; DestDir: "{app}\app"; Flags: ignoreversion recursesubdirs createallsubdirs
@@ -53,17 +53,14 @@ Source: "..\alembic.ini"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\pyproject.toml"; DestDir: "{app}"; Flags: ignoreversion
 Source: "..\installer\windows_portal_entry.py"; DestDir: "{app}\installer"; Flags: ignoreversion
 Source: "..\installer\scripts\*"; DestDir: "{app}\installer\scripts"; Flags: ignoreversion recursesubdirs createallsubdirs
-Source: "..\installer\scripts\start_both.ps1"; DestDir: "{app}\installer\scripts"; Flags: ignoreversion
-Source: "..\installer\scripts\start_api.ps1"; DestDir: "{app}\installer\scripts"; Flags: ignoreversion
-Source: "..\installer\scripts\start_ui.ps1"; DestDir: "{app}\installer\scripts"; Flags: ignoreversion
 Source: "..\installer\offline\*"; DestDir: "{app}\installer\offline"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\installer\manifests\*"; DestDir: "{app}\installer\manifests"; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "..\docs\module\developer_platform\submodules\installers\windows_one_click.md"; DestDir: "{app}\docs"; Flags: ignoreversion
 
 [Icons]
 Name: "{group}\Start AstroEngine"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_both.ps1\""; WorkingDir: "{app}"
-Name: "{group}\Start API Only"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_api.ps1\""; WorkingDir: "{app}"
-Name: "{group}\Start UI Only"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_ui.ps1\""; WorkingDir: "{app}"
+Name: "{group}\Start API Only";  Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_api.ps1\"";  WorkingDir: "{app}"
+Name: "{group}\Start UI Only";   Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_ui.ps1\"";   WorkingDir: "{app}"
 Name: "{group}\Uninstall AstroEngine"; Filename: "{uninstallexe}"
 Name: "{userdesktop}\Start AstroEngine"; Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; Parameters: "-NoProfile -ExecutionPolicy Bypass -NoExit -File \"{app}\installer\scripts\start_both.ps1\""; WorkingDir: "{app}"; Tasks: desktopicon
 
@@ -76,7 +73,7 @@ Filename: "{sys}\WindowsPowerShell\v1.0\powershell.exe"; \
 Type: filesandordirs; Name: "{app}\installer\cache"
 Type: filesandordirs; Name: "{app}\runtime"
 Type: filesandordirs; Name: "{app}\env"
-Type: dirifempty; Name: "{app}\logs"
+Type: dirifempty;      Name: "{app}\logs"
 
 [Code]
 var
@@ -138,26 +135,17 @@ end;
 
 function GetInstallMode(Param: string): string;
 begin
-  if OfflineRadio.Checked then
-    Result := 'Offline'
-  else
-    Result := 'Online';
+  if OfflineRadio.Checked then Result := 'Offline' else Result := 'Online';
 end;
 
 function GetInstallScope(Param: string): string;
 begin
-  if IsAdminInstallMode then
-    Result := 'AllUsers'
-  else
-    Result := 'PerUser';
+  if IsAdminInstallMode then Result := 'AllUsers' else Result := 'PerUser';
 end;
 
 function GetInstallPython(Param: string): string;
 begin
-  if InstallPython then
-    Result := 'True'
-  else
-    Result := 'False';
+  if InstallPython then Result := 'True' else Result := 'False';
 end;
 
 function NextButtonClick(CurPageID: Integer): Boolean;


### PR DESCRIPTION
## Summary
- synchronize `installer/AstroEngine.iss` with the SPEC-02 reference script
- update AppId, directory declarations, and script inclusions to match the provided configuration

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e46bb5ce7083249feae92e5a7970c1