### PR TITLE
Add Codex triage workflow

### DIFF
--- a/.github/workflows/codex-triage.yml
+++ b/.github/workflows/codex-triage.yml
@@ -1,0 +1,166 @@
+name: codex-triage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    env:
+      MODEL: gpt-5-codex
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      PIP_DISABLE_PIP_VERSION_CHECK: "1"
+      PYTHONDONTWRITEBYTECODE: "1"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          pip install -r requirements-dev.txt
+          pip install -e ".[api,providers,ui]" || pip install -e .
+          pip install black bandit pip-audit openai
+
+      - name: Prepare Swiss Ephemeris stub
+        run: |
+          mkdir -p "$HOME/.astroengine/ephemeris"
+          cp -a datasets/swisseph_stub/. "$HOME/.astroengine/ephemeris/" 2>/dev/null || true
+          echo "SE_EPHE_PATH=$HOME/.astroengine/ephemeris" >> "$GITHUB_ENV"
+
+      - name: Prepare artifact staging
+        run: mkdir -p ci_artifacts/logs
+
+      - name: Ruff lint
+        id: ruff
+        continue-on-error: true
+        run: |
+          set +e
+          ruff check . | tee ci_artifacts/logs/ruff.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Black formatting check
+        id: black
+        continue-on-error: true
+        run: |
+          set +e
+          black --check . | tee ci_artifacts/logs/black.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Isort import order
+        id: isort
+        continue-on-error: true
+        run: |
+          set +e
+          isort --check-only --profile black . | tee ci_artifacts/logs/isort.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Mypy type check
+        id: mypy
+        continue-on-error: true
+        run: |
+          set +e
+          mypy --config-file mypy.ini --cache-dir=.mypy_cache . | tee ci_artifacts/logs/mypy.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Bandit security scan
+        id: bandit
+        continue-on-error: true
+        run: |
+          set +e
+          bandit -r astroengine -ll -q --format json | tee ci_artifacts/logs/bandit.json
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: pip-audit vulnerability scan
+        id: pipaudit
+        continue-on-error: true
+        run: |
+          set +e
+          pip-audit -r requirements.txt -r requirements-dev.txt --format json | tee ci_artifacts/logs/pip-audit.json
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Pytest with coverage
+        id: pytest
+        continue-on-error: true
+        run: |
+          set +e
+          pytest --maxfail=1 --disable-warnings --cov=astroengine --cov-report=xml:ci_artifacts/coverage.xml --cov-report=term --junitxml=ci_artifacts/pytest-junit.xml | tee ci_artifacts/logs/pytest.log
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Collect auxiliary artifacts
+        if: always()
+        run: |
+          cp -f .coverage ci_artifacts/.coverage 2>/dev/null || true
+          cp -f coverage.xml ci_artifacts/coverage.xml 2>/dev/null || true
+          find . -maxdepth 2 -name "junit*.xml" -not -path "ci_artifacts/*" -exec cp {} ci_artifacts/ \; || true
+
+      - name: Bundle artifacts
+        if: always()
+        run: tar -czf codex-artifacts.tar.gz ci_artifacts
+
+      - name: Run Codex triage
+        if: env.OPENAI_API_KEY != ''
+        run: |
+          python scripts/ci/run_codex_triage.py --artifacts codex-artifacts.tar.gz --output codex/triage.md --model "$MODEL"
+
+      - name: Skip Codex triage (missing API key)
+        if: env.OPENAI_API_KEY == ''
+        run: echo "OPENAI_API_KEY not configured; skipping Codex triage step." >&2
+
+      - name: Upload triage report
+        if: env.OPENAI_API_KEY != ''
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-triage
+          path: codex/triage.md
+
+      - name: Upload CI artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: codex-ci-artifacts
+          path: ci_artifacts
+
+      - name: Enforce gates
+        if: always()
+        run: |
+          failed=0
+          report=""
+          check() {
+            local name="$1"
+            local code="$2"
+            if [ -n "$code" ] && [ "$code" != "0" ]; then
+              failed=1
+              report="${report}\n- ${name} failed (exit ${code})"
+            fi
+          }
+          check "ruff" "${{ steps.ruff.outputs.exit_code }}"
+          check "black" "${{ steps.black.outputs.exit_code }}"
+          check "isort" "${{ steps.isort.outputs.exit_code }}"
+          check "mypy" "${{ steps.mypy.outputs.exit_code }}"
+          check "bandit" "${{ steps.bandit.outputs.exit_code }}"
+          check "pip-audit" "${{ steps.pipaudit.outputs.exit_code }}"
+          check "pytest" "${{ steps.pytest.outputs.exit_code }}"
+          if [ "$failed" -ne 0 ]; then
+            echo "Codex triage workflow detected failures:${report}" >&2
+            exit 1
+          fi

