### PR TITLE
Add orchestration module with multi-agent workflow

### DIFF
--- a/astroengine/modules/__init__.py
+++ b/astroengine/modules/__init__.py
@@ -21,6 +21,7 @@ from .registry import (
     AstroSubmodule,
 )
 from .providers import register_providers_module
+from .orchestration import register_orchestration_module
 from .ritual import register_ritual_module
 from .ux import register_ux_module
 from .vca import register_vca_module
@@ -57,6 +58,7 @@ def bootstrap_default_registry() -> AstroRegistry:
     register_providers_module(registry)
     register_interop_module(registry)
     register_developer_platform_module(registry)
+    register_orchestration_module(registry)
     return registry
 
 

--- a/astroengine/modules/orchestration/__init__.py
+++ b/astroengine/modules/orchestration/__init__.py
@@ -1,0 +1,64 @@
+"""Registry wiring for collaborative workflow orchestration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from ..registry import AstroRegistry
+
+__all__ = ["register_orchestration_module", "load_multi_agent_plan", "MULTI_AGENT_PLAN_PATH"]
+
+MULTI_AGENT_PLAN_PATH = Path(__file__).with_name("multi_agent_workflow.json")
+
+
+def load_multi_agent_plan() -> dict[str, Any]:
+    """Return the parsed multi-agent workflow description."""
+
+    data = json.loads(MULTI_AGENT_PLAN_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):  # pragma: no cover - defensive guard
+        raise TypeError("Multi-agent workflow payload must be a mapping")
+    return data
+
+
+def register_orchestration_module(registry: AstroRegistry) -> None:
+    """Register orchestration workflows, including the multi-agent pipeline."""
+
+    plan = load_multi_agent_plan()
+    module = registry.register_module(
+        "orchestration",
+        metadata={
+            "description": "Operational workflows coordinating multi-agent astrology tasks.",
+            "data_inputs": ["csv", "json", "sqlite"],
+            "integrity_note": (
+                "Every workflow references Solar Fire exports, Swiss Ephemeris assets,"
+                " and documented reporting specs to keep results data-backed."
+            ),
+        },
+    )
+
+    multi_agent = module.register_submodule(
+        "multi_agent",
+        metadata={
+            "description": "Cooperative agents spanning ingest, ephemeris verification, and reporting.",
+            "plan_file": "astroengine/modules/orchestration/multi_agent_workflow.json",
+        },
+    )
+
+    workflows = multi_agent.register_channel(
+        "workflows",
+        metadata={
+            "description": "Multi-agent playbooks sourced from verified dataset contracts.",
+        },
+    )
+
+    workflows.register_subchannel(
+        plan.get("id", "multi_agent_plan"),
+        metadata={
+            "description": plan.get("description", ""),
+            "version": plan.get("version", "unknown"),
+            "agent_count": len(plan.get("agents", [])),
+        },
+        payload=plan,
+    )

--- a/astroengine/modules/orchestration/multi_agent_workflow.json
+++ b/astroengine/modules/orchestration/multi_agent_workflow.json
@@ -1,0 +1,157 @@
+{
+  "id": "solar_fire_tracking_v1",
+  "version": "2025.02",
+  "description": "Multi-agent workflow orchestrating Solar Fire ingest, Swiss Ephemeris verification, and daily transit reporting.",
+  "data_contracts": [
+    {
+      "path": "datasets/solarfire/README.md",
+      "description": "Mount point for verified Solar Fire exports described in docs/module/interop.md.",
+      "integrity_reference": "docs/governance/data_revision_policy.md"
+    },
+    {
+      "path": "datasets/swisseph_stub/README.md",
+      "description": "Swiss Ephemeris stub shipped with the repository for deterministic tests.",
+      "integrity_reference": "docs/SWISS_EPHEMERIS.md"
+    },
+    {
+      "path": "rulesets/transit/scan.ruleset.md",
+      "description": "Transit scan rule definitions consumed by the reporting agent.",
+      "integrity_reference": "rulesets/transit/stations.ruleset.md"
+    }
+  ],
+  "agents": [
+    {
+      "name": "ingest_coordinator",
+      "title": "Solar Fire ingest coordinator",
+      "responsibilities": [
+        "Validate checksums for mounted Solar Fire exports and produce an ingest manifest.",
+        "Index natal charts and transit tables required by downstream agents.",
+        "Ensure no datasets are removed when manifests are regenerated."
+      ],
+      "inputs": [
+        {
+          "type": "filesystem",
+          "path": "datasets/solarfire/README.md",
+          "description": "Confirms Solar Fire exports are mounted for ingestion."
+        },
+        {
+          "type": "documentation",
+          "path": "docs/module/interop.md",
+          "description": "Defines the export schema and checksum policy for Solar Fire assets."
+        }
+      ],
+      "outputs": [
+        {
+          "type": "manifest",
+          "path": "docs/governance/data_revision_policy.md",
+          "description": "Appends the latest checksum entries for Solar Fire exports."
+        }
+      ],
+      "handoff_artifacts": [
+        {
+          "name": "ingest_manifest",
+          "path": "docs/governance/data_revision_policy.md",
+          "delivered_to": "ephemeris_verifier"
+        }
+      ]
+    },
+    {
+      "name": "ephemeris_verifier",
+      "title": "Swiss Ephemeris verification agent",
+      "responsibilities": [
+        "Probe Swiss Ephemeris availability and confirm the configured year range.",
+        "Record provisioning metadata for downstream reporting.",
+        "Expose cache warm-up tasks aligned with detectors."
+      ],
+      "inputs": [
+        {
+          "type": "filesystem",
+          "path": "datasets/swisseph_stub/README.md",
+          "description": "Documents the stub data used for deterministic Swiss Ephemeris checks."
+        },
+        {
+          "type": "python_module",
+          "path": "astroengine/pipeline/provision.py",
+          "description": "Implements the provisioning routine executed by this agent."
+        }
+      ],
+      "outputs": [
+        {
+          "type": "json",
+          "path": "observability/trends/README.md",
+          "description": "Records provisioning telemetry referenced by dashboards."
+        },
+        {
+          "type": "script",
+          "path": "astroengine/pipeline/cache_warm.py",
+          "description": "Provides the cache warm-up entry point triggered after provisioning."
+        }
+      ],
+      "handoff_artifacts": [
+        {
+          "name": "ephemeris_status",
+          "path": "astroengine/pipeline/provision.py",
+          "delivered_to": "transit_reporter"
+        }
+      ]
+    },
+    {
+      "name": "transit_reporter",
+      "title": "Daily transit reporter",
+      "responsibilities": [
+        "Run Solar Fire aligned transit scans using verified ephemeris data.",
+        "Publish CSV/JSON payloads documented in the daily planner recipe.",
+        "Push observability markers to the engine_scans dashboard."
+      ],
+      "inputs": [
+        {
+          "type": "ruleset",
+          "path": "rulesets/transit/scan.ruleset.md",
+          "description": "Defines the deterministic transit scan configuration."
+        },
+        {
+          "type": "recipe",
+          "path": "docs/recipes/daily_planner.md",
+          "description": "Specifies the output contract for the daily planner report."
+        },
+        {
+          "type": "application",
+          "path": "apps/streamlit_transit_scanner.py",
+          "description": "Interactive surface sharing the same scan workflow."
+        }
+      ],
+      "outputs": [
+        {
+          "type": "dashboard",
+          "path": "observability/dashboards/engine_scans.json",
+          "description": "Telemetry configuration capturing scan throughput and success rates."
+        },
+        {
+          "type": "report_spec",
+          "path": "docs/recipes/daily_planner.md",
+          "description": "Published report matching the documented planner schema."
+        }
+      ],
+      "handoff_artifacts": []
+    }
+  ],
+  "handoffs": [
+    {
+      "from": "ingest_coordinator",
+      "to": "ephemeris_verifier",
+      "artifact": "ingest_manifest",
+      "path": "docs/governance/data_revision_policy.md"
+    },
+    {
+      "from": "ephemeris_verifier",
+      "to": "transit_reporter",
+      "artifact": "ephemeris_status",
+      "path": "astroengine/pipeline/provision.py"
+    }
+  ],
+  "observability": {
+    "metrics_dashboard": "observability/dashboards/engine_scans.json",
+    "telemetry_reference": "observability/trends/README.md",
+    "notes": "Workflow metrics must originate from real scan executions backed by Solar Fire exports and Swiss Ephemeris checks."
+  }
+}

--- a/docs/module/orchestration.md
+++ b/docs/module/orchestration.md
@@ -1,0 +1,41 @@
+# Orchestration Module
+
+- **Scope**: Module `orchestration` channel `workflows.solar_fire_tracking_v1`
+- **Status**: Planning complete; data-backed plan available for execution tooling.
+- **Primary datasets**: `datasets/solarfire/README.md`, `datasets/swisseph_stub/README.md`, `rulesets/transit/scan.ruleset.md`
+- **Outputs**: Observability dashboards (`observability/dashboards/engine_scans.json`) and reports described in `docs/recipes/daily_planner.md`.
+
+## Purpose
+
+The orchestration module catalogues cooperative workflows that coordinate multiple
+AstroEngine agents. Each workflow maintains the module → submodule → channel →
+subchannel lineage so Solar Fire derived datasets remain traceable when
+upgrading ingest or reporting automation.
+
+## Multi-agent workflow: `solar_fire_tracking_v1`
+
+| Agent | Responsibilities | Key References |
+| --- | --- | --- |
+| `ingest_coordinator` | Validate mounted Solar Fire exports, refresh checksum manifests, ensure no datasets are dropped during regeneration. | `datasets/solarfire/README.md`, `docs/module/interop.md`, `docs/governance/data_revision_policy.md` |
+| `ephemeris_verifier` | Probe Swiss Ephemeris availability, publish provisioning metadata, prepare cache warm-up routines. | `datasets/swisseph_stub/README.md`, `astroengine/pipeline/provision.py`, `observability/trends/README.md` |
+| `transit_reporter` | Execute transit scans backed by verified ephemeris data, emit planner outputs, update observability dashboards. | `rulesets/transit/scan.ruleset.md`, `docs/recipes/daily_planner.md`, `observability/dashboards/engine_scans.json` |
+
+### Data contracts
+
+The workflow references concrete assets rather than synthetic placeholders:
+
+- Solar Fire exports are mounted per `docs/module/interop.md` and tracked in
+  `docs/governance/data_revision_policy.md`.
+- Swiss Ephemeris availability is documented in
+  `astroengine/pipeline/provision.py` and the stub dataset at
+  `datasets/swisseph_stub/README.md`.
+- Transit scan behaviour is fixed by the ruleset collection under
+  `rulesets/transit/` and the planner recipe documented in
+  `docs/recipes/daily_planner.md`.
+
+### Observability
+
+Telemetry emitted by the workflow is visualised using
+`observability/dashboards/engine_scans.json`, with raw provisioning notes stored
+alongside `observability/trends/README.md`. All telemetry must stem from real
+runs that consumed verified Solar Fire exports and Swiss Ephemeris data.

--- a/tests/test_module_registry.py
+++ b/tests/test_module_registry.py
@@ -1,4 +1,5 @@
 from astroengine import DEFAULT_REGISTRY, serialize_vca_ruleset
+from astroengine.modules.orchestration import load_multi_agent_plan
 from astroengine.modules.reference.catalog import (
     CHART_TYPES,
     FRAMEWORKS,
@@ -67,3 +68,16 @@ def test_reference_module_exposes_catalogued_entries():
     systems = frameworks.get_channel("systems")
     for key, entry in FRAMEWORKS.items():
         assert systems.get_subchannel(key).metadata["term"] == entry.term
+
+
+def test_orchestration_module_registers_multi_agent_workflow():
+    module = DEFAULT_REGISTRY.get_module("orchestration")
+    submodule = module.get_submodule("multi_agent")
+    workflows = submodule.get_channel("workflows")
+    node = workflows.get_subchannel("solar_fire_tracking_v1").describe()
+    plan = load_multi_agent_plan()
+
+    assert node["version"] == plan["version"]
+    assert node["payload"]["observability"]["metrics_dashboard"] == "observability/dashboards/engine_scans.json"
+    assert [agent["name"] for agent in plan["agents"]]
+    assert node["payload"]["agents"][0]["name"] == plan["agents"][0]["name"]


### PR DESCRIPTION
## Summary
- register a new orchestration module in the AstroRegistry that catalogues cooperative multi-agent pipelines
- add the data-backed `solar_fire_tracking_v1` workflow specification and supporting documentation
- extend module registry tests to assert the multi-agent plan is loaded from the new registry channel

## Testing
- pytest -q *(skipped: pyswisseph not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e58ba220e0832494ceddd651f0cf28