### PR TITLE
Add autogenerated compatibility matrix and guard

### DIFF
--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -4,3 +4,101 @@ Matrix columns:
 Policy:
 - Update on every tagged release; CI checks matrix completeness.
 <!-- >>> AUTO-GEN END: Compatibility Matrix v1.0 (instructions) -->
+
+| Module | Submodule | Channel | Rulesets / Schemas | Profiles | Providers (Skyfield/SWE) | Exporters | Fixed-star datasets |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| chinese | four_pillars | engines | — | profiles/domains/chinese.yaml (BaZi/Zi Wei provenance) | — | — | — |
+| chinese | zi_wei_dou_shu | engines | — | profiles/domains/chinese.yaml (BaZi/Zi Wei provenance) | — | — | — |
+| data_packs | catalogs | csv | schemas/orbs_policy.json v2025-09-03 | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/dignities.csv (Solar Fire ESSENTIAL.DAT parity)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000)<br>profiles/vca_outline.json v2025-09-18 | — | — | datasets/star_names_iau.csv (IAU WGSN v2024-03)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| data_packs | profiles | catalogue | schemas/orbs_policy.json v2025-09-03 | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/dignities.csv (Solar Fire ESSENTIAL.DAT parity)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000)<br>profiles/vca_outline.json v2025-09-18 | Swiss Ephemeris | — | datasets/star_names_iau.csv (IAU WGSN v2024-03)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| data_packs | schemas | orbs | schemas/orbs_policy.json v2025-09-03 | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/dignities.csv (Solar Fire ESSENTIAL.DAT parity)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000)<br>profiles/vca_outline.json v2025-09-18 | — | — | datasets/star_names_iau.csv (IAU WGSN v2024-03)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| developer_platform | agents | toolkits | — | — | — | — | — |
+| developer_platform | cli | workflows | — | — | — | — | — |
+| developer_platform | codex | access | — | — | — | — | — |
+| developer_platform | devportal | surfaces | — | — | — | — | — |
+| developer_platform | sdks | languages | — | — | — | — | — |
+| developer_platform | webhooks | contracts | — | — | — | — | — |
+| esoterica | adapters | optional_tools | — | — | — | — | — |
+| esoterica | alchemy | operations | — | — | — | — | — |
+| esoterica | chakras | planetary_lineage | — | — | — | — | — |
+| esoterica | decans | chaldean_order | — | — | — | — | — |
+| esoterica | initiatory_orders | golden_dawn | — | — | — | — | — |
+| esoterica | numerology | digits | — | — | — | — | — |
+| esoterica | oracular_systems | geomancy | — | — | — | — | — |
+| esoterica | oracular_systems | i_ching | — | — | — | — | — |
+| esoterica | oracular_systems | runes | — | — | — | — | — |
+| esoterica | seven_rays | bailey_lineage | — | — | — | — | — |
+| esoterica | tarot | courts | — | — | — | — | — |
+| esoterica | tarot | majors | — | — | — | — | — |
+| esoterica | tarot | spreads | — | — | — | — | — |
+| esoterica | tree_of_life | paths | — | — | — | — | — |
+| esoterica | tree_of_life | sephiroth | — | — | — | — | — |
+| event_detectors | declination | declination | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | ingresses | house | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | ingresses | sign | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | lunations | lunar | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | lunations | solar | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | overlays | fixed_stars | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | astroengine.exporters.LegacyTransitEvent | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | overlays | midpoints | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | overlays | profections | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | overlays | returns | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| event_detectors | stations | stations | rulesets/transit/ingresses.ruleset.md (schema transit_ingress)<br>rulesets/transit/lunations.ruleset.md (schema transit_lunation)<br>rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) | Swiss Ephemeris | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| integrations | ephemeris_tooling | skyfield | — | — | Skyfield | — | — |
+| integrations | ephemeris_tooling | swiss_ephemeris | — | — | Swiss Ephemeris | — | — |
+| integrations | python_toolkits | libraries | — | — | — | — | — |
+| integrations | vedic_workflows | desktop_suites | — | — | — | — | — |
+| integrations | vedic_workflows | panchanga_projects | — | — | — | — | — |
+| interop | schemas | json_data | schemas/contact_gate_schema_v2.json<br>schemas/natal_input_v1_ext.json<br>schemas/orbs_policy.json v2025-09-03<br>schemas/result_schema_v1.json<br>schemas/result_schema_v1_with_domains.json | — | — | — | — |
+| interop | schemas | json_schema | schemas/contact_gate_schema_v2.json<br>schemas/natal_input_v1_ext.json<br>schemas/orbs_policy.json v2025-09-03<br>schemas/result_schema_v1.json<br>schemas/result_schema_v1_with_domains.json | — | — | — | — |
+| jyotish | aspects | graha_yuddha | — | — | — | — | — |
+| jyotish | aspects | srishti | — | — | — | — | — |
+| jyotish | houses | karakas | — | — | — | — | — |
+| jyotish | houses | lords | — | — | — | — | — |
+| jyotish | strength | combustion | — | — | — | — | — |
+| jyotish | strength | dignity | — | — | — | — | — |
+| mayan | calendar | haab | — | — | — | — | — |
+| mayan | calendar | lords_of_night | — | — | — | — | — |
+| mayan | calendar | tzolkin | — | — | — | — | — |
+| mayan | constants | correlation | — | — | — | — | — |
+| mundane | cycles | search | rulesets/transit/ingresses.ruleset.md (schema transit_ingress) | — | — | — | — |
+| mundane | ingress | solar_ingress | rulesets/transit/ingresses.ruleset.md (schema transit_ingress) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | — |
+| narrative | bundles | summaries | — | — | — | — | — |
+| narrative | profiles | persona | — | — | — | — | — |
+| narrative | timelords | systems | — | — | — | — | — |
+| orchestration | multi_agent | workflows | rulesets/transit/scan.ruleset.md (schema transit_event)<br>rulesets/transit/stations.ruleset.md (schema transit_station) | — | Swiss Ephemeris | — | — |
+| predictive | derived_charts | harmonics | — | — | Swiss Ephemeris | — | — |
+| predictive | derived_charts | midpoints | — | — | Swiss Ephemeris | — | — |
+| predictive | directions | contacts | — | — | Swiss Ephemeris | — | — |
+| predictive | directions | solar_arc | — | — | Swiss Ephemeris | — | — |
+| predictive | progressions | contacts | — | — | Swiss Ephemeris | — | — |
+| predictive | progressions | secondary | — | — | Swiss Ephemeris | — | — |
+| predictive | relationships | composite | — | — | Swiss Ephemeris | — | — |
+| predictive | relationships | synastry | — | — | Swiss Ephemeris | — | — |
+| predictive | returns | lunar | — | — | Swiss Ephemeris | — | — |
+| predictive | returns | solar | — | — | Swiss Ephemeris | — | — |
+| predictive | vedic_gochar | alerts | — | — | Swiss Ephemeris | — | — |
+| predictive | vedic_gochar | transits | — | — | Swiss Ephemeris | — | — |
+| predictive | vedic_gochar | triggers | — | — | Swiss Ephemeris | — | — |
+| providers | cadence | profiles | — | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/base_profile.yaml. | Skyfield | — | — |
+| providers | ephemeris | plugins | — | — | Skyfield<br>Swiss Ephemeris | — | — |
+| providers | frames | preferences | — | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Skyfield | — | — |
+| reference | charts | types | — | — | Swiss Ephemeris | — | — |
+| reference | frameworks | systems | — | profiles/vca_outline.json v2025-09-18<br>profiles/vca_outline.json dataset | — | — | — |
+| reference | glossary | definitions | schemas/orbs_policy.json v2025-09-03 | profiles/aspects_policy.json (AE Aspects Policy v1.1)<br>profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | — |
+| reference | indicators | catalog | — | profiles/aspects_policy.json (AE Aspects Policy v1.1)<br>profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)<br>profiles/dignities.csv (Solar Fire ESSENTIAL.DAT parity)<br>profiles/fixed_stars.csv (FK6/HYG v4.1, J2000)<br>profiles/vca_outline.json v2025-09-18 | — | — | profiles/fixed_stars.csv (FK6/HYG v4.1, J2000) |
+| ritual | elections | windows | — | — | — | — | — |
+| ritual | filters | void_of_course | — | — | — | — | — |
+| ritual | timing | planetary_days | — | — | — | — | — |
+| ritual | timing | planetary_hours | — | — | — | — | — |
+| tibetan | symbolism | animals | — | — | — | — | — |
+| tibetan | symbolism | elements | — | — | — | — | — |
+| tibetan | symbolism | parkha | — | — | — | — | — |
+| ux | maps | astrocartography | — | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | datasets/star_names_iau.csv (IAU WGSN v2024-03) |
+| ux | maps | transit_overlay | — | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | datasets/star_names_iau.csv (IAU WGSN v2024-03) |
+| ux | plugins | panels | — | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | datasets/star_names_iau.csv (IAU WGSN v2024-03) |
+| ux | timelines | outer_cycles | rulesets/transit/ingresses.ruleset.md (schema transit_ingress) | profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01) | Swiss Ephemeris | — | datasets/star_names_iau.csv (IAU WGSN v2024-03) |
+| vca | catalogs | bodies | — | — | — | — | — |
+| vca | profiles | domain | — | — | — | — | — |
+| vca | rulesets | aspects | — | — | — | — | — |
+| vca | uncertainty | corridors | — | — | — | — | — |
+| vca | uncertainty | resonance | — | — | — | — | — |

