### PR TITLE
Add security scanning gates and UI Playwright smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,35 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
 
 jobs:
-  build:
+  gitleaks:
+    name: Secrets scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        with:
+          args: >-
+            detect --source=. --no-git --redact --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload gitleaks report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks.sarif
+          if-no-files-found: ignore
+
+  python:
+    name: Python quality checks
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: gitleaks
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,6 +67,7 @@ jobs:
           set -euxo pipefail
           python -m pip install --upgrade pip wheel
           pip install -e ".[dev]"
+          pip install bandit pip-audit
 
       - name: Lint with ruff
         run: |
@@ -76,52 +103,20 @@ jobs:
           set -euxo pipefail
           python -m astroengine.maint --full --strict
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: apps/rulepack-authoring-ui/package-lock.json
-
-      - name: Install UI dependencies
-        working-directory: apps/rulepack-authoring-ui
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
+      - name: Enforce 100% Python coverage
         run: |
           set -euxo pipefail
-          npm ci
+          coverage report --fail-under=100
 
-      - name: Lint UI
-        working-directory: apps/rulepack-authoring-ui
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
+      - name: Run Bandit (high severity)
         run: |
           set -euxo pipefail
-          npm run lint
+          bandit -c bandit.yaml -r . --severity-level high --confidence-level high --format sarif --output reports/bandit.sarif
 
-      - name: Type check UI
-        working-directory: apps/rulepack-authoring-ui
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
+      - name: Run pip-audit
         run: |
           set -euxo pipefail
-          npm run typecheck
-
-      - name: Test UI
-        working-directory: apps/rulepack-authoring-ui
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
-        run: |
-          set -euxo pipefail
-          npm run test -- --runInBand
-
-      - name: Build UI
-        working-directory: apps/rulepack-authoring-ui
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
-        run: |
-          set -euxo pipefail
-          npm run build
+          pip-audit --strict --progress-spinner off > reports/pip-audit.txt
 
       - name: Upload Python coverage and test results
         if: always()
@@ -131,10 +126,99 @@ jobs:
           if-no-files-found: ignore
           path: |
             coverage.xml
-            reports/pytest.xml
+            reports/
 
-      - name: Codex failure triage (optional)
-        if: ${{ failure() && secrets.OPENAI_API_KEY != '' }}
+      - name: Upload Bandit SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: reports/bandit.sarif
+
+  node:
+    name: UI quality checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: gitleaks
+    env:
+      NEXT_TELEMETRY_DISABLED: "1"
+    defaults:
+      run:
+        working-directory: apps/rulepack-authoring-ui
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: apps/rulepack-authoring-ui/package-lock.json
+
+      - name: Install UI dependencies
+        run: |
+          set -euxo pipefail
+          npm ci
+
+      - name: Lint UI
+        run: |
+          set -euxo pipefail
+          npm run lint
+
+      - name: Type check UI
+        run: |
+          set -euxo pipefail
+          npm run typecheck
+
+      - name: npm audit (high severity)
+        run: |
+          set -euxo pipefail
+          npm audit --audit-level=high
+
+      - name: Run vitest with coverage
+        run: |
+          set -euxo pipefail
+          npm run test -- --coverage --runInBand --reporter=junit --outputFile=../vitest-junit.xml
+
+      - name: Enforce 100% UI coverage
+        run: |
+          set -euxo pipefail
+          node scripts/check-vitest-coverage.mjs
+
+      - name: Install Playwright browsers
+        run: |
+          set -euxo pipefail
+          npx playwright install --with-deps
+
+      - name: Run Playwright smoke tests
+        run: |
+          set -euxo pipefail
+          npx playwright test --config=playwright.config.ts
+
+      - name: Upload UI coverage and reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-test-artifacts
+          if-no-files-found: ignore
+          path: |
+            coverage/
+            ../vitest-junit.xml
+            playwright-report/
+
+  codex-triage:
+    name: Codex failure triage
+    needs:
+      - python
+      - node
+      - gitleaks
+    if: ${{ failure() && secrets.OPENAI_API_KEY != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Codex failure triage
         uses: openai/codex-action@main
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/apps/rulepack-authoring-ui/package-lock.json
+++ b/apps/rulepack-authoring-ui/package-lock.json
@@ -35,6 +35,7 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@playwright/test": "^1.48.2",
         "@types/node": "^20.11.19",
         "@types/react": "^18.2.55",
         "@types/react-dom": "^18.2.19",
@@ -1354,6 +1355,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
+      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/react-compose-refs": {
@@ -6718,6 +6735,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
+      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.56.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.56.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
+      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/apps/rulepack-authoring-ui/package.json
+++ b/apps/rulepack-authoring-ui/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "typecheck": "tsc --noEmit",
-    "test": "vitest"
+    "test": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.3.4",
@@ -42,6 +43,7 @@
     "@types/react": "^18.2.55",
     "@types/react-dom": "^18.2.19",
     "@types/yaml": "^1.9.7",
+    "@playwright/test": "^1.48.2",
     "eslint": "^8.56.0",
     "eslint-config-next": "^14.1.0",
     "jsdom": "^24.0.0",

--- a/apps/rulepack-authoring-ui/playwright.config.ts
+++ b/apps/rulepack-authoring-ui/playwright.config.ts
@@ -1,0 +1,36 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const port = Number(process.env.PLAYWRIGHT_WEB_PORT ?? 4173);
+const host = process.env.PLAYWRIGHT_WEB_HOST ?? "127.0.0.1";
+const baseUrl = `http://${host}:${port}`;
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  timeout: 60_000,
+  expect: {
+    timeout: 10_000
+  },
+  reporter: process.env.CI
+    ? [["github"], ["html", { open: "never" }]]
+    : "list",
+  use: {
+    baseURL: baseUrl,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure"
+  },
+  webServer: {
+    command: `npm run dev -- --hostname 0.0.0.0 --port ${port}`,
+    url: baseUrl,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] }
+    }
+  ]
+});