--- a/scripts/ci/run_codex_triage.py
+++ b/scripts/ci/run_codex_triage.py
@@ -1,0 +1,126 @@
+"""Utility for invoking GPT-5-Codex triage on CI artifacts.
+
+This script is referenced from GitHub Actions to forward compressed
+artifact bundles to the OpenAI Responses API with the Code Interpreter
+tool enabled.  The model unpacks the archive, inspects CI outputs,
+and produces a Markdown summary with remediation guidance and unified
+diff patches.  The resulting triage report is printed to stdout and
+persisted to disk for later upload as a workflow artifact.
+"""
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+from openai import OpenAI
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifacts",
+        type=Path,
+        required=True,
+        help="Path to the gzipped tarball containing CI artifacts.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        required=True,
+        help="Destination file for the Markdown triage report.",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.getenv("MODEL", "gpt-5-codex"),
+        help="Override the OpenAI model identifier.",
+    )
+    return parser.parse_args()
+
+
+def ensure_api_key() -> None:
+    if not os.getenv("OPENAI_API_KEY"):
+        raise RuntimeError(
+            "OPENAI_API_KEY is not set; unable to contact the OpenAI API."
+        )
+
+
+def build_prompt(archive_name: str) -> str:
+    return dedent(
+        f"""
+        You are the CI sherpa for the AstroEngine monorepo.  A gzip-compressed
+        tarball named {archive_name} is attached.  It contains:
+
+        * Lint logs from Ruff, Black, Isort, and Bandit.
+        * Static analysis output from mypy and pip-audit.
+        * Pytest coverage XML, JUnit XML, and human-readable test logs.
+
+        Responsibilities:
+        1. Extract the archive into a working directory inside the code interpreter.
+        2. Inspect every file to understand which checks failed and why.
+        3. Summarise failures with root-cause analysis that references filenames,
+           stack traces, or rule identifiers as appropriate.
+        4. When a fix is obvious, propose the minimal patch using fenced unified diffs
+           ("```diff" blocks) scoped to the correct repository paths.
+        5. If everything passed, confirm the healthy state and highlight which suites ran.
+        6. Always end with a concise checklist of developer actions (each item with a
+           leading "- [ ]").
+
+        Keep the tone crisp and actionable.  Prefer Markdown headings for readability.
+        """
+    ).strip()
+
+
+def request_triage(model: str, archive_path: Path) -> str:
+    client = OpenAI()
+    payload = base64.b64encode(archive_path.read_bytes()).decode()
+    prompt = build_prompt(archive_path.name)
+
+    response = client.responses.create(
+        model=model,
+        input=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": prompt},
+                    {
+                        "type": "input_file",
+                        "file_data": {
+                            "name": archive_path.name,
+                            "data": payload,
+                        },
+                    },
+                ],
+            }
+        ],
+        tools=[{"type": "code_interpreter"}],
+    )
+    return response.output_text
+
+
+def main() -> int:
+    args = parse_args()
+
+    try:
+        ensure_api_key()
+    except RuntimeError as exc:  # pragma: no cover - defensive, deterministic branch
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    if not args.artifacts.exists():
+        print(f"Artifact bundle not found: {args.artifacts}", file=sys.stderr)
+        return 1
+
+    report = request_triage(args.model, args.artifacts)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(report)
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a dedicated `codex-triage` GitHub Actions workflow that runs lint, security, and test suites while collecting artifacts for GPT-5 Codex analysis
- introduce `scripts/ci/run_codex_triage.py` to package CI logs and request triage output from the OpenAI Responses API with the Code Interpreter tool

## Testing
- pytest -q *(fails: multiple existing suite failures triggered by API schema initialisation)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a00e5a788324bc393bcb5d280c1f