--- a/scripts/update_compat_matrix.py
+++ b/scripts/update_compat_matrix.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Generate docs/COMPATIBILITY_MATRIX.md from the runtime registry."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+import re
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from astroengine.modules import DEFAULT_REGISTRY
+ 
+DOC_PATH = ROOT / "docs" / "COMPATIBILITY_MATRIX.md"
+INSTRUCTIONS = """<!-- >>> AUTO-GEN BEGIN: Compatibility Matrix v1.0 (instructions) -->\nMatrix columns:\n- astroengine-core, rulesets, profiles, providers(skyfield/swe), exporters, fixed-stars data.\nPolicy:\n- Update on every tagged release; CI checks matrix completeness.\n<!-- >>> AUTO-GEN END: Compatibility Matrix v1.0 (instructions) -->"""
+
+PROFILE_RE = re.compile(r"profiles/[\w./-]+")
+RULESET_RE = re.compile(r"rulesets/[\w./-]+")
+SCHEMA_RE = re.compile(r"schemas/[\w./-]+")
+DATASET_RE = re.compile(r"datasets/[\w./-]+")
+EXPORTER_RE = re.compile(r"astroengine\.exporters[\w.]*")
+
+DATASET_NOTES: dict[str, str] = {
+    "profiles/base_profile.yaml": "profiles/base_profile.yaml v0.1.0 (schema 1, updated 2024-05-01)",
+    "profiles/dignities.csv": "profiles/dignities.csv (Solar Fire ESSENTIAL.DAT parity)",
+    "profiles/fixed_stars.csv": "profiles/fixed_stars.csv (FK6/HYG v4.1, J2000)",
+    "profiles/vca_outline.json": "profiles/vca_outline.json v2025-09-18",
+    "profiles/aspects_policy.json": "profiles/aspects_policy.json (AE Aspects Policy v1.1)",
+    "profiles/domains/chinese.yaml": "profiles/domains/chinese.yaml (BaZi/Zi Wei provenance)",
+    "rulesets/transit/stations.ruleset.md": "rulesets/transit/stations.ruleset.md (schema transit_station)",
+    "rulesets/transit/ingresses.ruleset.md": "rulesets/transit/ingresses.ruleset.md (schema transit_ingress)",
+    "rulesets/transit/lunations.ruleset.md": "rulesets/transit/lunations.ruleset.md (schema transit_lunation)",
+    "rulesets/transit/scan.ruleset.md": "rulesets/transit/scan.ruleset.md (schema transit_event)",
+    "schemas/orbs_policy.json": "schemas/orbs_policy.json v2025-09-03",
+    "schemas/contact_gate_schema_v2.json": "schemas/contact_gate_schema_v2.json",
+    "schemas/natal_input_v1_ext.json": "schemas/natal_input_v1_ext.json",
+    "schemas/result_schema_v1.json": "schemas/result_schema_v1.json",
+    "schemas/result_schema_v1_with_domains.json": "schemas/result_schema_v1_with_domains.json",
+    "datasets/star_names_iau.csv": "datasets/star_names_iau.csv (IAU WGSN v2024-03)",
+}
+
+PROVIDER_LABELS = {
+    "Swiss Ephemeris": "Swiss Ephemeris",
+    "Skyfield": "Skyfield",
+}
+
+FIXED_STAR_HINTS = ("fixed_star", "star_names")
+
+
+def iter_strings(obj: object) -> Iterable[str]:
+    if isinstance(obj, str):
+        yield obj
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            yield from iter_strings(value)
+    elif isinstance(obj, Iterable):
+        for item in obj:
+            yield from iter_strings(item)
+
+
+def _extract_matches(text: str, pattern: re.Pattern[str]) -> list[str]:
+    return pattern.findall(text)
+
+
+def _collect_assets(strings: list[str]) -> tuple[set[str], set[str], set[str], set[str]]:
+    rulesets: set[str] = set()
+    profiles: set[str] = set()
+    datasets: set[str] = set()
+    exporters: set[str] = set()
+    for raw in strings:
+        if not isinstance(raw, str):
+            continue
+        for match in _extract_matches(raw, RULESET_RE):
+            rulesets.add(match)
+        for match in _extract_matches(raw, SCHEMA_RE):
+            rulesets.add(match)
+        for match in _extract_matches(raw, PROFILE_RE):
+            profiles.add(match)
+        for match in _extract_matches(raw, DATASET_RE):
+            datasets.add(match)
+        for match in _extract_matches(raw, EXPORTER_RE):
+            exporters.add(match)
+        if raw.startswith("profiles/"):
+            profiles.add(raw)
+        if raw.startswith("rulesets/") or raw.startswith("schemas/"):
+            rulesets.add(raw)
+        if raw.startswith("datasets/"):
+            datasets.add(raw)
+    return rulesets, profiles, datasets, exporters
+
+
+def _collect_providers(strings: list[str]) -> list[str]:
+    providers: set[str] = set()
+    for raw in strings:
+        if not isinstance(raw, str):
+            continue
+        lowered = raw.lower()
+        for needle, label in PROVIDER_LABELS.items():
+            if needle.lower() in lowered:
+                providers.add(label)
+    return sorted(providers)
+
+
+def _collect_fixed_star_assets(paths: set[str]) -> list[str]:
+    assets: set[str] = set()
+    for path in paths:
+        lowered = path.lower()
+        if any(hint in lowered for hint in FIXED_STAR_HINTS):
+            assets.add(path)
+    return sorted(assets)
+
+
+def _format_cells(items: list[str]) -> str:
+    if not items:
+        return "—"
+    return "<br>".join(items)
+
+
+def _annotate_paths(paths: Iterable[str]) -> list[str]:
+    annotated: list[str] = []
+    for path in sorted(paths):
+        annotated.append(DATASET_NOTES.get(path, path))
+    return annotated
+
+
+def main() -> None:
+    snapshot = DEFAULT_REGISTRY.as_dict()
+    rows: list[tuple[str, str, str, list[str], list[str], list[str], list[str], list[str]]] = []
+    for module_name, module in snapshot.items():
+        for submodule_name, submodule in module["submodules"].items():
+            for channel_name, channel in submodule["channels"].items():
+                strings: list[str] = []
+                strings.extend(iter_strings(module["metadata"]))
+                strings.extend(iter_strings(submodule["metadata"]))
+                strings.extend(iter_strings(channel["metadata"]))
+                for subchannel in channel["subchannels"].values():
+                    strings.extend(iter_strings(subchannel))
+                rulesets, profiles, datasets, exporters = _collect_assets(strings)
+                providers = _collect_providers(strings)
+                fixed_star_assets = _collect_fixed_star_assets(profiles | datasets)
+                rows.append(
+                    (
+                        module_name,
+                        submodule_name,
+                        channel_name,
+                        _annotate_paths(rulesets),
+                        _annotate_paths(profiles),
+                        providers,
+                        sorted(exporters),
+                        _annotate_paths(fixed_star_assets),
+                    )
+                )
+    rows.sort(key=lambda item: (item[0], item[1], item[2]))
+
+    header = [
+        "| Module | Submodule | Channel | Rulesets / Schemas | Profiles | Providers (Skyfield/SWE) | Exporters | Fixed-star datasets |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    body: list[str] = []
+    for module_name, submodule_name, channel_name, rulesets, profiles, providers, exporters, fixed_star in rows:
+        body.append(
+            "| {module} | {submodule} | {channel} | {rulesets} | {profiles} | {providers} | {exporters} | {fixed_star} |".format(
+                module=module_name,
+                submodule=submodule_name,
+                channel=channel_name,
+                rulesets=_format_cells(rulesets),
+                profiles=_format_cells(profiles),
+                providers=_format_cells(providers),
+                exporters=_format_cells(exporters),
+                fixed_star=_format_cells(fixed_star),
+            )
+        )
+
+    DOC_PATH.write_text(INSTRUCTIONS + "\n\n" + "\n".join(header + body) + "\n", encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/docs/test_compat_matrix.py
+++ b/tests/docs/test_compat_matrix.py
@@ -1,0 +1,16 @@
+"""Documentation guards for the compatibility matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from astroengine.modules import DEFAULT_REGISTRY
+
+
+def test_matrix_lists_all_modules() -> None:
+    """Every registered module must appear in docs/COMPATIBILITY_MATRIX.md."""
+
+    doc_path = Path(__file__).resolve().parents[2] / "docs" / "COMPATIBILITY_MATRIX.md"
+    matrix_text = doc_path.read_text(encoding="utf-8")
+    missing = [module.name for module in DEFAULT_REGISTRY.iter_modules() if module.name not in matrix_text]
+    assert not missing, f"Compatibility matrix missing modules: {missing}"


### PR DESCRIPTION
## Summary
- generate docs/COMPATIBILITY_MATRIX.md from the runtime registry so each module/submodule/channel lists its ruleset, profile, provider, exporter, and fixed-star dependencies with dataset versions
- add an update_compat_matrix.py helper to refresh the table when the registry or datasets change
- add a pytest guard that fails if any registered module name is missing from the published matrix

## Testing
- pytest tests/docs/test_compat_matrix.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917966067388324a774cf99d0a7e928)