### PR TITLE
Include app desktop modules in Windows bundle

### DIFF
--- a/packaging/windows/astroengine.spec
+++ b/packaging/windows/astroengine.spec
@@ -18,6 +18,8 @@ hidden += collect_submodules("pkg_resources")  # quiets altgraph/pkg_resources w
 hidden += collect_submodules("pywebview")
 hidden += collect_submodules("pystray")
 hidden += collect_submodules("PIL")
+hidden += collect_submodules("app.desktop")
+hidden += collect_submodules("app")
 
 # Data files from our own package
 astro_data = collect_data_files(


### PR DESCRIPTION
## Summary
- add the desktop package to the PyInstaller hidden imports so the frozen launcher can import app.desktop.launch_desktop

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e57d1b8b288324aa3e829c4b62d302