### PR TITLE
Add codex MCP manifest support

### DIFF
--- a/astroengine/modules/developer_platform/__init__.py
+++ b/astroengine/modules/developer_platform/__init__.py
@@ -118,6 +118,18 @@ def register_developer_platform_module(registry: AstroRegistry) -> None:
             "documentation": "docs/module/developer_platform/codex.md#python",
         },
     )
+    access.register_subchannel(
+        "mcp",
+        metadata={
+            "description": "Model Context Protocol manifest for codex registry helpers.",
+            "status": "available",
+        },
+        payload={
+            "manifest": "astroengine.codex.codex_mcp_server",
+            "recommendedServers": "astroengine.codex.common_mcp_servers",
+            "documentation": "docs/module/developer_platform/codex.md#mcp",
+        },
+    )
 
     devportal = module.register_submodule(
         "devportal",

--- a/docs/module/developer_platform/codex.md
+++ b/docs/module/developer_platform/codex.md
@@ -58,3 +58,20 @@ Calling `codex.registry_snapshot()` returns the same structure that powers the
 for integration tests. All metadata returned by these functions originates
 from the SolarFire-aligned registry definitions shipped in the repository—no
 synthetic values are introduced.
+
+## Model Context Protocol integration {#mcp}
+
+The codex helpers can be surfaced to a Model Context Protocol (MCP) host so
+external tools can query the same registry data that powers the CLI and
+Python APIs. Two key entry points are provided:
+
+* `astroengine codex mcp` emits a JSON manifest describing the available MCP
+  tools (`registry_snapshot`, `describe_path`, and `resolved_files`) alongside
+  curated filesystem servers that expose datasets and documentation.
+* `astroengine.codex.codex_mcp_server()` returns the same manifest for direct
+  programmatic use, while `astroengine.codex.common_mcp_servers()` lists the
+  complementary servers used by the CLI output.
+
+Each manifest is backed by the live registry snapshot and documentation paths
+tracked in this repository so that MCP orchestrators never reference synthetic
+or placeholder data.

--- a/tests/test_cli_codex.py
+++ b/tests/test_cli_codex.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from astroengine import cli
 
 
@@ -40,3 +42,11 @@ def test_codex_files_returns_documentation_path(capsys) -> None:
     assert exit_code == 0
     output = capsys.readouterr().out
     assert "codex.md" in output
+
+
+def test_codex_mcp_command_emits_manifest(capsys) -> None:
+    exit_code = cli.main(["codex", "mcp"])
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["server"]["name"] == "astroengine-codex"
+    assert payload["commonServers"], "Expected codex mcp command to include common servers"

--- a/tests/test_codex.py
+++ b/tests/test_codex.py
@@ -26,3 +26,21 @@ def test_resolved_files_for_python_helpers_points_to_docs() -> None:
     assert "codex.md" in filenames
     for path in paths:
         assert Path(path).exists()
+
+
+def test_codex_mcp_manifest_includes_registry_resource() -> None:
+    manifest = codex.codex_mcp_server()
+    payload = manifest.as_dict()
+    assert payload["name"] == "astroengine-codex"
+    assert "registry" in payload["resources"]
+    registry_resource = payload["resources"]["registry"]
+    assert isinstance(registry_resource.get("data"), dict)
+    assert payload["tools"], "Expected codex MCP manifest to expose tools"
+
+
+def test_common_mcp_servers_expose_dataset_root() -> None:
+    servers = codex.common_mcp_servers()
+    dataset_server = next(server for server in servers if server.name == "astroengine-datasets")
+    root_path = Path(dataset_server.configuration["root"])  # type: ignore[index]
+    assert root_path.exists()
+    assert root_path.name == "datasets"


### PR DESCRIPTION
## Summary
- expose MCP manifest and curated MCP server descriptors through `astroengine.codex`
- add a `codex mcp` CLI command, registry wiring, and documentation for MCP usage
- cover the new helpers and CLI surface with targeted tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e58b2ce294832499d801f94318637c