### PR TITLE
Enable pre-commit.ci autofix PRs

### DIFF
--- a/.pre-commit.ci.yml
+++ b/.pre-commit.ci.yml
@@ -1,3 +1,4 @@
 # >>> AUTO-GEN BEGIN: pre-commit ci v1.0
 autoupdate_schedule: quarterly
+autofix_prs: true
 # >>> AUTO-GEN END: pre-commit ci v1.0


### PR DESCRIPTION
## Summary
- enable pre-commit.ci to push autofix commits when lint checks fail automatically

## Testing
- Not run (config-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e58ce3291c8324b9349ecd82f9b5b6