### PR TITLE
Document Swiss Ephemeris delta-T toggle and guard docs

### DIFF
--- a/docs/module/providers_and_frames.md
+++ b/docs/module/providers_and_frames.md
@@ -45,7 +45,7 @@ Profiles reference providers through the following keys in `profiles/base_profil
 
 - `providers.default` selects the primary plugin (`skyfield` by default).
 - `providers.skyfield.cache_path` documents the expected ephemeris cache location (`${ASTROENGINE_CACHE}/skyfield/de440s`).
-- `providers.swe.enabled` and `providers.swe.delta_t` illustrate how optional providers expose toggles.
+- `providers.swe.enabled` and `providers.swe.delta_t` illustrate how optional providers expose toggles; the delta-T override is expressed in seconds (TT-UT) using Swiss Ephemeris constants and defaults to `swe.DELTAT_DEFAULT`, the Stephenson & Morrison (2016) curve distributed with Swiss Ephemeris.
 - `providers.*.cadence_hours` define recommended sampling cadences by body class (`inner`, `outer`, `moon`, `minor`). Detectors should inherit these settings to keep the pipeline deterministic.
 - Cadence and cache settings must be cross-checked against Solar Fire export intervals; record any deviations in the provenance log so comparisons remain valid.
 

--- a/profiles/base_profile.yaml
+++ b/profiles/base_profile.yaml
@@ -39,6 +39,10 @@ providers:
   swe:
     enabled: false
     ephemeris_path: null
+    # Delta-T override for Swiss Ephemeris (seconds TT-UT). Null keeps
+    # swe.DELTAT_DEFAULT, which follows the Stephenson & Morrison (2016)
+    # curve published with the Swiss Ephemeris distribution.
+    delta_t: null
     cadence_hours:
       inner: 6
       outer: 24

--- a/tests/test_config_features.py
+++ b/tests/test_config_features.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
+import yaml
 
 from astroengine.config.features import (
     EXPERIMENTAL_MODALITIES,
@@ -36,3 +39,23 @@ def test_is_enabled_programmatic_opt_in(name: str) -> None:
 @pytest.mark.parametrize("name", ["", "unknown", None])
 def test_is_enabled_unknown(name: str | None) -> None:
     assert not is_enabled(name or "")
+
+
+def test_swe_delta_t_profile_and_doc_remain_in_sync() -> None:
+    """Ensure the Swiss Ephemeris delta-T toggle stays documented and profiled."""
+
+    profile = yaml.safe_load(
+        Path("profiles/base_profile.yaml").read_text(encoding="utf-8")
+    )
+    swe_config = profile["providers"]["swe"]
+
+    assert "delta_t" in swe_config, "profiles/base_profile.yaml must expose providers.swe.delta_t"
+    assert swe_config["delta_t"] is None, "Default should defer to swe.DELTAT_DEFAULT"
+
+    providers_doc = Path("docs/module/providers_and_frames.md").read_text(
+        encoding="utf-8"
+    )
+    assert "`providers.swe.delta_t`" in providers_doc
+
+    feature_flags_doc = Path("profiles/feature_flags.md").read_text(encoding="utf-8")
+    assert "`providers.swe.delta_t`" in feature_flags_doc


### PR DESCRIPTION
## Summary
- add the providers.swe.delta_t default to the base profile with provenance notes
- explain the Swiss Ephemeris delta-T units and default in the providers contract doc
- assert the doc and profile stay aligned for the SWE delta-T toggle

## Testing
- pytest tests/test_config_features.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690e3452b40c83248e9b748a066d0797)