### PR TITLE
Ensure Windows launchers use ProgramData for writable data

### DIFF
--- a/installer/scripts/start_api.ps1
+++ b/installer/scripts/start_api.ps1
@@ -1,7 +1,11 @@
 $ErrorActionPreference = 'Stop'
 $AppRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-$LogDir  = Join-Path $AppRoot 'logs'
-New-Item -ItemType Directory -Force -Path $LogDir | Out-Null
+
+# Use ProgramData for data/logs when installed under Program Files
+$WritableRoot = if ($AppRoot -like "$($env:ProgramFiles)*") { Join-Path $env:ProgramData 'AstroEngine' } else { $AppRoot }
+$LogDir  = Join-Path $WritableRoot 'logs'
+$DataDir = Join-Path $WritableRoot 'var'
+New-Item -ItemType Directory -Force -Path $LogDir,$DataDir | Out-Null
 
 function Resolve-Python {
   $candidates = @(
@@ -18,7 +22,10 @@ function Resolve-Python {
   throw "Python 3.11/venv not found. Run Start AstroEngine (both) to auto-repair."
 }
 $py = Resolve-Python
-$env:DATABASE_URL = "sqlite+pysqlite:///$($AppRoot -replace '\\','/')/var/dev.db"
+
+# Point the app at the writable DB location and ensure imports resolve
+$env:DATABASE_URL = "sqlite+pysqlite:///$($DataDir -replace '\\','/')/dev.db"
+$env:PYTHONPATH   = $AppRoot
 
 $log = Join-Path $LogDir 'start_api.log'
 Start-Transcript -Path $log -Append | Out-Null


### PR DESCRIPTION
## Summary
- ensure the Windows launcher scripts create logs/var paths under ProgramData when installed to Program Files
- update post-install repair to configure Alembic and env vars using the same writable directories
- export PYTHONPATH alongside DATABASE_URL so the API imports resolve when launched from Program Files

## Testing
- not run (PowerShell scripts only)


------
https://chatgpt.com/codex/tasks/task_e_68e47327e8048324998ee37fe874fa51