--- a/apps/rulepack-authoring-ui/scripts/check-vitest-coverage.mjs
+++ b/apps/rulepack-authoring-ui/scripts/check-vitest-coverage.mjs
@@ -1,0 +1,35 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const summaryPath = join(process.cwd(), "coverage", "coverage-summary.json");
+
+async function main() {
+  let raw;
+  try {
+    raw = await readFile(summaryPath, "utf8");
+  } catch (error) {
+    console.error(`Unable to read coverage summary at ${summaryPath}`);
+    throw error;
+  }
+
+  const summary = JSON.parse(raw);
+  const totals = summary.total ?? {};
+  const failures = Object.entries(totals).filter(([, stats]) => {
+    const pct = Number(stats?.pct ?? 0);
+    return Number.isFinite(pct) && pct < 100;
+  });
+
+  if (failures.length > 0) {
+    console.error("Vitest coverage must be 100% for all metrics. Below-threshold metrics:");
+    for (const [metric, stats] of failures) {
+      console.error(
+        `  ${metric}: ${Number(stats?.pct ?? 0).toFixed(2)}% (covered ${stats?.covered ?? 0}/${stats?.total ?? 0})`
+      );
+    }
+    process.exit(1);
+  }
+
+  console.log("Vitest coverage is at 100% across all metrics.");
+}
+
+await main();

--- a/apps/rulepack-authoring-ui/tests/e2e/smoke.spec.ts
+++ b/apps/rulepack-authoring-ui/tests/e2e/smoke.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("rulepack authoring smoke", () => {
+  test("renders the editor shell", async ({ page }) => {
+    await page.goto("/");
+
+    await expect(page.getByRole("navigation")).toContainText("Rulepack Studio");
+    await expect(page.getByRole("heading", { level: 2, name: /validation/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /format/i })).toBeVisible();
+  });
+});

--- a/apps/rulepack-authoring-ui/tsconfig.json
+++ b/apps/rulepack-authoring-ui/tsconfig.json
@@ -20,7 +20,8 @@
     "incremental": true,
     "types": [
       "node",
-      "vite/client"
+      "vite/client",
+      "@playwright/test"
     ],
     "plugins": [
       {

--- a/apps/rulepack-authoring-ui/vitest.config.ts
+++ b/apps/rulepack-authoring-ui/vitest.config.ts
@@ -4,6 +4,17 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
-    setupFiles: []
+    setupFiles: [],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "json-summary"],
+      reportsDirectory: "coverage",
+      thresholds: {
+        lines: 100,
+        branches: 100,
+        functions: 100,
+        statements: 100
+      }
+    }
   }
 });

--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,3 +1,20 @@
-# Minimal Bandit configuration; expand as security policies evolve.
+# Bandit configuration tuned for AstroEngine CI. The GitHub workflow filters for high
+# severity + high confidence findings, but we still define the directories and rules to
+# analyze explicitly so local runs match the pipeline.
+exclude_dirs:
+  - tests
+  - docs
+  - analysis
+  - datasets
+  - profiles
+  - registry
+  - rulesets
+  - apps/rulepack-authoring-ui/node_modules
+  - node_modules
 skips:
+  # Allow the use of assert statements inside tests and fixtures.
   - B101
+  # Temporary network operations used in observability tooling rely on subprocess.
+  - B404
+  - B603
+  - B607

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,33 +1,31 @@
 [mypy]
+python_version = 3.11
+files = astroengine, scripts
 exclude = (?x)(
-    ^app/
-  | ^apps/
+    ^tests/
+  | ^docs/
   | ^datasets/
-  | ^db/
   | ^generated/
   | ^profiles/
   | ^registry/
-  | ^conftest\.py$
   | ^rulesets/
-  | ^scripts/
-  | ^\.github/
-  | ^astroengine/modules/
-  | ^astroengine/mundane/
-  | ^astroengine/narrative/
-  | ^tests/analysis/
-  | ^tests/relation_timeline/
-    )
-files = astroengine/electional, astroengine/forecast, scripts/perf/nightly_smoke.py
-warn_redundant_casts = True
-disallow_any_generics = True
-warn_unused_ignores = True
-warn_return_any = True
+  | ^analysis/
+  | ^apps/
+  | ^plugins/
+  | ^node_modules/
+  | ^sitecustomize\.py$
+)
 warn_unused_configs = True
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_return_any = True
+no_implicit_optional = True
+strict_equality = True
 disallow_untyped_defs = True
 disallow_incomplete_defs = True
 disallow_untyped_calls = True
-no_implicit_optional = True
-strict_equality = True
+show_error_codes = True
+pretty = True
 
 [mypy-astroengine.electional.*]
 strict = True
@@ -39,10 +37,10 @@ strict = True
 follow_imports = normal
 ignore_missing_imports = False
 
-[mypy-swisseph]
+[mypy-astroengine.ephemeris.swisseph_adapter]
 ignore_missing_imports = True
 
-[mypy-astroengine.ephemeris.swisseph_adapter]
+[mypy-swisseph]
 ignore_missing_imports = True
 
 [mypy-astroengine.*]


### PR DESCRIPTION
## Summary
- split the CI workflow into dedicated gitleaks, Python, and Node gates with coverage enforcement, Bandit, pip-audit, npm audit, and Playwright smoke coverage
- refresh Bandit and mypy configuration to match the stricter CI policy
- add Playwright configuration, coverage checker, and smoke test for the rulepack authoring UI along with the supporting npm scripts and dependencies

## Testing
- pytest *(fails: pyswisseph not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a420c92083249edba0d72773e73d